### PR TITLE
Address drag drop error - Fixes #81246446

### DIFF
--- a/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/PartPreviewWindow/View3D/View3DWidget.cs
@@ -1696,7 +1696,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
                 this.Invoke((Action)(() =>
                 {
                     //Do something special when unauthorized?
-                    StyledMessageBox.ShowMessageBox(null, "Oops! Unable to save changes.", "Unable to save");
+                    StyledMessageBox.ShowMessageBox(null, "Oops! Unable to save changes.\r\nYou may not have write permissions or the file may be read only", "Unable to save");
                 }));
             }
             catch


### PR DESCRIPTION
**Don't accept this pull request**

This is a proposed fix for the issue described in https://www.pivotaltracker.com/n/projects/874109/stories/81246446 where the "DragDrop registration did not succeed" message appears in unexpected places. The problem is the result of trying to call ShowMessageBox on a background thread rather than on the UI thread. Passing a Lambda to Invoke() might not be your ideal style but it resolves the issue without moving the code around too much. 

I believe we need to look at other locations where we catch exceptions on the background thread and consider apply this pattern as well
