### PR TITLE
Conditionally display AutoConnect on printer edit form - Fixes #86664638

### DIFF
--- a/PrinterControls/PrinterConnections/EditConnectionWidget.cs
+++ b/PrinterControls/PrinterConnections/EditConnectionWidget.cs
@@ -227,7 +227,9 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
 				ConnectionControlContainer.AddChild(serialPortScroll);
                 ConnectionControlContainer.AddChild(baudRateLabel);
                 ConnectionControlContainer.AddChild(baudRateWidget);
+#if !__ANDROID__ 
                 ConnectionControlContainer.AddChild(enableAutoconnect);
+#endif
             }
 
             FlowLayoutWidget buttonContainer = new FlowLayoutWidget(FlowDirection.LeftToRight);


### PR DESCRIPTION
Fixes [Suppress 'Auto Connect' checkbox on android](https://www.pivotaltracker.com/story/show/86664638)