### PR TITLE
Revise "Language Options" -> Restart implementation - Fixes #85629286

### DIFF
--- a/ConfigurationPage/ApplicationSettings/ApplicationSettingsView.cs
+++ b/ConfigurationPage/ApplicationSettings/ApplicationSettingsView.cs
@@ -363,15 +363,26 @@ namespace MatterHackers.MatterControl.ConfigurationPage
         {
             UiThread.RunOnIdle((state) =>
             {
-                //horrible hack - to be replaced
+                // Iterate to the top SystemWindow
                 GuiWidget parent = this;
-                while (parent as MatterControlApplication == null)
+                while (parent.Parent != null)
                 {
                     parent = parent.Parent;
                 }
-                MatterControlApplication app = parent as MatterControlApplication;
+
+                // MatterControlApplication is the root child on the SystemWindow object
+                MatterControlApplication app = parent.Children[0] as MatterControlApplication;
+#if !__ANDROID__ 
                 app.RestartOnClose = true;
                 app.Close();
+#else
+                // Re-initialize and load
+                LocalizedString.ResetTranslationMap();
+                ApplicationController.Instance.MainView = new CompactApplicationView();
+                app.RemoveAllChildren();
+                app.AddChild(new SoftKeyboardContentOffset(ApplicationController.Instance.MainView, 280));
+                app.AnchorAll();
+#endif
             });
         }
 

--- a/LocalizedString.cs
+++ b/LocalizedString.cs
@@ -65,6 +65,11 @@ namespace MatterHackers.Localizations
             return MatterControlTranslationMap.Translate(englishText);
         }
 
+		public static void ResetTranslationMap()
+		{
+			MatterControlTranslationMap = null;
+		}
+
         public static string Localize(this string englishString)
         {
             return Get(englishString);


### PR DESCRIPTION
An initial technique for enabling the "Restart" functionality on Android. The approach works by allowing callers to clear the current translation map, and on Android we clear the loaded translation map, remove all children from the MatterControlApplication object and then hard-code the init of a new CompactApplicationView. We discussed using ReloadAll but it's currently hard-coded for PC classes and the technique isn't the same as the approach below.

Next iteration might be to tackle ReloadAll approach? 