### PR TITLE
Ensure active connected printer is disabled if removed - Fixes #87154858

### DIFF
--- a/PrinterControls/PrinterConnections/PrinterListItems.cs
+++ b/PrinterControls/PrinterConnections/PrinterListItems.cs
@@ -230,14 +230,10 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
 
         void RemoveConnectionLink_Click(object sender, EventArgs mouseEvent)
         {
-
             if (ActivePrinterProfile.Instance.ActivePrinter != null)
             {
-                int connectedPrinterHash = ActivePrinterProfile.Instance.ActivePrinter.GetHashCode();
-                int printerOptionHash = this.printerRecord.GetHashCode();
-
                 //Disconnect printer if the printer being removed is currently connected
-                if (connectedPrinterHash == printerOptionHash)
+				if (this.printerRecord.Id == ActivePrinterProfile.Instance.ActivePrinter.Id)
                 {
                     PrinterConnectionAndCommunication.Instance.Disable();
                     ActivePrinterProfile.Instance.ActivePrinter = null;


### PR DESCRIPTION
- Fixes [Crash due to stale state after active/connected printer is removed](https://www.pivotaltracker.com/story/show/87154858)