### PR TITLE
Account for FrostedSerialPort.GetPortNames() having zero items

### DIFF
--- a/PrinterCommunication/PrinterConnectionAndCommunication.cs
+++ b/PrinterCommunication/PrinterConnectionAndCommunication.cs
@@ -1441,7 +1441,7 @@ namespace MatterHackers.MatterControl.PrinterCommunication
             // On Android, there will never be more than one serial port available for us to connect to. Override the current .ComPort value to account for
             // this aspect to ensure the validation logic that verifies port availablity/in use status can proceed without additional workarounds for Android
 #if __ANDROID__
-            string currentPortName = FrostedSerialPort.GetPortNames().Where(p => p != "/dev/bus/usb/002/002").FirstOrDefault();
+            string currentPortName = FrostedSerialPort.GetPortNames().FirstOrDefault();
 
             if(!string.IsNullOrEmpty(currentPortName))
             {

--- a/PrinterControls/PrinterConnections/EditConnectionWidget.cs
+++ b/PrinterControls/PrinterConnections/EditConnectionWidget.cs
@@ -7,6 +7,7 @@ using MatterHackers.MatterControl.DataStorage;
 using MatterHackers.MatterControl.CustomWidgets;
 using MatterHackers.MatterControl.PrinterCommunication;
 using MatterHackers.SerialPortCommunication.FrostedSerial;
+using System.Linq;
 
 namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
 {
@@ -64,7 +65,7 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
                 this.ActivePrinter.BaudRate = "250000";
                 try
                 {
-                    this.ActivePrinter.ComPort = FrostedSerialPort.GetPortNames()[0];
+					this.ActivePrinter.ComPort = FrostedSerialPort.GetPortNames().FirstOrDefault();
                 }
                 catch
                 {
@@ -84,7 +85,7 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
                 {
                     try
                     {
-                        this.ActivePrinter.ComPort = FrostedSerialPort.GetPortNames()[0];
+						this.ActivePrinter.ComPort = FrostedSerialPort.GetPortNames().FirstOrDefault();
                     }
                     catch
                     {
@@ -108,7 +109,7 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
             ConnectionControlContainer = new FlowLayoutWidget(FlowDirection.TopToBottom); 
             ConnectionControlContainer.Padding = new BorderDouble(5);
             ConnectionControlContainer.BackgroundColor = ActiveTheme.Instance.SecondaryBackgroundColor;
-            ConnectionControlContainer.HAnchor = HAnchor.ParentLeftRight;            
+            ConnectionControlContainer.HAnchor = HAnchor.ParentLeftRight;
             {
                 TextWidget printerNameLabel = new TextWidget(LocalizedString.Get("Printer Name"), 0, 0, 10);
                 printerNameLabel.TextColor = this.defaultTextColor;


### PR DESCRIPTION
- don't unnecessarily filter 002/002

Missed sending a pull for this yesterday