### PR TITLE
Revise export to zip

### DIFF
--- a/Utilities/ProjectFileHandler.cs
+++ b/Utilities/ProjectFileHandler.cs
@@ -194,20 +194,17 @@ namespace MatterHackers.MatterControl
                 EmptyFolder(directory);
             }
 
-            //Create and save the project manifest file into the temp directory
-            string jsonString = JsonConvert.SerializeObject(this.project, Newtonsoft.Json.Formatting.Indented);
-            FileStream fs = new FileStream(defaultManifestPathAndFileName, FileMode.Create);
-            StreamWriter sw = new System.IO.StreamWriter(fs);
-            sw.Write(jsonString);
-            sw.Close();
+			//Create and save the project manifest file into the temp directory
+			File.WriteAllText(defaultManifestPathAndFileName, JsonConvert.SerializeObject(this.project, Newtonsoft.Json.Formatting.Indented));
 
 			foreach (KeyValuePair<string, ManifestItem> item in this.sourceFiles)
 			{
 				CopyFileToTempFolder(item.Key, item.Value.FileName);
 			}
-			ZipFile.CreateFromDirectory(archiveStagingFolder, savedFileName,CompressionLevel.Optimal,true);
-		
-        }
+
+			// TODO: Figure out why exceptions throw here are silently surpressed and work out how to handle the case where users select an existing file
+			ZipFile.CreateFromDirectory(archiveStagingFolder, savedFileName,CompressionLevel.Optimal, true);
+		}
 
 		private static void CopyFileToTempFolder(string sourceFile, string fileName)
         {

--- a/Utilities/ProjectFileHandler.cs
+++ b/Utilities/ProjectFileHandler.cs
@@ -202,7 +202,7 @@ namespace MatterHackers.MatterControl
 				CopyFileToTempFolder(item.Key, item.Value.FileName);
 			}
 
-			// TODO: Figure out why exceptions throw here are silently surpressed and work out how to handle the case where users select an existing file
+            // TODO: Figure out why exceptions throw here are silently suppressed and work out how to handle the case where users select an existing file
 			ZipFile.CreateFromDirectory(archiveStagingFolder, savedFileName,CompressionLevel.Optimal, true);
 		}
 


### PR DESCRIPTION
Started to put in a call to Dispose on the FileStream but WriteAllText is really intended for this pattern and seemed like a better updated

Further, on Mac the .CreateFromDirectory call throws an exception if the file exists but strangely it does not bubble and is silently suppressed like the thread is aborted. Looking forward to another set of eyes on the problem.