### PR TITLE
Power option/button added

### DIFF
--- a/ActionBar/PrinterActionRow.cs
+++ b/ActionBar/PrinterActionRow.cs
@@ -181,7 +181,6 @@ namespace MatterHackers.MatterControl.ActionBar
             Button buttonClicked = ((Button)sender);
             if (buttonClicked.Enabled) {
                 PrinterConnectionAndCommunication.Instance.PowerisOn = true;
-                PrinterConnectionAndCommunication.Instance.SendLineToPrinterNow("M80");
             }
         }
 
@@ -189,7 +188,6 @@ namespace MatterHackers.MatterControl.ActionBar
             Button buttonClicked = ((Button)sender);
             if (buttonClicked.Enabled) {
                 PrinterConnectionAndCommunication.Instance.PowerisOn = false;
-                PrinterConnectionAndCommunication.Instance.SendLineToPrinterNow("M81");
             }
         }
 

--- a/DataStorage/Models.cs
+++ b/DataStorage/Models.cs
@@ -317,6 +317,7 @@ namespace MatterHackers.MatterControl.DataStorage
         public bool AutoConnectFlag { get; set; } //Auto connect to printer (if available)
         public string DeviceToken { get; set; }
         public string DeviceType { get; set; }
+        public bool HasPower { get; set; }
         
         // all the data about print leveling
         public bool DoPrintLeveling { get; set; }

--- a/PrinterCommunication/PrinterConnectionAndCommunication.cs
+++ b/PrinterCommunication/PrinterConnectionAndCommunication.cs
@@ -887,6 +887,9 @@ namespace MatterHackers.MatterControl.PrinterCommunication
         {
             if (CommunicationState == CommunicationStates.Connected || CommunicationState == CommunicationStates.FinishedPrint)
             {
+                if (ActivePrinter.HasPower) {
+                    PrinterConnectionAndCommunication.Instance.PowerisOn = true;
+                }
                 PrintActivePart();
             }
         }
@@ -1507,6 +1510,13 @@ namespace MatterHackers.MatterControl.PrinterCommunication
             }
             set {
                 thePowerIsOn = value;
+                if (thePowerIsOn) {
+                    PrinterConnectionAndCommunication.Instance.SendLineToPrinterNow("M80");
+                }
+                else {
+                    PrinterConnectionAndCommunication.Instance.SendLineToPrinterNow("M81");
+                }
+            
                 PowerStateChanged.CallEvents(this, null);
             }
         }

--- a/PrinterCommunication/PrinterConnectionAndCommunication.cs
+++ b/PrinterCommunication/PrinterConnectionAndCommunication.cs
@@ -151,6 +151,7 @@ namespace MatterHackers.MatterControl.PrinterCommunication
         public RootedObjectEventHandler ReadLine = new RootedObjectEventHandler();
         public RootedObjectEventHandler WroteLine = new RootedObjectEventHandler();
         public RootedObjectEventHandler PrintingStateChanged = new RootedObjectEventHandler();
+        public RootedObjectEventHandler PowerStateChanged = new RootedObjectEventHandler();
 
         FoundStringStartsWithCallbacks ReadLineStartCallBacks = new FoundStringStartsWithCallbacks();
         FoundStringContainsCallbacks ReadLineContainsCallBacks = new FoundStringContainsCallbacks();
@@ -158,6 +159,7 @@ namespace MatterHackers.MatterControl.PrinterCommunication
         FoundStringStartsWithCallbacks WriteLineStartCallBacks = new FoundStringStartsWithCallbacks();
         FoundStringContainsCallbacks WriteLineContainsCallBacks = new FoundStringContainsCallbacks();
 
+        bool thePowerIsOn = false;
         bool printWasCanceled = false;
 		public bool PrintWasCanceled { get { return printWasCanceled; } }
         int firstLineToResendIndex = 0;
@@ -1486,6 +1488,29 @@ namespace MatterHackers.MatterControl.PrinterCommunication
             }
         }
 
+        public bool HasPower {
+            get {
+                bool hasPower = false;
+                if (this.ActivePrinter != null) {
+                    hasPower = this.ActivePrinter.HasPower;
+
+                }
+                return hasPower;
+            }
+        }
+
+        public bool PowerisOn 
+        {
+            get 
+            {
+                return thePowerIsOn;
+            }
+            set {
+                thePowerIsOn = value;
+                PowerStateChanged.CallEvents(this, null);
+            }
+        }
+
         public int BaudRate
         {
             get
@@ -1677,6 +1702,10 @@ namespace MatterHackers.MatterControl.PrinterCommunication
             FirmwareVersionRead.CallEvents(this, e);
         }
 
+        void OnPowerStateChanged(EventArgs e) {
+            PowerStateChanged.CallEvents(this, e);
+        }
+        
         void OnExtruderTemperatureRead(EventArgs e)
         {
             ExtruderTemperatureRead.CallEvents(this, e);

--- a/PrinterControls/PrinterConnections/EditConnectionWidget.cs
+++ b/PrinterControls/PrinterConnections/EditConnectionWidget.cs
@@ -213,7 +213,7 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
                     enableAutoconnect.Checked = ((StateBeforeRefresh)state).autoConnect;
                 }
 
-                enableHasPower = new CheckBox(LocalizedString.Get("Has Power"));
+                enableHasPower = new CheckBox(LocalizedString.Get("Has Firmware Power"));
                 enableHasPower.TextColor = ActiveTheme.Instance.PrimaryTextColor;
                 enableHasPower.Margin = new BorderDouble(top: 10);
                 enableHasPower.HAnchor = HAnchor.ParentLeft;

--- a/PrinterControls/PrinterConnections/EditConnectionWidget.cs
+++ b/PrinterControls/PrinterConnections/EditConnectionWidget.cs
@@ -28,6 +28,7 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
         GuiWidget baudRateWidget;
 		RadioButton otherBaudRateRadioButton;
         CheckBox enableAutoconnect;
+        CheckBox enableHasPower;
         bool printerComPortIsAvailable = false;
         TextImageButtonFactory textImageButtonFactory = new TextImageButtonFactory();
 
@@ -212,6 +213,15 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
                     enableAutoconnect.Checked = ((StateBeforeRefresh)state).autoConnect;
                 }
 
+                enableHasPower = new CheckBox(LocalizedString.Get("Has Power"));
+                enableHasPower.TextColor = ActiveTheme.Instance.PrimaryTextColor;
+                enableHasPower.Margin = new BorderDouble(top: 10);
+                enableHasPower.HAnchor = HAnchor.ParentLeft;
+                if (this.ActivePrinter.HasPower) {
+                    enableHasPower.Checked = true;
+                }
+
+
                 SerialPortControl serialPortScroll = new SerialPortControl();
 
                 if (comPortContainer != null) 
@@ -230,6 +240,7 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
                 ConnectionControlContainer.AddChild(baudRateWidget);
 #if !__ANDROID__ 
                 ConnectionControlContainer.AddChild(enableAutoconnect);
+                ConnectionControlContainer.AddChild(enableHasPower);
 #endif
             }
 
@@ -488,6 +499,7 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
                 this.ActivePrinter.Make = printerMakeInput.Text;
                 this.ActivePrinter.Model = printerModelInput.Text;
                 this.ActivePrinter.AutoConnectFlag = enableAutoconnect.Checked;
+                this.ActivePrinter.HasPower  = enableHasPower.Checked;
             }
             catch
             {

--- a/PrinterControls/PrinterConnections/PrinterSetupStatus.cs
+++ b/PrinterControls/PrinterConnections/PrinterSetupStatus.cs
@@ -36,6 +36,7 @@ namespace MatterHackers.MatterControl
 				this.ActivePrinter.Name = "Default Printer ({0})".FormatWith(ExistingPrinterCount() + 1);
 				this.ActivePrinter.BaudRate = null;
 				this.ActivePrinter.ComPort = null;
+                this.ActivePrinter.HasPower = false;
 			}
 			else
 			{

--- a/StaticData/Translations/Master.txt
+++ b/StaticData/Translations/Master.txt
@@ -3158,3 +3158,12 @@ Translated:Interface Mode
 English:Standard
 Translated:Standard
 
+English:Has Power
+Translated:Has Power
+
+English:On
+Translated:On
+
+English:Off
+Translated:Off
+


### PR DESCRIPTION
Added a option on the printer definition to enable printer power control
and a button for this is visable when enabled
ToDo:
1. The Codes for power are hard coded to M80/M81, this should be
configurable.
2 Needs to send the power on code before any commands sent in case the
firmware has inactivity timer.