### PR TITLE
Revise serial port filtering

### DIFF
--- a/PrinterControls/PrinterConnections/BaseConnectionWidget.cs
+++ b/PrinterControls/PrinterConnections/BaseConnectionWidget.cs
@@ -1,9 +1,15 @@
 ﻿using MatterHackers.Agg;
+using MatterHackers.Agg.PlatformAbstract;
 using MatterHackers.Agg.UI;
 using MatterHackers.Agg.VertexSource;
+using MatterHackers.Localizations;
 using MatterHackers.MatterControl.DataStorage;
+using MatterHackers.SerialPortCommunication.FrostedSerial;
+
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
 {
@@ -237,6 +243,10 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
 
 	public class ConnectionWidgetBase : GuiWidget
 	{
+		private static Regex linuxDefaultUIFilter = new Regex("/dev/ttyS*\\d+", RegexOptions.CultureInvariant | RegexOptions.Compiled);
+		private List<SerialPortIndexRadioButton> SerialPortButtonsList = new List<SerialPortIndexRadioButton>();
+		private bool printerComPortIsAvailable = false;
+
 		protected GuiWidget containerWindowToClose;
 		protected RGBA_Bytes defaultTextColor = ActiveTheme.Instance.PrimaryTextColor;
 		protected RGBA_Bytes defaultBackgroundColor = ActiveTheme.Instance.PrimaryBackgroundColor;
@@ -274,6 +284,86 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
 				unregisterEvents(this, null);
 			}
 			base.OnClosed(e);
+		}
+
+		private SerialPortIndexRadioButton createComPortOption(string portName, bool isActivePrinterPort)
+		{
+			SerialPortIndexRadioButton comPortOption = new SerialPortIndexRadioButton(portName, portName)
+			{
+				HAnchor = HAnchor.ParentLeft,
+				Margin = new BorderDouble(3, 3, 5, 3),
+				TextColor = this.subContainerTextColor,
+				Checked = isActivePrinterPort
+			};
+			return comPortOption;
+		}
+
+		protected string GetSelectedSerialPort()
+		{
+			foreach (SerialPortIndexRadioButton button in SerialPortButtonsList)
+			{
+				if (button.Checked)
+				{
+					return button.PortValue;
+				}
+			}
+
+			throw new Exception(LocalizedString.Get("Could not find a selected button."));
+		}
+
+		protected void CreateSerialPortControls(FlowLayoutWidget comPortContainer, string activePrinterSerialPort)
+		{
+			int portIndex = 0;
+			string[] allPorts = FrostedSerialPort.GetPortNames();
+			IEnumerable<string> filteredPorts;
+
+			if (OsInformation.OperatingSystem == OSType.X11)
+			{
+				// A default and naive filter that works well on Ubuntu 14
+				filteredPorts = allPorts.Where(portName => portName != "/dev/tty" && !linuxDefaultUIFilter.Match(portName).Success);
+			}
+			else
+			{
+				// looks_like_mac -- serialPort.StartsWith("/dev/tty."); looks_like_pc -- serialPort.StartsWith("COM")
+				filteredPorts = allPorts.Where(portName => portName.StartsWith("/dev/tty.") || portName.StartsWith("COM"));
+			}
+
+			IEnumerable<string> portsToCreate = filteredPorts.Any() ? filteredPorts : allPorts;
+
+			// Add a radio button for each filtered port
+			foreach (string portName in portsToCreate)
+			{
+				SerialPortIndexRadioButton comPortOption = createComPortOption(portName, activePrinterSerialPort == portName);
+				if (comPortOption.Checked)
+				{
+					printerComPortIsAvailable = true;
+				}
+
+				SerialPortButtonsList.Add(comPortOption);
+				comPortContainer.AddChild(comPortOption);
+
+				portIndex++;
+			}
+
+			// Add a virtual entry for serial ports that were previously configured but are not currently connected
+			if (!printerComPortIsAvailable && activePrinterSerialPort != null)
+			{
+				SerialPortIndexRadioButton comPortOption = createComPortOption(activePrinterSerialPort, true);
+				comPortOption.Enabled = false;
+
+				comPortContainer.AddChild(comPortOption);
+				SerialPortButtonsList.Add(comPortOption);
+				portIndex++;
+			}
+
+			//If there are still no com ports show a message to that effect
+			if (portIndex == 0)
+			{
+				TextWidget comPortOption = new TextWidget(LocalizedString.Get("No COM ports available"));
+				comPortOption.Margin = new BorderDouble(3, 6, 5, 6);
+				comPortOption.TextColor = this.subContainerTextColor;
+				comPortContainer.AddChild(comPortOption);
+			}
 		}
 	}
 }

--- a/PrinterControls/PrinterConnections/EditConnectionWidget.cs
+++ b/PrinterControls/PrinterConnections/EditConnectionWidget.cs
@@ -5,6 +5,7 @@ using MatterHackers.MatterControl.CustomWidgets;
 using MatterHackers.MatterControl.DataStorage;
 using MatterHackers.MatterControl.PrinterCommunication;
 using MatterHackers.SerialPortCommunication.FrostedSerial;
+
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -28,7 +29,6 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
 		private GuiWidget baudRateWidget;
 		private RadioButton otherBaudRateRadioButton;
 		private CheckBox enableAutoconnect;
-		private bool printerComPortIsAvailable = false;
 		private TextImageButtonFactory textImageButtonFactory = new TextImageButtonFactory();
 
 		private bool addNewPrinterFlag = false;
@@ -141,47 +141,7 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
 				comPortContainer.Margin = new BorderDouble(0);
 				comPortContainer.HAnchor = HAnchor.ParentLeftRight;
 
-				int portIndex = 0;
-				foreach (string serialPort in FrostedSerialPort.GetPortNames())
-				{
-					//Filter com port list based on usb type (applies to Mac mostly)
-					bool looks_like_mac = serialPort.StartsWith("/dev/tty.");
-					bool looks_like_pc = serialPort.StartsWith("COM");
-					if (looks_like_mac || looks_like_pc)
-					{
-						SerialPortIndexRadioButton comPortOption = createComPortOption(serialPort);
-						comPortContainer.AddChild(comPortOption);
-						portIndex++;
-					}
-				}
-
-				//If there are no com ports in the filtered list assume we are missing something and show the unfiltered list
-				if (portIndex == 0)
-				{
-					foreach (string serialPort in FrostedSerialPort.GetPortNames())
-					{
-						SerialPortIndexRadioButton comPortOption = createComPortOption(serialPort);
-						comPortContainer.AddChild(comPortOption);
-						portIndex++;
-					}
-				}
-
-				if (!printerComPortIsAvailable && this.ActivePrinter.ComPort != null)
-				{
-					SerialPortIndexRadioButton comPortOption = createComPortOption(this.ActivePrinter.ComPort);
-					comPortOption.Enabled = false;
-					comPortContainer.AddChild(comPortOption);
-					portIndex++;
-				}
-
-				//If there are still no com ports show a message to that effect
-				if (portIndex == 0)
-				{
-					TextWidget comPortOption = new TextWidget(LocalizedString.Get("No COM ports available"));
-					comPortOption.Margin = new BorderDouble(3, 6, 5, 6);
-					comPortOption.TextColor = this.subContainerTextColor;
-					comPortContainer.AddChild(comPortOption);
-				}
+				CreateSerialPortControls(comPortContainer, this.ActivePrinter.ComPort);
 #endif
 
 				TextWidget baudRateLabel = new TextWidget(LocalizedString.Get("Baud Rate"), 0, 0, 10);
@@ -385,26 +345,6 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
 			{
 				otherBaudRateInput.Visible = false;
 			}
-		}
-
-		public SerialPortIndexRadioButton createComPortOption(string serialPort)
-		{
-			//Add formatting here to make port names prettier
-			string portName = serialPort;
-
-			SerialPortIndexRadioButton comPortOption = new SerialPortIndexRadioButton(portName, serialPort);
-			SerialPortButtonsList.Add(comPortOption);
-
-			comPortOption.HAnchor = HAnchor.ParentLeft;
-			comPortOption.Margin = new BorderDouble(3, 3, 5, 3);
-			comPortOption.TextColor = this.subContainerTextColor;
-
-			if (this.ActivePrinter.ComPort == serialPort)
-			{
-				comPortOption.Checked = true;
-				printerComPortIsAvailable = true;
-			}
-			return comPortOption;
 		}
 
 		internal class StateBeforeRefresh


### PR DESCRIPTION
 - Add filtering on Linux builds; ignore ttyS*\d+ devices
 - Move control creation and filtering logic to base class to share across Add/Edit forms
 - Reduce calls to .GetPortNames()