### PR TITLE
Reset PrintItem.Id after dropping db row - Fixes #95812886

### DIFF
--- a/PrintQueue/PrintItemWrapper.cs
+++ b/PrintQueue/PrintItemWrapper.cs
@@ -135,6 +135,10 @@ namespace MatterHackers.MatterControl.PrintQueue
 		public void Delete()
 		{
 			PrintItem.Delete();
+
+			// Reset the Id field after calling delete to clear the association and ensure that future db operations
+			// result in inserts rather than update statements on a missing row
+			this.PrintItem.Id = 0;
 		}
 
 		public string Name


### PR DESCRIPTION
Resetting the Id property ensures that the queuedata item persisted to default.mcp loses its association with the removed db row. This ensures that future operations that determine if insert or update queries will be executed, see a (x.Id == 0) condition and perform the needed insert operation