### PR TITLE
Restore ability to attach VS to Android via debugger

### DIFF
--- a/AboutPage/AboutWidget.cs
+++ b/AboutPage/AboutWidget.cs
@@ -101,6 +101,11 @@ namespace MatterHackers.MatterControl
 
 		public static void DeleteCacheData()
 		{
+			if(LibraryProviderSQLite.Instance.PreloadingCalibrationFiles)
+			{
+				return;
+			}
+
 			// delete everything in the GCodeOutputPath
 			//   AppData\Local\MatterControl\data\gcode
 			// delete everything in the temp data that is not in use
@@ -213,7 +218,8 @@ namespace MatterHackers.MatterControl
 					case ".STL":
 					case ".AMF":
 					case ".GCODE":
-						if (referencedPrintItemsFilePaths.Contains(file))
+						// 
+						if (referencedPrintItemsFilePaths.Contains(file) || LibraryProviderSQLite.Instance.PreloadingCalibrationFiles && Path.GetDirectoryName(file).Contains("calibration-parts"))
 						{
 							contentCount++;
 						}

--- a/History/PrintHistoryData.cs
+++ b/History/PrintHistoryData.cs
@@ -53,31 +53,6 @@ namespace MatterHackers.MatterControl.PrintHistory
 			}
 		}
 
-		private List<string> GetLibraryParts()
-		{
-			List<string> libraryFilesToPreload = new List<string>();
-			string setupSettingsPathAndFile = Path.Combine("OEMSettings", "PreloadedLibraryFiles.txt");
-			if (StaticData.Instance.FileExists(setupSettingsPathAndFile))
-			{
-				try
-				{
-					foreach (string line in StaticData.Instance.ReadAllLines(setupSettingsPathAndFile))
-					{
-						//Ignore commented lines
-						if (!line.StartsWith("#"))
-						{
-							string settingLine = line.Trim();
-							libraryFilesToPreload.Add(settingLine);
-						}
-					}
-				}
-				catch
-				{
-				}
-			}
-			return libraryFilesToPreload;
-		}
-
 		public static readonly int RecordLimit = 20;
 
 		public IEnumerable<DataStorage.PrintTask> GetHistoryItems(int recordCount)

--- a/Library/Provider/LibraryProviderQueue.cs
+++ b/Library/Provider/LibraryProviderQueue.cs
@@ -62,13 +62,9 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 		}
 	}
 
-	public class LibraryProviderQueue : LibraryProvider
+	public class LibraryProviderQueue : ClassicSqliteStorageProvider
 	{
 		private static LibraryProviderQueue instance = null;
-		private PrintItemCollection baseLibraryCollection;
-
-		private List<PrintItemCollection> childCollections = new List<PrintItemCollection>();
-		private string keywordFilter = string.Empty;
 
 		EventHandler unregisterEvent;
 
@@ -116,15 +112,6 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 			}
 		}
 
-		public override bool Visible
-		{
-			get { return true; }
-		}
-
-		public override void Dispose()
-		{
-		}
-
 		public override int CollectionCount
 		{
 			get
@@ -141,32 +128,11 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 			}
 		}
 
-		public override string KeywordFilter
-		{
-			get
-			{
-				return keywordFilter;
-			}
-
-			set
-			{
-				keywordFilter = value;
-			}
-		}
-
 		public override string Name
 		{
 			get
 			{
 				return "Print Queue";
-			}
-		}
-
-		public override string ProviderData
-		{
-			get 
-			{
-				return baseLibraryCollection.Id.ToString();
 			}
 		}
 
@@ -176,35 +142,6 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 			{
 				return StaticProviderKey;
 			}
-		}
-
-		static public void SaveToLibraryFolder(PrintItemWrapper printItemWrapper, List<MeshGroup> meshGroups, bool AbsolutePositioned)
-		{
-			string[] metaData = { "Created By", "MatterControl" };
-			if (AbsolutePositioned)
-			{
-				metaData = new string[] { "Created By", "MatterControl", "BedPosition", "Absolute" };
-			}
-			if (printItemWrapper.FileLocation.Contains(ApplicationDataStorage.Instance.ApplicationLibraryDataPath))
-			{
-				MeshOutputSettings outputInfo = new MeshOutputSettings(MeshOutputSettings.OutputType.Binary, metaData);
-				MeshFileIo.Save(meshGroups, printItemWrapper.FileLocation, outputInfo);
-			}
-			else // save a copy to the library and update this to point at it
-			{
-				string fileName = Path.ChangeExtension(Path.GetRandomFileName(), ".amf");
-				printItemWrapper.FileLocation = Path.Combine(ApplicationDataStorage.Instance.ApplicationLibraryDataPath, fileName);
-
-				MeshOutputSettings outputInfo = new MeshOutputSettings(MeshOutputSettings.OutputType.Binary, metaData);
-				MeshFileIo.Save(meshGroups, printItemWrapper.FileLocation, outputInfo);
-
-				printItemWrapper.PrintItem.Commit();
-
-				// let the queue know that the item has changed so it load the correct part
-				QueueData.Instance.SaveDefaultQueue();
-			}
-
-			printItemWrapper.OnFileHasChanged();
 		}
 
 		public override void AddCollectionToLibrary(string collectionName)
@@ -219,11 +156,6 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 		public void AddItem(PrintItemWrapper item, int indexToInsert = -1)
 		{
 			QueueData.Instance.AddItem(item, indexToInsert);
-		}
-
-		public override PrintItemCollection GetCollectionItem(int collectionIndex)
-		{
-			return childCollections[collectionIndex];
 		}
 
 		public async override Task<PrintItemWrapper> GetPrintItemWrapperAsync(int index)
@@ -244,115 +176,6 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 		{
 			QueueData.Instance.RemoveAt(itemToRemoveIndex);
 			OnDataReloaded(null);
-		}
-
-		private static void AddStlOrGcode(LibraryProviderQueue libraryToAddTo, string loadedFileName, string extension)
-		{
-			PrintItem printItem = new PrintItem();
-			printItem.Name = Path.GetFileNameWithoutExtension(loadedFileName);
-			printItem.FileLocation = Path.GetFullPath(loadedFileName);
-			printItem.PrintItemCollectionID = libraryToAddTo.baseLibraryCollection.Id;
-			printItem.Commit();
-
-			if ((extension != "" && MeshFileIo.ValidFileExtensions().Contains(extension)))
-			{
-				List<MeshGroup> meshToConvertAndSave = MeshFileIo.Load(loadedFileName);
-
-				try
-				{
-					PrintItemWrapper printItemWrapper = new PrintItemWrapper(printItem, libraryToAddTo);
-					SaveToLibraryFolder(printItemWrapper, meshToConvertAndSave, false);
-					libraryToAddTo.AddItem(printItemWrapper);
-				}
-				catch (System.UnauthorizedAccessException)
-				{
-					UiThread.RunOnIdle(() =>
-					{
-						//Do something special when unauthorized?
-						StyledMessageBox.ShowMessageBox(null, "Oops! Unable to save changes, unauthorized access", "Unable to save");
-					});
-				}
-				catch
-				{
-					UiThread.RunOnIdle(() =>
-					{
-						StyledMessageBox.ShowMessageBox(null, "Oops! Unable to save changes.", "Unable to save");
-					});
-				}
-			}
-			else // it is not a mesh so just add it
-			{
-				PrintItemWrapper printItemWrapper = new PrintItemWrapper(printItem, libraryToAddTo);
-				if (false)
-				{
-					libraryToAddTo.AddItem(printItemWrapper);
-				}
-				else // save a copy to the library and update this to point at it
-				{
-					string sourceFileName = printItem.FileLocation;
-					string newFileName = Path.ChangeExtension(Path.GetRandomFileName(), Path.GetExtension(printItem.FileLocation));
-					string destFileName = Path.Combine(ApplicationDataStorage.Instance.ApplicationLibraryDataPath, newFileName);
-
-					File.Copy(sourceFileName, destFileName, true);
-
-					printItemWrapper.FileLocation = destFileName;
-					printItemWrapper.PrintItem.Commit();
-
-					// let the queue know that the item has changed so it load the correct part
-					libraryToAddTo.AddItem(printItemWrapper);
-				}
-			}
-		}
-
-		private IEnumerable<PrintItemCollection> GetChildCollections()
-		{
-			string query = string.Format("SELECT * FROM PrintItemCollection WHERE ParentCollectionID = {0} ORDER BY Name ASC;", baseLibraryCollection.Id);
-			IEnumerable<PrintItemCollection> result = (IEnumerable<PrintItemCollection>)Datastore.Instance.dbSQLite.Query<PrintItemCollection>(query);
-			return result;
-		}
-
-		public IEnumerable<PrintItem> GetLibraryItems(string keyphrase = null)
-		{
-			string query;
-			if (keyphrase == null)
-			{
-				query = string.Format("SELECT * FROM PrintItem WHERE PrintItemCollectionID = {0} ORDER BY Name ASC;", baseLibraryCollection.Id);
-			}
-			else
-			{
-				query = string.Format("SELECT * FROM PrintItem WHERE PrintItemCollectionID = {0} AND Name LIKE '%{1}%' ORDER BY Name ASC;", baseLibraryCollection.Id, keyphrase);
-			}
-			IEnumerable<PrintItem> result = (IEnumerable<PrintItem>)Datastore.Instance.dbSQLite.Query<PrintItem>(query);
-			return result;
-		}
-
-		private void loadFilesIntoLibraryBackgoundWorker_DoWork(IList<string> fileList)
-		{
-			foreach (string loadedFileName in fileList)
-			{
-				string extension = Path.GetExtension(loadedFileName).ToUpper();
-				if ((extension != "" && MeshFileIo.ValidFileExtensions().Contains(extension))
-					|| extension == ".GCODE"
-					|| extension == ".ZIP")
-				{
-					if (extension == ".ZIP")
-					{
-						ProjectFileHandler project = new ProjectFileHandler(null);
-						List<PrintItem> partFiles = project.ImportFromProjectArchive(loadedFileName);
-						if (partFiles != null)
-						{
-							foreach (PrintItem part in partFiles)
-							{
-								AddStlOrGcode(this, part.FileLocation, Path.GetExtension(part.FileLocation).ToUpper());
-							}
-						}
-					}
-					else
-					{
-						AddStlOrGcode(this, loadedFileName, extension);
-					}
-				}
-			}
 		}
 	}
 }

--- a/Library/Provider/LibraryProviderSqlite.cs
+++ b/Library/Provider/LibraryProviderSqlite.cs
@@ -62,17 +62,15 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 		}
 	}
 
-	public class LibraryProviderSQLite : LibraryProvider
+	public class LibraryProviderSQLite : ClassicSqliteStorageProvider
 	{
-		private static LibraryProviderSQLite instance = null;
-		private PrintItemCollection baseLibraryCollection;
+		public bool PreloadingCalibrationFiles = false;
 
-		private List<PrintItemCollection> childCollections = new List<PrintItemCollection>();
-		private string keywordFilter = string.Empty;
+		private static LibraryProviderSQLite instance = null;
 
 		private List<PrintItemWrapper> printItems = new List<PrintItemWrapper>();
 
-		string visibleName;
+		private string visibleName;
 
 		public LibraryProviderSQLite(PrintItemCollection baseLibraryCollection, LibraryProvider parentLibraryProvider, string visibleName)
 			: base(parentLibraryProvider)
@@ -81,14 +79,14 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 
 			if (baseLibraryCollection == null)
 			{
-				baseLibraryCollection = GetRootLibraryCollection2(this);
+				baseLibraryCollection = GetRootLibraryCollection2().Result;
 			}
 
 			this.baseLibraryCollection = baseLibraryCollection;
 			LoadLibraryItems();
 		}
 
-		public static LibraryProvider Instance
+		public static LibraryProviderSQLite Instance
 		{
 			get
 			{
@@ -128,15 +126,6 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 			}
 		}
 
-		public override bool Visible
-		{
-			get { return true; }
-		}
-
-		public override void Dispose()
-		{
-		}
-
 		public override int CollectionCount
 		{
 			get
@@ -153,32 +142,11 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 			}
 		}
 
-		public override string KeywordFilter
-		{
-			get
-			{
-				return keywordFilter;
-			}
-
-			set
-			{
-				keywordFilter = value;
-			}
-		}
-
 		public override string Name
 		{
 			get
 			{
 				return visibleName;
-			}
-		}
-
-		public override string ProviderData
-		{
-			get 
-			{
-				return baseLibraryCollection.Id.ToString();
 			}
 		}
 
@@ -188,94 +156,6 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 			{
 				return StaticProviderKey;
 			}
-		}
-
-		public static IEnumerable<PrintItem> GetAllPrintItemsRecursive()
-		{
-			// NOTE: We are making the assumption that everything is reference if it does not have a 0 in eth PrintItemCollectionID.
-			string query = "SELECT * FROM PrintItem WHERE PrintItemCollectionID != 0;";
-			IEnumerable<PrintItem> result = (IEnumerable<PrintItem>)Datastore.Instance.dbSQLite.Query<PrintItem>(query);
-			return result;
-		}
-
-		static PrintItemCollection GetRootLibraryCollection2(LibraryProviderSQLite rootLibrary)
-		{
-			// Attempt to initialize the library from the Datastore if null
-			PrintItemCollection rootLibraryCollection = Datastore.Instance.dbSQLite.Table<PrintItemCollection>().Where(v => v.Name == "_library").Take(1).FirstOrDefault();
-
-			// If the _library collection is still missing, create and populate it with default content
-			if (rootLibraryCollection == null)
-			{
-				rootLibraryCollection = new PrintItemCollection();
-				rootLibraryCollection.Name = "_library";
-				rootLibraryCollection.Commit();
-
-				// Preload library with Oem supplied list of default parts
-				string[] itemsToAdd = SyncCalibrationFilesToDisk(OemSettings.Instance.PreloadedLibraryFiles);
-				if (itemsToAdd.Length > 0)
-				{
-					// Import any files sync'd to disk into the library, then add them to the queue
-					rootLibrary.AddFilesToLibrary(itemsToAdd);
-				}
-			}
-
-			return rootLibraryCollection;
-		}
-
-		static public void SaveToLibraryFolder(PrintItemWrapper printItemWrapper, List<MeshGroup> meshGroups, bool AbsolutePositioned)
-		{
-			string[] metaData = { "Created By", "MatterControl" };
-			if (AbsolutePositioned)
-			{
-				metaData = new string[] { "Created By", "MatterControl", "BedPosition", "Absolute" };
-			}
-			if (printItemWrapper.FileLocation.Contains(ApplicationDataStorage.Instance.ApplicationLibraryDataPath))
-			{
-				MeshOutputSettings outputInfo = new MeshOutputSettings(MeshOutputSettings.OutputType.Binary, metaData);
-				MeshFileIo.Save(meshGroups, printItemWrapper.FileLocation, outputInfo);
-			}
-			else // save a copy to the library and update this to point at it
-			{
-				string fileName = Path.ChangeExtension(Path.GetRandomFileName(), ".amf");
-				printItemWrapper.FileLocation = Path.Combine(ApplicationDataStorage.Instance.ApplicationLibraryDataPath, fileName);
-
-				MeshOutputSettings outputInfo = new MeshOutputSettings(MeshOutputSettings.OutputType.Binary, metaData);
-				MeshFileIo.Save(meshGroups, printItemWrapper.FileLocation, outputInfo);
-
-				printItemWrapper.PrintItem.Commit();
-
-				// let the queue know that the item has changed so it load the correct part
-				QueueData.Instance.SaveDefaultQueue();
-			}
-
-			printItemWrapper.OnFileHasChanged();
-		}
-
-		public static string[] SyncCalibrationFilesToDisk(List<string> calibrationPrintFileNames)
-		{
-			// Ensure the CalibrationParts directory exists to store/import the files from disk
-			string tempPath = Path.Combine(ApplicationDataStorage.Instance.ApplicationUserDataPath, "data", "temp", "calibration-parts");
-			Directory.CreateDirectory(tempPath);
-
-			// Build a list of temporary files that should be imported into the library
-			return calibrationPrintFileNames.Where(fileName =>
-			{
-				// Filter out items that already exist in the library
-				LibraryProviderSQLite rootLibrary = new LibraryProviderSQLite(null, null, "Local Library");
-				return rootLibrary.GetLibraryItems(Path.GetFileNameWithoutExtension(fileName)).Count() <= 0;
-			}).Select(fileName =>
-			{
-				// Copy calibration prints from StaticData to the filesystem before importing into the library
-				string tempFile = Path.Combine(tempPath, Path.GetFileName(fileName));
-				using (FileStream outstream = File.OpenWrite(tempFile))
-				using (Stream instream = StaticData.Instance.OpenSteam(Path.Combine("OEMSettings", "SampleParts", fileName)))
-				{
-					instream.CopyTo(outstream);
-				}
-
-				// Project the new filename to the output
-				return tempFile;
-			}).ToArray();
 		}
 
 		public override void AddCollectionToLibrary(string collectionName)
@@ -288,42 +168,18 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 
 		public async override void AddItem(PrintItemWrapper itemToAdd)
 		{
-			if (itemToAdd != null && itemToAdd.FileLocation != null)
-			{
-				// create enough info to show that we have items pending (maybe use names from this file list for them)
-				// refresh the display to show the pending items
-				//LibraryProvider.OnDataReloaded(null);
+			await AddItemAsync(itemToAdd.Name, itemToAdd.FileLocation, fireDataReloaded: true);
 
-				await Task.Run(() => AddStlOrGcode(this, itemToAdd.FileLocation, itemToAdd.Name));
-
-				if (baseLibraryCollection != null)
-				{
-					LoadLibraryItems();
-					OnDataReloaded(null);
-				}
-			}
+			LoadLibraryItems();
+			OnDataReloaded(null);
 		}
 
-		public void AddItem(PrintItemWrapper item, int indexToInsert = -1)
+		public async Task AddItemAsync(string fileName, string fileLocation, bool fireDataReloaded)
 		{
-			if (indexToInsert == -1)
+			if (!string.IsNullOrEmpty(fileName) && !string.IsNullOrEmpty(fileLocation))
 			{
-				indexToInsert = printItems.Count;
+				await Task.Run(() => AddStlOrGcode(fileLocation, fileName));
 			}
-			printItems.Insert(indexToInsert, item);
-			// Check if the collection we are adding to is the the currently visible collection.
-			List<ProviderLocatorNode> currentDisplayedCollection = GetProviderLocator();
-			if (currentDisplayedCollection.Count > 0 && currentDisplayedCollection[0].Key == LibraryProviderSQLite.StaticProviderKey)
-			{
-				//OnItemAdded(new IndexArgs(indexToInsert));
-			}
-			item.PrintItem.PrintItemCollectionID = baseLibraryCollection.Id;
-			item.PrintItem.Commit();
-		}
-
-		public override PrintItemCollection GetCollectionItem(int collectionIndex)
-		{
-			return childCollections[collectionIndex];
 		}
 
 		public async override Task<PrintItemWrapper> GetPrintItemWrapperAsync(int index)
@@ -339,30 +195,6 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 		public override LibraryProvider GetProviderForCollection(PrintItemCollection collection)
 		{
 			return new LibraryProviderSQLite(collection, this, collection.Name);
-		}
-
-		void LoadLibraryItems()
-		{
-			printItems.Clear();
-			IEnumerable<PrintItem> partFiles = GetLibraryItems(KeywordFilter);
-			if (partFiles != null)
-			{
-				foreach (PrintItem part in partFiles)
-				{
-					PrintItemWrapper item = new PrintItemWrapper(part, this);
-					printItems.Add(item);
-				}
-			}
-
-			childCollections.Clear();
-			GetChildCollections();
-			IEnumerable<PrintItemCollection> collections = GetChildCollections();
-			if(collections != null)
-			{
-				childCollections.AddRange(collections);
-			}
-
-			OnDataReloaded(null);
 		}
 
 		public override void RemoveCollection(int collectionIndexToRemove)
@@ -389,86 +221,101 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 			OnDataReloaded(null);
 		}
 
-		private static void AddStlOrGcode(LibraryProviderSQLite libraryToAddTo, string loadedFileName, string displayName)
+		public async Task EnsureSamplePartsExist(IEnumerable<string> filenamesToValidate)
 		{
-			string extension = Path.GetExtension(loadedFileName).ToUpper();
+			PreloadingCalibrationFiles = true;
 
-			PrintItem printItem = new PrintItem();
-			printItem.Name = displayName;
-			printItem.FileLocation = Path.GetFullPath(loadedFileName);
-			printItem.PrintItemCollectionID = libraryToAddTo.baseLibraryCollection.Id;
-			printItem.Commit();
+			// Ensure the CalibrationParts directory exists to store/import the files from disk
+			string tempPath = Path.Combine(ApplicationDataStorage.Instance.ApplicationUserDataPath, "data", "temp", "calibration-parts");
+			Directory.CreateDirectory(tempPath);
 
-			if ((extension != "" && MeshFileIo.ValidFileExtensions().Contains(extension)))
+			var existingLibaryItems = this.GetLibraryItems().Select(i => i.Name);
+
+			// Build a list of files that need to be imported into the library
+			var missingFiles = filenamesToValidate.Where(fileName => !existingLibaryItems.Contains(fileName, StringComparer.OrdinalIgnoreCase));
+
+			// Create temp files on disk that can be imported into the library
+			var tempFilesToImport = missingFiles.Select(fileName =>
 			{
-				List<MeshGroup> meshToConvertAndSave = MeshFileIo.Load(loadedFileName);
+				// Copy calibration prints from StaticData to the filesystem before importing into the library
+				string tempFilePath = Path.Combine(tempPath, Path.GetFileName(fileName));
+				using (FileStream outstream = File.OpenWrite(tempFilePath))
+				using (Stream instream = StaticData.Instance.OpenSteam(Path.Combine("OEMSettings", "SampleParts", fileName)))
+				{
+					instream.CopyTo(outstream);
+				}
 
-				try
-				{
-					PrintItemWrapper printItemWrapper = new PrintItemWrapper(printItem, libraryToAddTo);
-					SaveToLibraryFolder(printItemWrapper, meshToConvertAndSave, false);
-					libraryToAddTo.AddItem(printItemWrapper);
-				}
-				catch (System.UnauthorizedAccessException)
-				{
-					UiThread.RunOnIdle(() =>
-					{
-						//Do something special when unauthorized?
-						StyledMessageBox.ShowMessageBox(null, "Oops! Unable to save changes, unauthorized access", "Unable to save");
-					});
-				}
-				catch
-				{
-					UiThread.RunOnIdle(() =>
-					{
-						StyledMessageBox.ShowMessageBox(null, "Oops! Unable to save changes.", "Unable to save");
-					});
-				}
-			}
-			else // it is not a mesh so just add it
+				// Project the new filename to the output
+				return tempFilePath;
+			}).ToArray();
+
+			// Import any missing files into the library
+			foreach (string file in tempFilesToImport)
 			{
-				PrintItemWrapper printItemWrapper = new PrintItemWrapper(printItem, libraryToAddTo);
-				if (false)
-				{
-					libraryToAddTo.AddItem(printItemWrapper);
-				}
-				else // save a copy to the library and update this to point at it
-				{
-					string sourceFileName = printItem.FileLocation;
-					string newFileName = Path.ChangeExtension(Path.GetRandomFileName(), Path.GetExtension(printItem.FileLocation));
-					string destFileName = Path.Combine(ApplicationDataStorage.Instance.ApplicationLibraryDataPath, newFileName);
-
-					File.Copy(sourceFileName, destFileName, true);
-
-					printItemWrapper.FileLocation = destFileName;
-					printItemWrapper.PrintItem.Commit();
-
-					// let the queue know that the item has changed so it load the correct part
-					libraryToAddTo.AddItem(printItemWrapper);
-				}
+				// Ensure these operations run in serial rather than in parallel where they stomp on each other when writing to default.mcp
+				await this.AddItemAsync(Path.GetFileNameWithoutExtension(file), file, false);
 			}
+
+			PreloadingCalibrationFiles = false;
 		}
 
-		private IEnumerable<PrintItemCollection> GetChildCollections()
+		/// <summary>
+		/// Exposes all PrintItems for use in file purge code in AboutWidget
+		/// </summary>
+		/// <returns>A list of all print items</returns>
+		public static IEnumerable<PrintItem> GetAllPrintItemsRecursive()
 		{
-			string query = string.Format("SELECT * FROM PrintItemCollection WHERE ParentCollectionID = {0} ORDER BY Name ASC;", baseLibraryCollection.Id);
-			IEnumerable<PrintItemCollection> result = (IEnumerable<PrintItemCollection>)Datastore.Instance.dbSQLite.Query<PrintItemCollection>(query);
-			return result;
-		}
-
-		public IEnumerable<PrintItem> GetLibraryItems(string keyphrase = null)
-		{
-			string query;
-			if (keyphrase == null)
-			{
-				query = string.Format("SELECT * FROM PrintItem WHERE PrintItemCollectionID = {0} ORDER BY Name ASC;", baseLibraryCollection.Id);
-			}
-			else
-			{
-				query = string.Format("SELECT * FROM PrintItem WHERE PrintItemCollectionID = {0} AND Name LIKE '%{1}%' ORDER BY Name ASC;", baseLibraryCollection.Id, keyphrase);
-			}
+			// NOTE: We are making the assumption that everything is reference if it does not have a 0 in eth PrintItemCollectionID.
+			string query = "SELECT * FROM PrintItem WHERE PrintItemCollectionID != 0;";
 			IEnumerable<PrintItem> result = (IEnumerable<PrintItem>)Datastore.Instance.dbSQLite.Query<PrintItem>(query);
 			return result;
+		}
+
+		private async Task<PrintItemCollection> GetRootLibraryCollection2()
+		{
+			// Attempt to initialize the library from the Datastore if null
+			PrintItemCollection rootLibraryCollection = Datastore.Instance.dbSQLite.Table<PrintItemCollection>().Where(v => v.Name == "_library").Take(1).FirstOrDefault();
+
+			// If the _library collection is still missing, create and populate it with default content
+			if (rootLibraryCollection == null)
+			{
+				rootLibraryCollection = new PrintItemCollection();
+				rootLibraryCollection.Name = "_library";
+				rootLibraryCollection.Commit();
+
+				// In this case we now need to update the baseLibraryCollection instance member as code that executes
+				// down this path will attempt to use the property and will exception if its not set
+				this.baseLibraryCollection = rootLibraryCollection;
+
+				// Preload library with Oem supplied list of default parts
+				await this.EnsureSamplePartsExist(OemSettings.Instance.PreloadedLibraryFiles);
+			}
+
+			return rootLibraryCollection;
+		}
+
+		private void LoadLibraryItems()
+		{
+			printItems.Clear();
+			IEnumerable<PrintItem> partFiles = GetLibraryItems(KeywordFilter);
+			if (partFiles != null)
+			{
+				foreach (PrintItem part in partFiles)
+				{
+					PrintItemWrapper item = new PrintItemWrapper(part, this);
+					printItems.Add(item);
+				}
+			}
+
+			childCollections.Clear();
+			GetChildCollections();
+			IEnumerable<PrintItemCollection> collections = GetChildCollections();
+			if (collections != null)
+			{
+				childCollections.AddRange(collections);
+			}
+
+			OnDataReloaded(null);
 		}
 	}
 }

--- a/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/PartPreviewWindow/View3D/View3DWidget.cs
@@ -1779,7 +1779,6 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			PushMeshGroupDataToAsynchLists(TraceInfoOpperation.DO_COPY);
 
 			Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
-			BackgroundWorker backgroundWorker = (BackgroundWorker)sender;
 			try
 			{
 				// push all the transforms into the meshes

--- a/PrinterControls/PrinterConnections/PrinterSetupStatus.cs
+++ b/PrinterControls/PrinterConnections/PrinterSetupStatus.cs
@@ -61,14 +61,13 @@ namespace MatterHackers.MatterControl
 				var queueItems = QueueData.Instance.GetItemNames();
 
 				// Finally, ensure missing calibration parts are added to the queue if missing
-				foreach (string nameOnly in calibrationPrintFileNames)
+				var filenamesWithoutExtensions = calibrationPrintFileNames.Select(f => Path.GetFileNameWithoutExtension(f));
+				foreach (string nameOnly in filenamesWithoutExtensions)
 				{
 					if (queueItems.Contains(nameOnly))
 					{
 						continue;
 					}
-
-					// TODO: We add any file named X into the queue? Isn't it possible to have bunch of files named X, in which case we copy all of them at this step?
 
 					// If the library item does not exist in the queue, add it
 					foreach (PrintItem libraryItem in LibraryProviderSQLite.Instance.GetLibraryItems(nameOnly))
@@ -81,7 +80,6 @@ namespace MatterHackers.MatterControl
 				}
 			}
 		}
-
 
 		private List<string> LoadCalibrationPartNamesForPrinter(string make, string model)
 		{

--- a/PrinterControls/PrinterConnections/SetupStepMakeModelName.cs
+++ b/PrinterControls/PrinterConnections/SetupStepMakeModelName.cs
@@ -255,12 +255,12 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
 			}
 		}
 
-		private void NextButton_Click(object sender, EventArgs mouseEvent)
+		private async void NextButton_Click(object sender, EventArgs mouseEvent)
 		{
 			bool canContinue = this.OnSave();
 			if (canContinue)
 			{
-				this.currentPrinterSetupStatus.LoadCalibrationPrints();
+				await this.currentPrinterSetupStatus.LoadCalibrationPrints();
 				UiThread.RunOnIdle(MoveToNextWidget);
 			}
 		}

--- a/Utilities/ProjectFileHandler.cs
+++ b/Utilities/ProjectFileHandler.cs
@@ -240,29 +240,6 @@ namespace MatterHackers.MatterControl
 			}
 		}
 
-		public void OpenFromDialog()
-		{
-			OpenFileDialogParams openParams = new OpenFileDialogParams("Zip file|*.zip");
-			FileDialog.OpenFileDialog(openParams, onProjectArchiveLoad);
-		}
-
-		private void onProjectArchiveLoad(OpenFileDialogParams openParams)
-		{
-			List<PrintItem> partFiles;
-			if (openParams.FileNames != null)
-			{
-				string loadedFileName = openParams.FileName;
-				partFiles = ImportFromProjectArchive(loadedFileName);
-				if (partFiles != null)
-				{
-					foreach (PrintItem part in partFiles)
-					{
-						QueueData.Instance.AddItem(new PrintItemWrapper(new PrintItem(part.Name, part.FileLocation)));
-					}
-				}
-			}
-		}
-
 		public List<PrintItem> ImportFromProjectArchive(string loadedFileName = null)
 		{
 			if (loadedFileName == null)
@@ -270,10 +247,14 @@ namespace MatterHackers.MatterControl
 				loadedFileName = defaultProjectPathAndFileName;
 			}
 
-			if (System.IO.File.Exists(loadedFileName))
+			if (!System.IO.File.Exists(loadedFileName))
 			{
-				FileStream fs = File.OpenRead(loadedFileName);
-				ZipArchive zip = new ZipArchive(fs);
+				return null;
+			}
+
+			using (FileStream fs = File.OpenRead(loadedFileName))
+			using (ZipArchive zip = new ZipArchive(fs))
+			{
 				int projectHashCode = zip.GetHashCode();
 
 				//If the temp folder doesn't exist - create it, otherwise clear it
@@ -351,10 +332,6 @@ namespace MatterHackers.MatterControl
 				}
 
 				return printItemList;
-			}
-			else
-			{
-				return null;
 			}
 		}
 


### PR DESCRIPTION
 - Prevent accidental construction of ProviderSQLite objects inside of ProviderSQLite constructor
 - Initialize .baseLibraryCollection during rootLibraryCollection construction to prevent null reference errors
   caused by access before assignment
 - Remove AddItem -> AddStlOrGcode -> AddItem recursion - Fixes crash due to concurrent writes to default.mcp
 - Add sqlite async methods and supporting logic to ensure disk IO operations aren’t run in parallel
 - Consolidate logic around sample part extraction from StaticData from various areas into a single method
 - Rename that method from SyncCalibrationFilesToDisk to EnsureSamplePartsExist
 - Break apart the large LINQ query into discrete and easier to understand steps
 - Add shared base class for sqlite backed library providers and resuse common code in base
 - Guard against cache deletion during one-time library initialization
 - Discard StreamReader cases in favor of ReadAllText - Ensures .Dispose is always called and is ultra succinct
 - Purge orphaned code