### PR TITLE
Refresh root library view as needed

### DIFF
--- a/CustomWidgets/LibrarySelector/LibrarySelectorWidget.cs
+++ b/CustomWidgets/LibrarySelector/LibrarySelectorWidget.cs
@@ -373,7 +373,7 @@ namespace MatterHackers.MatterControl.CustomWidgets.LibrarySelector
 
 			if (provider != null)
 			{
-				if (provider.ProviderKey != "ProviderSelectorKey")
+				if (provider.ProviderKey != LibraryProviderSelector.ProviderKeyName)
 				{
 					PrintItemCollection parent = new PrintItemCollection("..", provider.ProviderKey);
 					LibrarySelectorRowItem queueItem = new LibrarySelectorRowItem(parent, -1, this, provider.ParentLibraryProvider, GetThumbnailWidget(provider.ParentLibraryProvider, parent, LibraryProvider.UpFolderImage), "Back".Localize());

--- a/Library/LibraryDataView.cs
+++ b/Library/LibraryDataView.cs
@@ -372,7 +372,7 @@ namespace MatterHackers.MatterControl.PrintLibrary
 			var provider = this.CurrentLibraryProvider;
 			if (provider != null)
 			{
-				if (provider.ProviderKey != "ProviderSelectorKey")
+				if (provider.ProviderKey != LibraryProviderSelector.ProviderKeyName)
 				{
 					// Create logical "up folder" entry
 					PrintItemCollection parent = new PrintItemCollection("..", provider.ProviderKey);

--- a/StaticData/Translations/Master.txt
+++ b/StaticData/Translations/Master.txt
@@ -3814,3 +3814,6 @@ Translated:Material {0}
 English:Redeem Purchase
 Translated:Redeem Purchase
 
+English:Oops! Please sign in to enable this feature.
+Translated:Oops! Please sign in to enable this feature.
+


### PR DESCRIPTION
 - Add LibraryRootNotice event
 - Hook LibraryRootNotice into new Socketeer LibraryRootNotice DeviceEvent
 - Listen for LibraryRootNotice in LibraryProviderSelector and call ReloadData to ping ProviderFactories for visibility
 - Refactor LibraryProviderSharedPlugin for clarity
 - Refactor LibraryProviderSharedPlugin to support refreshing visibility logic after ShouldBeShown() calls
 - Revise AcquireCollectionData() to use 'internal' access modifier for reuse in LibraryProviderSharedPlugin
 - Ensure the input field on CloudShareRedeemForm is focused by default, make buttons available to test automation
 - Add new test for 'Shared with Me' folder visibility
 - Update existing Purchased folder test to look for revised item name
 - Replace magic 'ProviderSelectorKey' token with static member for compile time consistency