### PR TITLE
Automation updates

### DIFF
--- a/DataStorage/Datastore.cs
+++ b/DataStorage/Datastore.cs
@@ -46,9 +46,7 @@ namespace MatterHackers.MatterControl.DataStorage
 		private static readonly string applicationDataFolderName = "MatterControl";
 		private readonly string datastoreName = "MatterControl.db";
 		private string applicationPath;
-		//private string testDataPath = Path.Combine("..", "..", "..", "..", "Tests", "TestData");
-
-
+		private static string applicationUserDataPath = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData), applicationDataFolderName);
 
 		public ApplicationDataStorage()
 		//Constructor - validates that local storage folder exists, creates if necessary
@@ -75,8 +73,6 @@ namespace MatterHackers.MatterControl.DataStorage
 			}
 		}
 
-		private static string applicationUserDataPath = Path.Combine(System.Environment.GetFolderPath(System.Environment.SpecialFolder.LocalApplicationData), applicationDataFolderName);
-		
 		public string ApplicationLibraryDataPath
 		{
 			get
@@ -93,10 +89,18 @@ namespace MatterHackers.MatterControl.DataStorage
 			}
 		}
 
-		internal void OverrideApplicationPath(string path)
+		/// <summary>
+		/// Overrides the AppData location.
+		/// </summary>
+		/// <param name="path">The new AppData path.</param>
+		internal void OverrideAppDataLocation(string path)
 		{
+			// Ensure the target directory exists
 			Directory.CreateDirectory(path);
+
 			applicationUserDataPath = path;
+
+			// Initialize a fresh datastore instance after overriding the AppData path
 			Datastore.Instance = new Datastore();
 			Datastore.Instance.Initialize();
 		}
@@ -135,8 +139,8 @@ namespace MatterHackers.MatterControl.DataStorage
 			{
 				return applicationUserDataPath;
 			}
-
 		}
+
 		/// <summary>
 		/// Returns the path to the sqlite database
 		/// </summary>
@@ -250,6 +254,8 @@ namespace MatterHackers.MatterControl.DataStorage
 				}
 				return globalInstance;
 			}
+
+			// Special case to allow tests to set custom application paths 
 			internal set
 			{
 				globalInstance = value;

--- a/StaticData/SliceSettings/Properties.json
+++ b/StaticData/SliceSettings/Properties.json
@@ -796,7 +796,7 @@
   },
   {
     "SlicerConfigName": "skirt_distance",
-    "PresentationName": "Distance from Object",
+    "PresentationName": "Distance From Object",
     "HelpText": "The distance to start drawing the first skirt loop. Make this 0 to create an anchor for the part to the bed.",
     "DataEditType": "POSITIVE_DOUBLE",
     "ExtraSettings": "mm",

--- a/Tests/MatterControl.AutomationTests/OptionsTabTests.cs
+++ b/Tests/MatterControl.AutomationTests/OptionsTabTests.cs
@@ -24,7 +24,6 @@ namespace MatterHackers.MatterControl.UI
 			{
 				AutomationRunner testRunner = new AutomationRunner(MatterControlUtilities.DefaultTestImages);
 				{
-
 					testRunner.ClickByName("SettingsAndControls", 5);
 					testRunner.Wait(2);
 					testRunner.ClickByName("Options Tab", 6);
@@ -33,7 +32,8 @@ namespace MatterHackers.MatterControl.UI
 					resultsHarness.AddTestResult(terminalWindowExists1 == false, "Terminal Window does not exist");
 
 					testRunner.ClickByName("Show Terminal Button", 6);
-		
+					testRunner.Wait(1);
+
 					SystemWindow containingWindow;
 					GuiWidget terminalWindow = testRunner.GetWidgetByName("Gcode Terminal", out containingWindow, 3);
 					resultsHarness.AddTestResult(terminalWindow != null, "Terminal Window exists after Show Terminal button is clicked");
@@ -44,7 +44,7 @@ namespace MatterHackers.MatterControl.UI
 				}
 			};
 
-			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, "MC_Three_Queue_Items");
+			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun);
 
 			Assert.IsTrue(testHarness.AllTestsPassed);
 			Assert.IsTrue(testHarness.TestCount == 2); // make sure we ran all our tests

--- a/Tests/MatterControl.AutomationTests/PrintQueueTests.cs
+++ b/Tests/MatterControl.AutomationTests/PrintQueueTests.cs
@@ -71,7 +71,7 @@ namespace MatterHackers.MatterControl.UI
 				}
 			};
 
-			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, "MC_Three_Queue_Items");
+			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, queueItemFolderToAdd: QueueTemplate.Three_Queue_Items);
 
 			Assert.IsTrue(testHarness.AllTestsPassed);
 			Assert.IsTrue(testHarness.TestCount == 2); // make sure we ran all our tests
@@ -157,7 +157,7 @@ namespace MatterHackers.MatterControl.UI
 				}
 			};
 
-			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, null, null, "Three_Queue_Items");
+			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, queueItemFolderToAdd: QueueTemplate.Three_Queue_Items);
 			Assert.IsTrue(testHarness.AllTestsPassed);
 			Assert.IsTrue(testHarness.TestCount == 2); // make sure we ran all our tests
 
@@ -222,7 +222,7 @@ namespace MatterHackers.MatterControl.UI
 				}
 			};
 
-			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, null, null, "Three_Queue_Items");
+			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, queueItemFolderToAdd: QueueTemplate.Three_Queue_Items);
 			Assert.IsTrue(testHarness.AllTestsPassed);
 			Assert.IsTrue(testHarness.TestCount == 2); // make sure we ran all our tests
 		}
@@ -268,7 +268,7 @@ namespace MatterHackers.MatterControl.UI
 				}
 			};
 
-			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, null, null, "Three_Queue_Items");
+			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, queueItemFolderToAdd: QueueTemplate.Three_Queue_Items);
 			Assert.IsTrue(testHarness.AllTestsPassed);
 			Assert.IsTrue(testHarness.TestCount == 2); // make sure we ran all our tests
 		}
@@ -461,7 +461,7 @@ namespace MatterHackers.MatterControl.UI
 				}
 			};
 
-			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, null, null, "Three_Queue_Items");
+			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, queueItemFolderToAdd: QueueTemplate.Three_Queue_Items);
 			Assert.IsTrue(testHarness.AllTestsPassed);
 			Assert.IsTrue(testHarness.TestCount == 3); // make sure we ran all our tests
 		}
@@ -524,7 +524,7 @@ namespace MatterHackers.MatterControl.UI
 				}
 			};
 
-			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, null, null, "Three_Queue_Items");
+			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, queueItemFolderToAdd: QueueTemplate.Three_Queue_Items);
 			Assert.IsTrue(testHarness.AllTestsPassed);
 			Assert.IsTrue(testHarness.TestCount == 3); // make sure we ran all our tests
 		}
@@ -587,7 +587,7 @@ namespace MatterHackers.MatterControl.UI
 				}
 			};
 
-			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, null, null, "Three_Queue_Items");
+			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, queueItemFolderToAdd: QueueTemplate.Three_Queue_Items);
 			Assert.IsTrue(testHarness.AllTestsPassed);
 			Assert.IsTrue(testHarness.TestCount == 3); // make sure we ran all our tests
 		}
@@ -654,7 +654,7 @@ namespace MatterHackers.MatterControl.UI
 				}
 			};
 
-			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, null, null, "Three_Queue_Items");
+			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, queueItemFolderToAdd: QueueTemplate.Three_Queue_Items);
 			Assert.IsTrue(testHarness.AllTestsPassed);
 			Assert.IsTrue(testHarness.TestCount == 4); // make sure we ran all our tests
 		}
@@ -695,9 +695,14 @@ namespace MatterHackers.MatterControl.UI
 
 					testRunner.Wait(2);
 
-
 					//Type in Absolute Path to Save 
 					string exportZipPath = MatterControlUtilities.PathToQueueItemsFolder("TestExportZip");
+
+					// Ensure file does not exist before save
+					if(File.Exists(exportZipPath))
+					{
+						File.Delete(exportZipPath);
+					}
 
 					testRunner.Type(exportZipPath);
 
@@ -745,7 +750,7 @@ namespace MatterHackers.MatterControl.UI
 				}
 			};
 
-			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, null, null, "Three_Queue_Items");
+			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, queueItemFolderToAdd: QueueTemplate.Three_Queue_Items);
 			Assert.IsTrue(testHarness.AllTestsPassed);
 			Assert.IsTrue(testHarness.TestCount == 3); // make sure we ran all our tests
 		}
@@ -796,7 +801,7 @@ namespace MatterHackers.MatterControl.UI
 				}
 			};
 
-			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, null, null, "Three_Queue_Items");
+			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, queueItemFolderToAdd: QueueTemplate.Three_Queue_Items);
 			Assert.IsTrue(testHarness.AllTestsPassed);
 			Assert.IsTrue(testHarness.TestCount == 2); // make sure we ran all our tests
 		}
@@ -867,7 +872,7 @@ namespace MatterHackers.MatterControl.UI
 				}
 			};
 
-			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, null, null, "Three_Queue_Items");
+			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, queueItemFolderToAdd: QueueTemplate.Three_Queue_Items);
 			Assert.IsTrue(testHarness.AllTestsPassed);
 			Assert.IsTrue(testHarness.TestCount == 8); // make sure we ran all our tests
 		}
@@ -931,7 +936,7 @@ namespace MatterHackers.MatterControl.UI
 				}
 			};
 
-			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, null, null, "Three_Queue_Items");
+			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, queueItemFolderToAdd: QueueTemplate.Three_Queue_Items);
 			Assert.IsTrue(testHarness.AllTestsPassed);
 			Assert.IsTrue(testHarness.TestCount == 5); // make sure we ran all our tests
 		}
@@ -1006,7 +1011,7 @@ namespace MatterHackers.MatterControl.UI
 				}
 			};
 			
-			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, null, null, "Three_Queue_Items");
+			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, queueItemFolderToAdd: QueueTemplate.Three_Queue_Items);
 			Assert.IsTrue(testHarness.AllTestsPassed);
 			Assert.IsTrue(testHarness.TestCount == 7); // make sure we ran all our tests
 		}

--- a/Tests/MatterControl.AutomationTests/SqLiteLibraryProvider.cs
+++ b/Tests/MatterControl.AutomationTests/SqLiteLibraryProvider.cs
@@ -40,13 +40,13 @@ namespace MatterHackers.MatterControl.UI
 					resultsHarness.AddTestResult(testRunner.ClickByName("Save As Save Button", 1));
 
 					// ensure that it is now in the library folder (that the folder updated)
-					resultsHarness.AddTestResult(testRunner.WaitForName("Row Item " + "Test Part", 5), "The part we added sholud be in the library");
+					resultsHarness.AddTestResult(testRunner.WaitForName("Row Item " + "Test Part", 5), "The part we added should be in the library");
 
-					MatterControlUtilities.CloseMatterControl(testRunner);
+					MatterControlUtilities.CloseMatterControl(testRunner); 
 				}
 			};
 
-			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, "MC_One_Queue_No_Library");
+			AutomationTesterHarness testHarness = MatterControlUtilities.RunTest(testToRun, queueItemFolderToAdd: QueueTemplate.Three_Queue_Items);
 
 			Assert.IsTrue(testHarness.AllTestsPassed);
 			Assert.IsTrue(testHarness.TestCount == 8); // make sure we ran all our tests

--- a/Tests/MatterControl.Tests/MatterControl/LibraryProviderSqliteTests.cs
+++ b/Tests/MatterControl.Tests/MatterControl/LibraryProviderSqliteTests.cs
@@ -63,7 +63,7 @@ namespace MatterControl.Tests
 		[Test, RunInApplicationDomain]
 		public void LibraryProviderSqlite_NavigationWorking()
 		{
-			MatterControlUtilities.MakeNewMatterControlAppDataFolderForTesting();
+			MatterControlUtilities.OverrideAppDataLocation();
 
 			LibraryProviderSQLite testProvider = new LibraryProviderSQLite(null, null, null, "Local Library");
 			testProvider.DataReloaded += (sender, e) => { dataReloaded = true; };


### PR DESCRIPTION
 - Revise skirt_distance label per support team
 - Remove CreateInstance(showWindow) out variable
 - Remove embedded tools requiring showWindow out variable
 - Remove queueItemFolderToAdd variable/parameter
 - Change AfterFirstDraw event to null conditional invoke
 - Removed unused AutomationTest from MatterControlApplication
 - Refactor for style consistency and document new methods
 - Change queueItemFolderToAdd type to custom enum to ensure optional parameters are not mixed up
 - Ensure TestExportZip file is deleted before attempting export