### PR TITLE
Restore CloudLibrary save functionality, revise convert to AMF behavior

### DIFF
--- a/Library/LibraryRowItemPart.cs
+++ b/Library/LibraryRowItemPart.cs
@@ -240,11 +240,15 @@ namespace MatterHackers.MatterControl.PrintLibrary
 			}
 		}
 
-		public async void OpenPartViewWindow(View3DWidget.OpenMode openMode = View3DWidget.OpenMode.Viewing)
+		public async void OpenPartViewWindow(View3DWidget.OpenMode openMode = View3DWidget.OpenMode.Viewing, PrintItemWrapper printItemWrapper = null)
 		{
 			if (viewingWindow == null)
 			{
-				var printItemWrapper = await this.GetPrintItemWrapperAsync();
+				// Only call GetPrintItemWrapperAsync if need to avoid unneeded overhead
+				if (printItemWrapper == null)
+				{
+					printItemWrapper = await this.GetPrintItemWrapperAsync();
+				}
 				viewingWindow = new PartPreviewMainWindow(printItemWrapper, View3DWidget.AutoRotate.Enabled, openMode);
 				viewingWindow.Closed += new EventHandler(PartPreviewMainWindow_Closed);
 			}
@@ -433,7 +437,7 @@ namespace MatterHackers.MatterControl.PrintLibrary
 				string pathAndFile = printItemWrapper.FileLocation;
 				if (File.Exists(pathAndFile))
 				{
-					OpenPartViewWindow(openMode);
+					OpenPartViewWindow(openMode, printItemWrapper);
 				}
 				else
 				{

--- a/Library/Provider/LibraryProviderSelector.cs
+++ b/Library/Provider/LibraryProviderSelector.cs
@@ -137,7 +137,12 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 			string downloadsDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads");
 			if (Directory.Exists(downloadsDirectory))
 			{
-				libraryCreators.Add(new LibraryProviderFileSystemCreator(downloadsDirectory, "Downloads"));
+				libraryCreators.Add(
+					new LibraryProviderFileSystemCreator(
+						downloadsDirectory,
+						"Downloads",
+						useIncrementedNameDuringTypeChange: true));
+
 				AddFolderImage("download_folder.png");
 			}
 
@@ -148,7 +153,12 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 				{
 					if(Directory.Exists(directory))
 					{
-						libraryCreators.Add(new LibraryProviderFileSystemCreator(directory, (new DirectoryInfo(directory).Name)));
+						libraryCreators.Add(
+							new LibraryProviderFileSystemCreator(
+								directory, 
+								(new DirectoryInfo(directory).Name),
+								useIncrementedNameDuringTypeChange: true));
+
 						AddFolderImage("download_folder.png");
 					}
 				}

--- a/Queue/PrintItemWrapper.cs
+++ b/Queue/PrintItemWrapper.cs
@@ -211,6 +211,16 @@ namespace MatterHackers.MatterControl.PrintQueue
 			}
 		}
 
+		public string GetFileExtension()
+		{
+			return Path.GetExtension(this.PrintItem.FileLocation);
+		}
+
+		public string GetFileNameWithoutExtension()
+		{
+			return Path.GetFileNameWithoutExtension(this.PrintItem.FileLocation); ;
+		}
+
 		public string Name
 		{
 			get { return this.PrintItem.Name; }
@@ -238,6 +248,7 @@ namespace MatterHackers.MatterControl.PrintQueue
 		public bool SlicingHadError { get { return slicingHadError; } }
 
 		public List<ProviderLocatorNode> SourceLibraryProviderLocator { get; private set; }
+		public bool UseIncrementedNameDuringTypeChange { get; internal set; }
 
 		public void Delete()
 		{


### PR DESCRIPTION
 - Fixes #111237022 - Unable to save any changes to CloudLibrary items
 - Add useIncrementedNameDuringTypeChange to PrintItemWrapper to control naming behavior
 - Pass useIncrementedName value though from provider factory all the way to PrintItemWrapper
 - Prevent duplicate calls to GetPrintItemWrapperAsync within the same callstack i.e. pass instance through
 - Only rename files when switching to AMF and use different logic for different provider types
 - Add path helper methods to PrintItemWrapper for clarity and conciseness in callers