### PR TITLE
Guard LoadHistoryItems with WidgetHasBeenClosed

### DIFF
--- a/ApplicationView/MenuRow/MenuOptionSettings.cs
+++ b/ApplicationView/MenuRow/MenuOptionSettings.cs
@@ -25,14 +25,14 @@ namespace MatterHackers.MatterControl
 		override protected TupleList<string, Func<bool>> GetMenuItems()
 		{
 			return new TupleList<string, Func<bool>>
-            {
-                {LocalizedString.Get("Settings"), openPrintingPannel_Click},
-                {LocalizedString.Get("Controls"), openControlsPannel_Click},
-				{LocalizedString.Get("Terminal"), openTermanialPannel_Click},
-            };
+			{
+				{"Settings".Localize(), openPrintingPanel_Click},
+				{"Controls".Localize(), openControlsPanel_Click},
+				{"Terminal".Localize(), openTerminalPanel_Click},
+			};
 		}
 
-		private bool openPrintingPannel_Click()
+		private bool openPrintingPanel_Click()
 		{
 			UiThread.RunOnIdle(() =>
 			{
@@ -44,7 +44,7 @@ namespace MatterHackers.MatterControl
 			return true;
 		}
 
-		private bool openControlsPannel_Click()
+		private bool openControlsPanel_Click()
 		{
 			UiThread.RunOnIdle(() =>
 			{
@@ -56,7 +56,7 @@ namespace MatterHackers.MatterControl
 			return true;
 		}
 
-		private bool openTermanialPannel_Click()
+		private bool openTerminalPanel_Click()
 		{
 			UiThread.RunOnIdle(TerminalWindow.Show);
 			return true;

--- a/History/PrintHistoryDataView.cs
+++ b/History/PrintHistoryDataView.cs
@@ -146,7 +146,10 @@ namespace MatterHackers.MatterControl.PrintHistory
 		{
 			UiThread.RunOnIdle(() =>
 			{
-				LoadHistoryItems(Count);
+				if(!this.WidgetHasBeenClosed)
+				{
+					LoadHistoryItems(Count);
+				}
 			});
 		}
 

--- a/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/PartPreviewWindow/View3D/View3DWidget.cs
@@ -170,7 +170,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				editToolBar.VAnchor |= Agg.UI.VAnchor.ParentCenter;
 				processingProgressControl.Visible = false;
 
-				// If the window is embeded (in the center pannel) and there is no item loaded then don't show the add button
+				// If the window is embedded (in the center panel) and there is no item loaded then don't show the add button
 				enterEditButtonsContainer = new FlowLayoutWidget();
 				{
 					Button addButton = textImageButtonFactory.Generate("Insert".Localize(), "icon_insert_32x32.png");

--- a/SlicerConfiguration/SlicePresetsWindow/SlicePresetDetailWidget.cs
+++ b/SlicerConfiguration/SlicePresetsWindow/SlicePresetDetailWidget.cs
@@ -924,7 +924,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 					windowController.functionToCallOnSave(this, null);
 					windowController.ChangeToSlicePresetList();
 					ActiveSliceSettings.Instance.LoadAllSettings();
-					// Dissabled this as the pannel is already reloaded from LoadAllSettings LBB 2015 01 03.
+					// Disabled this as the panel is already reloaded from LoadAllSettings LBB 2015 01 03.
 					//ApplicationController.Instance.ReloadAdvancedControlsPanel();
 				}
 			});


### PR DESCRIPTION
 - Observed exception on shutdown where PrintHistory was reloaded during
   shutdown after the db had been closed. Skip load if Closing/closed
 - Spelling, whitespace, use .Localize()