### PR TITLE
Ensure text creators keep their derived type and hierarchy

### DIFF
--- a/PartPreviewWindow/View3D/SideBar/View3DWidgetSidebar.cs
+++ b/PartPreviewWindow/View3D/SideBar/View3DWidgetSidebar.cs
@@ -37,6 +37,7 @@ using MatterHackers.Localizations;
 using MatterHackers.MatterControl.DataStorage;
 using MatterHackers.MatterControl.SlicerConfiguration;
 using MatterHackers.PolygonMesh;
+using MatterHackers.PolygonMesh.Processors;
 using MatterHackers.RayTracer;
 using MatterHackers.RenderOpenGl;
 using MatterHackers.VectorMath;
@@ -363,6 +364,17 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 					Task.Run(() =>
 					{
 						IObject3D item = createMeshFunction();
+
+						// If the item has an empty mesh but children, flatten them into a mesh and swap the new item into place
+						if (item.Mesh == null && item.HasChildren)
+						{
+							item = new Object3D()
+							{
+								ItemType = Object3DTypes.Model,
+								Mesh = MeshFileIo.DoMerge(item.ToMeshGroupList(), new MeshOutputSettings())
+							};
+						}
+
 						item.Mesh?.Triangulate();
 
 						ThumbnailTracer tracer = new ThumbnailTracer(item, 64, 64);

--- a/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/PartPreviewWindow/View3D/View3DWidget.cs
@@ -2145,7 +2145,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 			// Used to be bound to SelectionChanged event that no one was using and that overlapped with Queue SelectionChanged events that already signify this state change. 
 			// Eliminate unnecessary event and restore later if some external caller needs this hook
-			if (Scene.HasSelection)
+			if (Scene.HasSelection && Scene.SelectedItem.Mesh != null)
 			{
 				// TODO: Likely needs to be reviewed as described above and in the context of the scene graph
 				MeshMaterialData material = MeshMaterialData.Get(Scene.SelectedItem.Mesh);

--- a/TextCreator/SidebarPlugins/TextCreatorsSidebar.cs
+++ b/TextCreator/SidebarPlugins/TextCreatorsSidebar.cs
@@ -71,18 +71,12 @@ namespace MatterHackers.MatterControl.Plugins.TextCreator
 					if(textItem == null)
 					{
 						var generator = new TextGenerator();
-						var generatedItem = generator.CreateText(
+						textItem = generator.CreateText(
 							"Text".Localize(),
 							1,
 							.25,
 							1,
 							true);
-
-						textItem = new Object3D()
-						{
-							ItemType = Object3DTypes.Model,
-							Mesh = MeshFileIo.DoMerge(generatedItem.ToMeshGroupList(), new MeshOutputSettings())
-						}; 
 					}
 
 					return textItem;
@@ -96,18 +90,12 @@ namespace MatterHackers.MatterControl.Plugins.TextCreator
 						string braille = "Braille".Localize();
 
 						var generator = new BrailleGenerator();
-						var generatedItem = generator.CreateText(
+						brailleItem = generator.CreateText(
 							braille,
 							1,
 							.25,
 							true,
 							braille);
-
-						brailleItem = new Object3D()
-						{
-							ItemType = Object3DTypes.Model,
-							Mesh = MeshFileIo.DoMerge(generatedItem.ToMeshGroupList(), new MeshOutputSettings())
-						};
 					}
 
 					return brailleItem;


### PR DESCRIPTION
 - Text creators need to return unflattened Object3Ds
 - Sidebar.CreateAddButton should flatten for icons as needed
 - Guard for null reference error on non-mesh items