### PR TITLE
Fix file duplication with instanced copies, revise load caching

### DIFF
--- a/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/PartPreviewWindow/View3D/View3DWidget.cs
@@ -988,10 +988,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 			IObject3D loadedItem = await Task.Run(() =>
 			{
-				return Object3D.Load(
-					dragSource.MeshPath,
-					meshViewerWidget.ItemCache,
-					new DragDropLoadProgress(this, dragSource).UpdateLoadProgress);
+				return Object3D.Load(dragSource.MeshPath, progress: new DragDropLoadProgress(this, dragSource).UpdateLoadProgress);
 			});
 
 			if (loadedItem != null)
@@ -1560,7 +1557,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 					bedCenter = ActiveSliceSettings.Instance.BedCenter;
 				}
 
-				await meshViewerWidget.LoadMesh(newPrintItem.FileLocation, doCentering, bedCenter, newPrintItem.Name);
+				await meshViewerWidget.LoadItemIntoScene(newPrintItem.FileLocation, doCentering, bedCenter, newPrintItem.Name);
 
 				Invalidate();
 			}
@@ -1883,9 +1880,11 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				double ratioPerFile = 1.0 / filesToLoad.Count;
 				double currentRatioDone = 0;
 
+				var itemCache = new Dictionary<string, IObject3D>();
+
 				foreach (string loadedFileName in filesToLoad)
 				{
-					IObject3D newItem = Object3D.Load(loadedFileName, meshViewerWidget.ItemCache, (double progress0To1, string processingState, out bool continueProcessing) =>
+					IObject3D newItem = Object3D.Load(loadedFileName, itemCache, (double progress0To1, string processingState, out bool continueProcessing) =>
 					{
 						continueProcessing = !this.WidgetHasBeenClosed;
 						double ratioAvailable = (ratioPerFile * .5);
@@ -2057,10 +2056,6 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 								}, 
 								returnInfo.destinationLibraryProvider.GetProviderLocator());
 						}
-
-						// Reset the cache to the new data
-						//meshViewerWidget.ItemCache[printItemWrapper.FileLocation] = Scene;
-						meshViewerWidget.ItemCache.Remove(printItemWrapper.FileLocation);
 
 						// TODO: Hook up progress reporting
 						Scene.Save(printItemWrapper.FileLocation, ApplicationDataStorage.Instance.ApplicationLibraryDataPath);


### PR DESCRIPTION
 - Fix bug with saving where every instance became a new mesh on disk
 - Save embedded assets into library/assets with <sha1>.stl file
 - Ensure instanced files all point at the same asset
 - Remove persistent item cache, only cache assets during file load
 - Add ComputeSHA functionality to MeshFileIO
 - Add custom hashing function to Mesh.cs, do not override GetHashCode
   until additional validation and testing are completed