### PR TITLE
Prevent setting DragDropSource on scrollbar mouse events

### DIFF
--- a/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/PartPreviewWindow/View3D/View3DWidget.cs
@@ -149,7 +149,11 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			progressBar.RatioComplete = progress0To1;
 			if (progress0To1 == 1)
 			{
-				view3DWidget.AfterDraw -= View3DWidget_AfterDraw;
+				if (view3DWidget != null)
+				{
+					view3DWidget.AfterDraw -= View3DWidget_AfterDraw;
+				}
+
 				view3DWidget = null;
 			}
 		}

--- a/Queue/QueueDataView.cs
+++ b/Queue/QueueDataView.cs
@@ -48,7 +48,7 @@ namespace MatterHackers.MatterControl.PrintQueue
 
 		private event EventHandler unregisterEvents;
 
-		private bool downOnMouse = false;
+		private bool mouseDownWithinQueueItemContainer = false;
 
 		// make this private so it can only be built from the Instance
 		private void SetDisplayAttributes()
@@ -209,7 +209,7 @@ namespace MatterHackers.MatterControl.PrintQueue
 			return null;
 		}
 
-		protected FlowLayoutWidget topToBottomItemList;
+		internal FlowLayoutWidget topToBottomItemList;
 
 		private RGBA_Bytes hoverColor = new RGBA_Bytes(204, 204, 204, 255);
 
@@ -374,20 +374,22 @@ namespace MatterHackers.MatterControl.PrintQueue
 
 		public override void OnMouseDown(MouseEventArgs mouseEvent)
 		{
-			downOnMouse = true;
+			var topToBottomItemListBounds = topToBottomItemList.LocalBounds;
+			mouseDownWithinQueueItemContainer = topToBottomItemList.LocalBounds.Contains(mouseEvent.Position);
+
 			base.OnMouseDown(mouseEvent);
 		}
 
 		public override void OnMouseUp(MouseEventArgs mouseEvent)
 		{
-			downOnMouse = false;
+			mouseDownWithinQueueItemContainer = false;
 			this.SuppressScroll = false;
 			base.OnMouseUp(mouseEvent);
 		}
 
 		public override void OnMouseMove(MouseEventArgs mouseEvent)
 		{
-			this.SuppressScroll = downOnMouse && !PositionWithinLocalBounds(mouseEvent.X, 20);
+			this.SuppressScroll = mouseDownWithinQueueItemContainer && !PositionWithinLocalBounds(mouseEvent.X, 20);
 			base.OnMouseMove(mouseEvent);
 		}
 

--- a/Queue/QueueDataWidget.cs
+++ b/Queue/QueueDataWidget.cs
@@ -527,13 +527,18 @@ namespace MatterHackers.MatterControl.PrintQueue
 		public override void OnMouseDown(MouseEventArgs mouseEvent)
 		{
 			view3DWidget = MatterControlApplication.Instance.ActiveView3DWidget;
-
-			if(view3DWidget == null)
+			if (view3DWidget == null)
 			{
 				return;
 			}
 
-			view3DWidget.DragDropSource = new Object3D
+			var screenSpaceMousePosition = this.TransformToScreenSpace(mouseEvent.Position);
+			var topToBottomItemListBounds = queueDataView.topToBottomItemList.TransformToScreenSpace(queueDataView.topToBottomItemList.LocalBounds);
+
+			bool mouseInQueueItemList = topToBottomItemListBounds.Contains(screenSpaceMousePosition);
+
+			// Clear or assign a drag source
+			view3DWidget.DragDropSource = (!mouseInQueueItemList) ? null : new Object3D
 			{
 				ItemType = Object3DTypes.Model,
 				Mesh = PlatonicSolids.CreateCube(10, 10, 10)
@@ -565,8 +570,6 @@ namespace MatterHackers.MatterControl.PrintQueue
 
 					view3DWidget.LoadDragSource();
 				}
-				
-				// TODO: If we derived from scrollable container, we could disable scroll in this drag context and enable on mouse up
 			}
 
 			base.OnMouseMove(mouseArgs);


### PR DESCRIPTION
 - Improves responsiveness & suppress unexpected dragdrop during scroll
 - Only suppress queue scroll events during queue item dragdrop
 - Prevent null reference error when unsubscribing progress draw hook