### PR TITLE
Add support for renaming and duplicating presets

### DIFF
--- a/ActionBar/PrinterSelector.cs
+++ b/ActionBar/PrinterSelector.cs
@@ -52,9 +52,9 @@ namespace MatterHackers.MatterControl
 				this.AddItem(printer.Name, printer.Id.ToString());
 			}
 
-			if(ActiveSliceSettings.Instance != null)
+			if (ActiveSliceSettings.Instance != null)
 			{
-				this.SelectedValue = ActiveSliceSettings.Instance.Id();
+				this.SelectedValue = ActiveSliceSettings.Instance.ID;
 			}
 
 			ImageBuffer plusImage = StaticData.Instance.LoadIcon("icon_plus.png", 32, 32);
@@ -62,17 +62,17 @@ namespace MatterHackers.MatterControl
 
 			this.SelectionChanged += (s, e) =>
 			{
-				int printerID;
-				if (int.TryParse(this.SelectedValue, out printerID))
+				string printerID = this.SelectedValue;
+				if (printerID == "new")
 				{
-					ActiveSliceSettings.SwitchToProfile(printerID);
-				}
-				else if(this.SelectedValue == "new")
-				{
-					if(AddPrinter != null)
+					if (AddPrinter != null)
 					{
 						UiThread.RunOnIdle(() => AddPrinter(this, null));
 					}
+				}
+				else
+				{
+					ActiveSliceSettings.SwitchToProfile(printerID);
 				}
 			};
 		}

--- a/DataStorage/Classic/ClassicSqlitePrinterProfiles.cs
+++ b/DataStorage/Classic/ClassicSqlitePrinterProfiles.cs
@@ -86,8 +86,9 @@ namespace MatterHackers.MatterControl.DataStorage.ClassicDB
 			LoadQualitySettings(layeredProfile, printer);
 			LoadMaterialSettings(layeredProfile, printer);
 
+			layeredProfile.ID = printer.Id.ToString();
+
 			layeredProfile.UserLayer["MatterControl.PrinterName"] = printer.Name ?? "";
-			layeredProfile.UserLayer["MatterControl.PrinterID"] = printer.Id.ToString();
 			layeredProfile.UserLayer["MatterControl.Make"] = printer.Make ?? "";
 			layeredProfile.UserLayer["MatterControl.Model"] = printer.Model ?? "";
 			layeredProfile.UserLayer["MatterControl.BaudRate"] = printer.BaudRate ?? "";
@@ -133,6 +134,7 @@ namespace MatterHackers.MatterControl.DataStorage.ClassicDB
 			// TODO: Where can we find CalibrationFiiles in the current model?
 			//layeredProfile.SetActiveValue("MatterControl.CalibrationFiles", printer.Make);
 
+			layeredProfile.ID = printer.Id.ToString();
 			string fullProfilePath = Path.Combine(profilePath, printer.Id + ".json");
 			File.WriteAllText(fullProfilePath, JsonConvert.SerializeObject(layeredProfile, Formatting.Indented));
 		}

--- a/PrinterCommunication/PrinterConnectionAndCommunication.cs
+++ b/PrinterCommunication/PrinterConnectionAndCommunication.cs
@@ -2491,7 +2491,7 @@ namespace MatterHackers.MatterControl.PrinterCommunication
 						// TODO: Fix printerItemID int requirement
 						activePrintTask = new PrintTask();
 						activePrintTask.PrintStart = DateTime.Now;
-						activePrintTask.PrinterId = this.ActivePrinter.Id().GetHashCode();
+						activePrintTask.PrinterId = this.ActivePrinter.ID.GetHashCode();
 						activePrintTask.PrintName = ActivePrintItem.PrintItem.Name;
 						activePrintTask.PrintItemId = ActivePrintItem.PrintItem.Id;
 						activePrintTask.PrintingGCodeFileName = ActivePrintItem.GetGCodePathAndFileName();

--- a/PrinterControls/PrinterConnections/BaseConnectionWidget.cs
+++ b/PrinterControls/PrinterConnections/BaseConnectionWidget.cs
@@ -264,7 +264,7 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
 						BaudRate = settings.BaudRate(),
 						ComPort = settings.ComPort(),
 						DriverType = settings.DriverType(),
-						Id = settings.Id(),
+						Id = settings.ID,
 						Name = settings.Name()
 					};
 				}

--- a/PrinterControls/PrinterConnections/SetupConnectionWidgetBase.cs
+++ b/PrinterControls/PrinterConnections/SetupConnectionWidgetBase.cs
@@ -72,7 +72,6 @@ namespace MatterHackers.MatterControl.PrinterControls.PrinterConnections
 				settings.SetBaudRate(ActivePrinter.BaudRate);
 				settings.SetComPort(ActivePrinter.ComPort);
 				settings.SetDriverType(ActivePrinter.DriverType);
-				settings.SetId(ActivePrinter.Id);
 				settings.SetName(ActivePrinter.Name);
 			});
 

--- a/SlicerConfiguration/Settings/LayeredProfile.cs
+++ b/SlicerConfiguration/Settings/LayeredProfile.cs
@@ -33,6 +33,7 @@ using System.Linq;
 using System.Runtime.Serialization;
 using System;
 using System.IO;
+using Newtonsoft.Json.Linq;
 
 namespace MatterHackers.MatterControl.SlicerConfiguration
 {
@@ -43,8 +44,73 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		public DateTime LastModified { get; set; }
 	}
 
+	public static class ProfileMigrations
+	{
+		public static string MigrateDocument(string filePath, int fromVersion)
+		{
+			var jObject = JObject.Parse(File.ReadAllText(filePath));
+
+			if (fromVersion < 201605131)
+			{
+				var materialLayers = jObject["MaterialLayers"] as JObject;
+				foreach (JProperty layer in materialLayers.Properties().ToList())
+				{
+					layer.Remove();
+
+					string layerID = Guid.NewGuid().ToString();
+
+					var body = layer.Value as JObject;
+					body["MatterControl.LayerID"] = layerID;
+					body["MatterControl.LayerName"] = layer.Name;
+
+					materialLayers[layerID] = layer.Value;
+				}
+
+				var qualityLayers = jObject["QualityLayers"] as JObject;
+				foreach (JProperty layer in qualityLayers.Properties().ToList())
+				{
+					layer.Remove();
+
+					string layerID = Guid.NewGuid().ToString();
+
+					var body = layer.Value as JObject;
+					body["MatterControl.LayerID"] = layerID;
+					body["MatterControl.LayerName"] = layer.Name;
+
+					qualityLayers[layerID] = layer.Value;
+				}
+
+
+				jObject["DocumentVersion"] = 201605131;
+			}
+
+			if (fromVersion < 201605132)
+			{
+				string printerID = Guid.NewGuid().ToString();
+				jObject.Remove("DocumentPath");
+				jObject["ID"] = printerID;
+				jObject["DocumentVersion"] = 201605132;
+
+				File.Delete(filePath);
+				filePath = Path.Combine(Path.GetDirectoryName(filePath), printerID + ".json");
+			}
+
+			File.WriteAllText(
+						filePath,
+						JsonConvert.SerializeObject(jObject, Formatting.Indented));
+
+			return filePath;
+		}
+	}
+
 	public class LayeredProfile
 	{
+		public int DocumentVersion { get; set; }
+
+		public string ID { get; set; }
+
+		public static int LatestVersion { get; } = 201605132;
+
 		[JsonIgnore]
 		internal SettingsLayer QualityLayer { get; private set; }
 
@@ -126,7 +192,6 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			}
 		}
 
-
 		public string GetMaterialPresetKey(int extruderIndex)
 		{
 			if (extruderIndex >= MaterialSettingsKeys.Count)
@@ -165,13 +230,14 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 		public List<string> MaterialSettingsKeys { get; set; } = new List<string>();
 
+		[JsonIgnore]
 		public string DocumentPath { get; set; }
 
 		internal void Save()
 		{
 			if (!string.IsNullOrEmpty(DocumentPath))
 			{
-				File.WriteAllText(DocumentPath, JsonConvert.SerializeObject(this));
+				File.WriteAllText(DocumentPath, JsonConvert.SerializeObject(this, Formatting.Indented));
 			}
 		}
 
@@ -180,19 +246,17 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		/// </summary>
 		public SettingsLayer UserLayer { get; } = new SettingsLayer();
 
-		public IEnumerable<string> AllMaterialKeys()
-		{
-			return MaterialLayers.Keys.Union(this.OemProfile.MaterialLayers.Keys);
-		}
-
-		public IEnumerable<string> AllQualityKeys()
-		{
-			return QualityLayers.Keys.Union(this.OemProfile.QualityLayers.Keys);
-		}
-
 		internal static LayeredProfile LoadFile(string printerProfilePath)
 		{
 			var layeredProfile = JsonConvert.DeserializeObject<LayeredProfile>(File.ReadAllText(printerProfilePath));
+			if (layeredProfile.DocumentVersion < LayeredProfile.LatestVersion)
+			{
+				printerProfilePath = ProfileMigrations.MigrateDocument(printerProfilePath, layeredProfile.DocumentVersion);
+
+				// Reload the document with the new schema
+				layeredProfile = JsonConvert.DeserializeObject<LayeredProfile>(File.ReadAllText(printerProfilePath));
+			}
+
 			layeredProfile.DocumentPath = printerProfilePath;
 
 			return layeredProfile;
@@ -210,18 +274,22 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		/// </summary>
 		public Dictionary<string, SettingsLayer> QualityLayers { get; } = new Dictionary<string, SettingsLayer>();
 
-
 		///<summary>
 		///Returns the settings value at the 'top' of the stack
 		///</summary>
 		public string GetValue(string sliceSetting)
 		{
-			return GetValue(sliceSetting, settingsLayers);
+			return GetValue(sliceSetting, defaultLayerCascade);
 		}
 
-		public string GetValue(string sliceSetting, IEnumerable<SettingsLayer> layers)
+		public string GetValue(string sliceSetting, IEnumerable<SettingsLayer> layerCascade)
 		{
-			foreach (SettingsLayer layer in layers)
+			if (layerCascade == null)
+			{
+				layerCascade = defaultLayerCascade;
+			}
+
+			foreach (SettingsLayer layer in layerCascade)
 			{
 				string value;
 				if (layer.TryGetValue(sliceSetting, out value))
@@ -235,7 +303,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 		public SettingsLayer BaseLayer { get; set; }
 
-		private IEnumerable<SettingsLayer> settingsLayers
+		private IEnumerable<SettingsLayer> defaultLayerCascade
 		{
 			get
 			{


### PR DESCRIPTION
 - Fixes #720 - Changing preset names has no effect
 - Fixes #767 - Presets editor contains user overrides
 - Fixes #768 - Oem presets should be copied...
 - Migrate from int to string based printer IDs
 - Add json document migration capabilities