### PR TITLE
Improve Duplicate preset

### DIFF
--- a/SlicerConfiguration/SettingsControlSelectors.cs
+++ b/SlicerConfiguration/SettingsControlSelectors.cs
@@ -111,7 +111,11 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 						var presetsContext = new PresetsContext(ActiveSliceSettings.Instance.MaterialLayers, presetsKey)
 						{
 							LayerType = NamedSettingsLayers.Material,
-							SetAsActive = (materialKey) => ActiveSliceSettings.Instance.ActiveMaterialKey = materialKey
+							SetAsActive = (materialKey) =>
+							{
+								ActiveSliceSettings.Instance.ActiveMaterialKey = materialKey;
+								ActiveSliceSettings.Instance.SetMaterialPreset(this.extruderIndex, materialKey);
+							}
 						};
 
 						ApplicationController.Instance.EditMaterialPresetsWindow = new SlicePresetsWindow(presetsContext);


### PR DESCRIPTION
 - Update Material preset array when preset changed from presets window
 - Update PresetsContext.PersistenceLayer when presets are duplicated
 - Rebuild SliceSettingsWidget on duplicate without leaving window
 - Refactor GetTopRow to eliminate excess widgets & create a single row
 - Update presets name after leaving input rather than on window close