### PR TITLE
Fixing incorrect help text.

### DIFF
--- a/StaticData/SliceSettings/Properties.json
+++ b/StaticData/SliceSettings/Properties.json
@@ -1815,7 +1815,7 @@
     "SetSettingsOnChange": [],
     "SlicerConfigName": "support_air_gap",
     "PresentationName": "Air Gap",
-    "HelpText": "The distance between the first layer (the bottom) and the top of the raft. A good value depends on the type of material. For PLA and ABS a value between 0.1 and 0.3 generaly works well.",
+    "HelpText": "The distance between the first layer (the bottom) and the top of the support material. A good value depends on the type of material. For PLA and ABS a value between 0.1 and 0.3 generaly works well.",
     "DataEditType": "POSITIVE_DOUBLE",
     "ExtraSettings": "mm",
     "ShowAsOverride": true,


### PR DESCRIPTION
Help text for Air gap was the same for both air gaps. Fixed verbiage for support material.