### PR TITLE
Fix Profile selection issues

### DIFF
--- a/SlicerConfiguration/Settings/LayeredProfile.cs
+++ b/SlicerConfiguration/Settings/LayeredProfile.cs
@@ -151,7 +151,6 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		internal void OnDeserializedMethod(StreamingContext context)
 		{
 			QualityLayer = GetQualityLayer(ActiveQualityKey);
-			MaterialLayer = GetMaterialLayer(ActiveMaterialKey); ;
 		}
 
 		public OemProfile OemProfile { get; set; }
@@ -171,20 +170,6 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		internal PrinterSettingsLayer GetQualityLayer(string layerID)
 		{
 			return QualityLayers.Where(layer => layer.LayerID == layerID).FirstOrDefault();
-		}
-
-		public string ActiveMaterialKey
-		{
-			get
-			{
-				return GetValue("MatterControl.ActiveMaterialKey");
-			}
-			internal set
-			{
-				SetActiveValue("MatterControl.ActiveMaterialKey", value);
-				MaterialLayer = GetMaterialLayer(value);
-				Save();
-			}
 		}
 
 		public string ActiveQualityKey
@@ -230,7 +215,6 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 			if (extruderIndex == 0)
 			{
-				ActiveMaterialKey = materialKey;
 				ApplicationController.Instance.ReloadAdvancedControlsPanel();
 			}
 

--- a/SlicerConfiguration/Settings/ProfileManager.cs
+++ b/SlicerConfiguration/Settings/ProfileManager.cs
@@ -130,6 +130,12 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			//          Determine if the local profile is dirty. If so, we need to perform conflict resolution to work through the issues
 			//          If not, simply write the profile to disk as latest, load and return
 
+			// Only load profiles by ID that are defined in the profiles.json document
+			if (ProfileManager.Instance[profileID] == null)
+			{
+				return null;
+			}
+
 			string profilePath = Path.Combine(ProfilesPath, profileID + ".json");
 			return File.Exists(profilePath) ? LoadProfileFromDisk(profilePath) : null;
 		}
@@ -283,6 +289,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			}
 		}
 
+		/*
 		private static void LoadProfilesFromDisk()
 		{
 			foreach (string filePath in Directory.GetFiles(ProfilesPath, "*.json"))
@@ -308,7 +315,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 					System.Diagnostics.Debug.WriteLine("Error loading profile: {1}\r\n{2}", filePath, ex.Message);
 				}
 			}
-		}
+		}*/
 
 		public void Save()
 		{

--- a/SlicerConfiguration/Settings/SettingsProfile.cs
+++ b/SlicerConfiguration/Settings/SettingsProfile.cs
@@ -91,18 +91,6 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 		public PrinterSettingsLayer UserLayer => layeredProfile.UserLayer;
 
-		public string ActiveMaterialKey
-		{
-			get
-			{
-				return layeredProfile.ActiveMaterialKey;
-			}
-			set
-			{
-				layeredProfile.ActiveMaterialKey = value;
-			}
-		}
-
 		public string ActiveQualityKey
 		{
 			get
@@ -230,7 +218,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 		internal PrinterSettingsLayer MaterialLayer(string key)
 		{
-			return layeredProfile.GetMaterialLayer(key);
+			return layeredProfile.GetMaterialLayer(layeredProfile.MaterialSettingsKeys[0]);
 		}
 
 		internal PrinterSettingsLayer QualityLayer(string key)
@@ -798,11 +786,17 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 		public void SetMarkedForDelete(bool markedForDelete)
 		{
-			// TODO: It's unfortunate that changes to UI elements drive the SettingsChanged event rather than the data model. As such, we must manually
-			// MarkedForDelete and call profile save
-			ProfileManager.Instance.ActiveProfile.MarkedForDelete = markedForDelete;
-			ProfileManager.Instance.Save();
-			SetActiveValue("MatterControl.MarkedForDelete", "1");
+			var printerInfo = ProfileManager.Instance.ActiveProfile;
+			if (printerInfo != null)
+			{
+				printerInfo.MarkedForDelete = markedForDelete;
+
+				ProfileManager.Instance.Save();
+				SetActiveValue("MatterControl.MarkedForDelete", "1");
+			}
+
+			// Clear selected printer state
+			UserSettings.Instance.set("ActiveProfileID", "");
 
 			UiThread.RunOnIdle(() => ActiveSliceSettings.Instance = ProfileManager.LoadEmptyProfile());
 		}

--- a/SlicerConfiguration/SettingsControlSelectors.cs
+++ b/SlicerConfiguration/SettingsControlSelectors.cs
@@ -115,7 +115,6 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 							LayerType = NamedSettingsLayers.Material,
 							SetAsActive = (materialKey) =>
 							{
-								ActiveSliceSettings.Instance.ActiveMaterialKey = materialKey;
 								ActiveSliceSettings.Instance.SetMaterialPreset(this.extruderIndex, materialKey);
 							}
 						};
@@ -234,7 +233,6 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				{
 					newLayer.Name = "Material" + ActiveSliceSettings.Instance.MaterialLayers.Count;
 					ActiveSliceSettings.Instance.MaterialLayers.Add(newLayer);
-					ActiveSliceSettings.Instance.ActiveMaterialKey = newLayer.LayerID;
 					ActiveSliceSettings.Instance.SetMaterialPreset(this.extruderIndex, newLayer.LayerID);
 				}
 


### PR DESCRIPTION
 - Ensure that only profiles known to ProfileManager can be loaded by ID
 - Ensure ActiveProfileID is cleared on delete printer
 - Remove ActiveMaterialKey duplication, use MaterialSettingsKeys[n]