### PR TITLE
Remove OemProfile property, promote OemLayer property to parent

### DIFF
--- a/DataStorage/Classic/ClassicSqlitePrinterProfiles.cs
+++ b/DataStorage/Classic/ClassicSqlitePrinterProfiles.cs
@@ -80,8 +80,10 @@ namespace MatterHackers.MatterControl.DataStorage.ClassicDB
 			};
 			profileData.Profiles.Add(printerInfo);
 
-			var layeredProfile = new PrinterSettings(
-				new OemProfile(LoadOemLayer(printer)));
+			var layeredProfile = new PrinterSettings()
+			{
+				OemLayer = LoadOemLayer(printer)
+			};
 
 			LoadQualitySettings(layeredProfile, printer);
 			LoadMaterialSettings(layeredProfile, printer);
@@ -165,7 +167,7 @@ namespace MatterHackers.MatterControl.DataStorage.ClassicDB
 			}
 		}
 
-		public static Dictionary<string, string> LoadOemLayer(Printer printer)
+		public static PrinterSettingsLayer LoadOemLayer(Printer printer)
 		{
 			SliceSettingsCollection collection;
 			if (printer.DefaultSettingsCollectionId != 0)
@@ -182,7 +184,7 @@ namespace MatterHackers.MatterControl.DataStorage.ClassicDB
 				printer.DefaultSettingsCollectionId = collection.Id;
 			}
 
-			return LoadSettings(collection);
+			return new PrinterSettingsLayer(LoadSettings(collection));
 		}
 
 		private static Dictionary<string, string> LoadSettings(SliceSettingsCollection collection)

--- a/MatterControl.csproj
+++ b/MatterControl.csproj
@@ -260,6 +260,7 @@
     <Compile Include="SlicerConfiguration\Settings\OemProfile.cs" />
     <Compile Include="SlicerConfiguration\Settings\ProfileMigrations.cs" />
     <Compile Include="SlicerConfiguration\Settings\ProfileManager.cs" />
+    <Compile Include="SlicerConfiguration\Settings\PrinterSettingsLayer.cs" />
     <Compile Include="SlicerConfiguration\SliceSettingsDetailControl.cs" />
     <Compile Include="SlicerConfiguration\Settings\SettingsProfile.cs" />
     <Compile Include="SlicerConfiguration\Settings\ActiveSliceSettings.cs" />

--- a/SlicerConfiguration/Settings/LayeredProfile.cs
+++ b/SlicerConfiguration/Settings/LayeredProfile.cs
@@ -41,15 +41,16 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 {
 	public class PrinterSettings
 	{
-		static PrinterSettingsLayer baseLayerCache;
+		// Latest version should be 2016|06|08|1
+		// Year|month|day|versionForDay (to support multiple revisions on a given day)
+		public static int LatestVersion { get; } = 201606271;
+
+		private static PrinterSettingsLayer baseLayerCache;
 
 		public int DocumentVersion { get; set; }
 
 		public string ID { get; set; }
 
-		// Latest version should be 2016|06|08|1
-		// Year|month|day|versionForDay (to support multiple revisions on a given day)
-		public static int LatestVersion { get; } = 201606161;
 
 		[JsonIgnore]
 		internal PrinterSettingsLayer QualityLayer { get; private set; }
@@ -57,10 +58,8 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		[JsonIgnore]
 		internal PrinterSettingsLayer MaterialLayer { get; private set; }
 
-		public PrinterSettings(OemProfile printerProfile, PrinterSettingsLayer baseLayer = null)
+		public PrinterSettings()
 		{
-			baseLayerCache = baseLayer;
-			this.OemProfile = printerProfile;
 		}
 
 		public List<GCodeMacro> Macros { get; set; } = new List<GCodeMacro>();
@@ -77,10 +76,8 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			}
 		}
 
-		public OemProfile OemProfile { get; set; }
+		public PrinterSettingsLayer OemLayer { get; set; }
 
-		//public SettingsLayer OemLayer { get; set; }
-		
 		internal PrinterSettingsLayer GetMaterialLayer(string layerID)
 		{
 			if (string.IsNullOrEmpty(layerID))
@@ -260,6 +257,11 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 				return baseLayerCache;
 			}
+
+			internal set
+			{
+				baseLayerCache = value;
+			}
 		}
 
 		private IEnumerable<PrinterSettingsLayer> defaultLayerCascade
@@ -281,9 +283,9 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 					yield return this.QualityLayer;
 				}
 
-				if (this.OemProfile.OemLayer != null)
+				if (this.OemLayer != null)
 				{
-					yield return this.OemProfile.OemLayer;
+					yield return this.OemLayer;
 				}
 
 				yield return this.BaseLayer;

--- a/SlicerConfiguration/Settings/PrinterSettingsLayer.cs
+++ b/SlicerConfiguration/Settings/PrinterSettingsLayer.cs
@@ -1,0 +1,175 @@
+﻿/*
+Copyright (c) 2016, Lars Brubaker, John Lewin
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the FreeBSD Project.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace MatterHackers.MatterControl.SlicerConfiguration
+{
+    using SettingsDictionary = Dictionary<string, string>;
+
+    public class PrinterSettingsLayer : SettingsDictionary
+	{
+		public PrinterSettingsLayer() { }
+
+		public PrinterSettingsLayer(Dictionary<string, string> settingsDictionary)
+		{
+			foreach(var keyValue in settingsDictionary)
+			{
+				this[keyValue.Key] = keyValue.Value;
+			}
+		}
+
+		public string LayerID
+		{
+			get
+			{
+				string layerKey = ValueOrDefault("layer_id");
+				if (string.IsNullOrEmpty(layerKey))
+				{
+					// Generate a new GUID when missing or empty. We can't do this in the constructor as the dictionary deserialization will fail if
+					// an existing key exists for layer_id and on new empty layers, we still need to construct an initial identifier. 
+					layerKey = Guid.NewGuid().ToString();
+					LayerID = layerKey;
+				}
+
+				return layerKey;
+			}
+			set
+			{
+				this["layer_id"] = value;
+			}
+		}
+
+		public string Name
+		{
+			get
+			{
+				return ValueOrDefault("layer_name");
+			}
+			set
+			{
+				this["layer_name"] = value;
+			}
+		}
+
+		public string Source
+		{
+			get
+			{
+				return ValueOrDefault("layer_source");
+			}
+			set
+			{
+				this["layer_source"] = value;
+			}
+		}
+
+		public string ETag
+		{
+			get
+			{
+				return ValueOrDefault("layer_etag");
+			}
+			set
+			{
+				this["layer_etag"] = value;
+			}
+		}
+
+		public string ValueOrDefault(string key, string defaultValue = "")
+		{
+			string foundValue;
+			this.TryGetValue(key, out foundValue);
+
+			return foundValue ?? defaultValue;
+		}
+
+		public string ValueOrNull(string key)
+		{
+			string foundValue;
+			this.TryGetValue(key, out foundValue);
+
+			return foundValue;
+		}
+
+		public static PrinterSettingsLayer LoadFromIni(TextReader reader)
+		{
+			var layer = new PrinterSettingsLayer();
+
+			string line;
+			while ((line = reader.ReadLine()) != null)
+			{
+				var segments = line.Split('=');
+				if (!line.StartsWith("#") && !string.IsNullOrEmpty(line))
+				{
+					string key = segments[0].Trim();
+					layer[key] = segments[1].Trim();
+				}
+			}
+
+			return layer;
+		}
+
+		public static PrinterSettingsLayer LoadFromIni(string filePath)
+		{
+			var settings = from line in File.ReadAllLines(filePath)
+						   let segments = line.Split('=')
+						   where !line.StartsWith("#") && !string.IsNullOrEmpty(line) && segments.Length == 2
+						   select new
+						   {
+							   Key = segments[0].Trim(),
+							   Value = segments[1].Trim()
+						   };
+
+			var layer = new PrinterSettingsLayer();
+			foreach (var setting in settings)
+			{
+				layer[setting.Key] = setting.Value;
+			}
+
+			return layer;
+		}
+
+		public PrinterSettingsLayer Clone()
+		{
+			string id = Guid.NewGuid().ToString();
+			return new PrinterSettingsLayer(this as Dictionary<string, string>)
+			{
+				LayerID = id,
+				Name = this.Name,
+				ETag = this.ETag,
+				Source = this.Source
+			};
+		}
+	}
+
+}

--- a/SlicerConfiguration/Settings/ProfileManager.cs
+++ b/SlicerConfiguration/Settings/ProfileManager.cs
@@ -131,7 +131,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 		public static SettingsProfile LoadEmptyProfile()
 		{
-			var empytProfile = new SettingsProfile(new PrinterSettings(new OemProfile()));
+			var empytProfile = new SettingsProfile(new PrinterSettings());
 
 			empytProfile.SetActiveValue(SettingsKey.printer_name.ToString(), "Printers...".Localize());
 
@@ -197,11 +197,10 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				case ".ini":
 					var settingsToImport = PrinterSettingsLayer.LoadFromIni(settingsFilePath);
 
-					var oemProfile = new OemProfile(settingsToImport);
-
-					var layeredProfile = new PrinterSettings(oemProfile)
+					var layeredProfile = new PrinterSettings()
 					{
 						ID = printerInfo.ID,
+						OemLayer = settingsToImport
 					};
 
 					// TODO: Resolve name conflicts
@@ -221,13 +220,14 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		{
 			string guid = Guid.NewGuid().ToString();
 
-			OemProfile printerProfile = LoadHttpOemProfile(make, model);
+			OemProfile oemProfile = LoadHttpOemProfile(make, model);
 
-			var layeredProfile = new PrinterSettings(printerProfile)
+			var layeredProfile = new PrinterSettings()
 			{
 				ID = guid,
 				// TODO: This should really be set by the system that generates the source documents 
-				DocumentVersion = PrinterSettings.LatestVersion
+				DocumentVersion = PrinterSettings.LatestVersion,
+				OemLayer = oemProfile.OemLayer
 			};
 			layeredProfile.UserLayer[SettingsKey.printer_name.ToString()] = printerName;
 
@@ -260,17 +260,14 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			}
 
 			// Copy OemProfile presets into user layers
-			foreach (var materialPreset in layeredProfile.OemProfile.MaterialLayers)
+			foreach (var materialPreset in oemProfile.MaterialLayers)
 			{
 				layeredProfile.MaterialLayers.Add(materialPreset);
 			}
-			foreach (var qualityPreset in layeredProfile.OemProfile.QualityLayers)
+			foreach (var qualityPreset in oemProfile.QualityLayers)
 			{
 				layeredProfile.QualityLayers.Add(qualityPreset);
 			}
-
-			layeredProfile.OemProfile.MaterialLayers.Clear();
-			layeredProfile.OemProfile.QualityLayers.Clear();
 
 			layeredProfile.Save();
 

--- a/SlicerConfiguration/Settings/ProfileMigrations.cs
+++ b/SlicerConfiguration/Settings/ProfileMigrations.cs
@@ -273,6 +273,18 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				jObject["DocumentVersion"] = 201606161;
 			}
 
+			if (fromVersion < 201606271)
+			{
+				JObject oemProfile = jObject["OemProfile"] as JObject;
+				if (oemProfile != null)
+				{
+					jObject.Property("OemProfile").Remove();
+					jObject["OemLayer"] = oemProfile["OemLayer"];
+
+				}
+				jObject["DocumentVersion"] = 201606271;
+			}
+
 			File.WriteAllText(
 						filePath,
 						JsonConvert.SerializeObject(jObject, Formatting.Indented));

--- a/SlicerConfiguration/Settings/SettingsProfile.cs
+++ b/SlicerConfiguration/Settings/SettingsProfile.cs
@@ -44,7 +44,6 @@ using System.Text;
 namespace MatterHackers.MatterControl.SlicerConfiguration
 {
 	using ConfigurationPage.PrintLeveling;
-	using SettingsDictionary = Dictionary<string, string>;
 	using DataStorage;
 	using Agg.PlatformAbstract;
 	using Newtonsoft.Json.Linq;
@@ -80,7 +79,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 		private PrinterSettings layeredProfile;
 
-		public bool PrinterSelected => layeredProfile.OemProfile.OemLayer.Keys.Count > 0;
+		public bool PrinterSelected => layeredProfile.OemLayer.Keys.Count > 0;
 
 		internal SettingsProfile(PrinterSettings profile)
 		{
@@ -116,7 +115,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 		public PrinterSettingsLayer BaseLayer => layeredProfile.BaseLayer;
 
-		public PrinterSettingsLayer OemLayer => layeredProfile.OemProfile.OemLayer;
+		public PrinterSettingsLayer OemLayer => layeredProfile.OemLayer;
 
 		public PrinterSettingsLayer UserLayer => layeredProfile.UserLayer;
 
@@ -881,142 +880,6 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			layeredProfile.SetValue("manual_movement_speeds", speed);
 		}
 
-	}
-
-	public class PrinterSettingsLayer : SettingsDictionary
-	{
-		public PrinterSettingsLayer() { }
-
-		public PrinterSettingsLayer(Dictionary<string, string> settingsDictionary)
-		{
-			foreach(var keyValue in settingsDictionary)
-			{
-				this[keyValue.Key] = keyValue.Value;
-			}
-		}
-
-		public string LayerID
-		{
-			get
-			{
-				string layerKey = ValueOrDefault("layer_id");
-				if (string.IsNullOrEmpty(layerKey))
-				{
-					// Generate a new GUID when missing or empty. We can't do this in the constructor as the dictionary deserialization will fail if
-					// an existing key exists for layer_id and on new empty layers, we still need to construct an initial identifier. 
-					layerKey = Guid.NewGuid().ToString();
-					LayerID = layerKey;
-				}
-
-				return layerKey;
-			}
-			set
-			{
-				this["layer_id"] = value;
-			}
-		}
-
-		public string Name
-		{
-			get
-			{
-				return ValueOrDefault("layer_name");
-			}
-			set
-			{
-				this["layer_name"] = value;
-			}
-		}
-
-		public string Source
-		{
-			get
-			{
-				return ValueOrDefault("layer_source");
-			}
-			set
-			{
-				this["layer_source"] = value;
-			}
-		}
-
-		public string ETag
-		{
-			get
-			{
-				return ValueOrDefault("layer_etag");
-			}
-			set
-			{
-				this["layer_etag"] = value;
-			}
-		}
-
-		public string ValueOrDefault(string key, string defaultValue = "")
-		{
-			string foundValue;
-			this.TryGetValue(key, out foundValue);
-
-			return foundValue ?? defaultValue;
-		}
-
-		public string ValueOrNull(string key)
-		{
-			string foundValue;
-			this.TryGetValue(key, out foundValue);
-
-			return foundValue;
-		}
-
-		public static PrinterSettingsLayer LoadFromIni(TextReader reader)
-		{
-			var layer = new PrinterSettingsLayer();
-
-			string line;
-			while ((line = reader.ReadLine()) != null)
-			{
-				var segments = line.Split('=');
-				if (!line.StartsWith("#") && !string.IsNullOrEmpty(line))
-				{
-					string key = segments[0].Trim();
-					layer[key] = segments[1].Trim();
-				}
-			}
-
-			return layer;
-		}
-
-		public static PrinterSettingsLayer LoadFromIni(string filePath)
-		{
-			var settings = from line in File.ReadAllLines(filePath)
-						   let segments = line.Split('=')
-						   where !line.StartsWith("#") && !string.IsNullOrEmpty(line) && segments.Length == 2
-						   select new
-						   {
-							   Key = segments[0].Trim(),
-							   Value = segments[1].Trim()
-						   };
-
-			var layer = new PrinterSettingsLayer();
-			foreach (var setting in settings)
-			{
-				layer[setting.Key] = setting.Value;
-			}
-
-			return layer;
-		}
-
-		public PrinterSettingsLayer Clone()
-		{
-			string id = Guid.NewGuid().ToString();
-			return new PrinterSettingsLayer(this as Dictionary<string, string>)
-			{
-				LayerID = id,
-				Name = this.Name,
-				ETag = this.ETag,
-				Source = this.Source
-			};
-		}
 	}
 
 	public class PrinterInfo


### PR DESCRIPTION
 - Extract PrinterSettingLayer to separate file
 - Create profile migration for OemProfile -> OemLayer
 - Rename confusing LayerCascade property in tests to PrinterSettings
 - Issue #1023