### PR TITLE
Async download of profiles not in cache

### DIFF
--- a/SettingsManagement/OemSettings.cs
+++ b/SettingsManagement/OemSettings.cs
@@ -144,6 +144,24 @@ namespace MatterHackers.MatterControl.SettingsManagement
 
 			OemProfiles = oemProfiles;
 			SetManufacturers(oemProfiles.Select(m => new KeyValuePair<string, string>(m.Key, m.Key)).ToList());
+			Task.Run((Action)downloadMissingProfiles);
+		}
+
+		private void downloadMissingProfiles()
+		{
+			string cacheDirectory = Path.Combine(ApplicationDataStorage.ApplicationUserDataPath, "data", "temp", "cache", "profiles");
+			string filePath;
+			foreach (string oem in OemProfiles.Keys)
+			{
+				foreach (string profileKey in OemProfiles[oem].Values)
+				{
+					filePath = Path.Combine(cacheDirectory, String.Format("{0}.json", profileKey));
+					if (!File.Exists(filePath))
+					{
+						File.WriteAllText(filePath, RetrievePublicProfileRequest.DownloadPrinterProfile(profileKey));
+					}
+				}
+			}
 		}
 
 		private OemSettings()

--- a/SlicerConfiguration/Settings/ProfileManager.cs
+++ b/SlicerConfiguration/Settings/ProfileManager.cs
@@ -38,6 +38,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 {
 	using Agg;
 	using Localizations;
+	using DataStorage;
 	using SettingsManagement;
 	using System.Collections.ObjectModel;
 	using System.Net;
@@ -348,7 +349,11 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				"profiles",
 				() =>
 				{
-					string responseText = RetrievePublicProfileRequest.DownloadPrinterProfile(deviceToken);
+					string responseText = null;
+					if(!File.Exists(Path.Combine(ApplicationDataStorage.ApplicationUserDataPath, "data", "temp", "cache", "profiles",String.Format("{0}.json",deviceToken))))
+					{
+						responseText = RetrievePublicProfileRequest.DownloadPrinterProfile(deviceToken);
+					}
 					return responseText;
 				});
 		}


### PR DESCRIPTION
When creating a printer checks if profile is already on disk before downloading