### PR TITLE
Sync on start up

### DIFF
--- a/ApplicationView/AdvancedControlsPanel.cs
+++ b/ApplicationView/AdvancedControlsPanel.cs
@@ -67,6 +67,10 @@ namespace MatterHackers.MatterControl
 		public void ReloadSliceSettings()
 		{
 			WidescreenPanel.PreChangePanels.CallEvents(null, null);
+			if (advancedTab.HasBeenClosed)
+			{
+				return;
+			}
 
 			// remove the advance control and replace it with new ones built for the selected printer
 			int advancedControlsIndex = GetChildIndex(advancedTab);

--- a/ApplicationView/MainApplicationWidget.cs
+++ b/ApplicationView/MainApplicationWidget.cs
@@ -169,6 +169,7 @@ namespace MatterHackers.MatterControl
 
 		public static Func<string, Task<Dictionary<string, string>>> GetProfileHistory;
 		public static Func<PrinterInfo,string, Task> GetPrinterProfile;
+		public static Func<Task> SyncPrinterProfiles;
 
 		public SlicePresetsWindow EditMaterialPresetsWindow { get; set; }
 

--- a/ApplicationView/MainApplicationWidget.cs
+++ b/ApplicationView/MainApplicationWidget.cs
@@ -370,8 +370,10 @@ namespace MatterHackers.MatterControl
 			// Ensure SQLite printers are imported
 			profileManager.EnsurePrintersImported();
 
+			var guestDB = ProfileManager.LoadGuestDB();
+
 			// If profiles.json was created, run the import wizard to pull in any SQLite printers
-			if (!profileManager.IsGuestProfile && !profileManager.PrintersImported)
+			if (guestDB?.Profiles != null && guestDB.Profiles.Any() && !profileManager.IsGuestProfile && !profileManager.PrintersImported)
 			{
 				var wizardPage = new CopyGuestProfilesToUser(() =>
 				{

--- a/MatterControlApplication.cs
+++ b/MatterControlApplication.cs
@@ -722,6 +722,7 @@ namespace MatterHackers.MatterControl
 				}
 				ApplicationController.SyncPrinterProfiles().ContinueWith((task) =>
 				{
+					ApplicationController.Instance.ReloadAdvancedControlsPanel();
 					if (!ProfileManager.Instance.ActiveProfiles.Any())
 					{
 						// Start the setup wizard if no profiles exist

--- a/MatterControlApplication.cs
+++ b/MatterControlApplication.cs
@@ -720,12 +720,15 @@ namespace MatterHackers.MatterControl
 				{
 					UiThread.RunOnIdle(() => WizardWindow.Show<LicenseAgreementPage>("SoftwareLicense", "Software License Agreement"));
 				}
-
-				if (!ProfileManager.Instance.ActiveProfiles.Any())
+				ApplicationController.SyncPrinterProfiles().ContinueWith((task) =>
 				{
-					// Start the setup wizard if no profiles exist
-					UiThread.RunOnIdle(() => WizardWindow.Show());
-				}
+					if (!ProfileManager.Instance.ActiveProfiles.Any())
+					{
+						// Start the setup wizard if no profiles exist
+						UiThread.RunOnIdle(() => WizardWindow.Show());
+					}
+				});
+				
 			}
 
 			//msGraph.AddData("ms", totalDrawTime.ElapsedMilliseconds);

--- a/SlicerConfiguration/Settings/ProfileManager.cs
+++ b/SlicerConfiguration/Settings/ProfileManager.cs
@@ -233,7 +233,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				return ActiveSliceSettings.Instance;
 			}
 
-			string profilePath = Path.Combine(ProfilesPath, profileID + ".json");
+			string profilePath = Path.Combine(ProfilesPath, profileID +  ProfileManager.ProfileExtension);
 			return File.Exists(profilePath) ? LoadProfileFromDisk(profilePath) : null;
 		}
 

--- a/SlicerConfiguration/Settings/ProfileMigrations.cs
+++ b/SlicerConfiguration/Settings/ProfileMigrations.cs
@@ -92,7 +92,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				jObject["DocumentVersion"] = 201605132;
 
 				File.Delete(filePath);
-				filePath = Path.Combine(Path.GetDirectoryName(filePath), printerID + ".json");
+				filePath = Path.Combine(Path.GetDirectoryName(filePath), printerID + ProfileManager.ProfileExtension);
 			}
 
 			if (fromVersion < 201606081)


### PR DESCRIPTION
Sync is now call on start up before deciding to launch create printer window
Fixed bug where upload printer dialog would launch when there were no printers to upload
Fixed bug where incorrect profile extensions were used