### PR TITLE
Printer Settings defaults DocumentVersion to the lastest

### DIFF
--- a/SlicerConfiguration/Settings/PrinterSettings.cs
+++ b/SlicerConfiguration/Settings/PrinterSettings.cs
@@ -59,7 +59,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 		private static PrinterSettingsLayer baseLayerCache;
 
-		public int DocumentVersion { get; set; }
+		public int DocumentVersion { get; set; } = LatestVersion;
 
 		public string ID { get; set; }
 
@@ -342,9 +342,9 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				yield return this.BaseLayer;
 			}
 		}
-
+		[JsonIgnore]
 		public SettingsHelpers Helpers { get; set; }
-
+		[JsonIgnore]
 		public bool PrinterSelected => OemLayer?.Keys.Count > 0;
 
 		internal void RunInTransaction(Action<PrinterSettings> action)


### PR DESCRIPTION
Serializing Printer setting now Ignores Helpers and PrinterSelected