### PR TITLE
converted oemprofiles to be .printer files and to be retrieved as such from various locations.

### DIFF
--- a/SettingsManagement/OemSettings.cs
+++ b/SettingsManagement/OemSettings.cs
@@ -29,6 +29,7 @@ either expressed or implied, of the FreeBSD Project.
 
 using MatterHackers.Agg.PlatformAbstract;
 using MatterHackers.MatterControl.DataStorage;
+using MatterHackers.MatterControl.SlicerConfiguration;
 using MatterHackers.MatterControl.VersionManagement;
 using Newtonsoft.Json;
 using System;
@@ -165,7 +166,7 @@ namespace MatterHackers.MatterControl.SettingsManagement
 			{
 				foreach (string profileKey in OemProfiles[oem].Values)
 				{
-					filePath = Path.Combine(cacheDirectory, String.Format("{0}.json", profileKey));
+					filePath = Path.Combine(cacheDirectory, String.Format("{0}{1}", profileKey, ProfileManager.ProfileExtension));
 					if (!File.Exists(filePath))
 					{
 						File.WriteAllText(filePath, RetrievePublicProfileRequest.DownloadPrinterProfile(profileKey));

--- a/SlicerConfiguration/Settings/PrinterSettings.cs
+++ b/SlicerConfiguration/Settings/PrinterSettings.cs
@@ -306,7 +306,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			var profile = ProfileManager.Instance[profileKey];
 			
 			string publicProfileDeviceToken = OemSettings.Instance.OemProfiles[profile.Make][profile.Model];
-			string publicProfileToLoad = Path.Combine(ApplicationDataStorage.ApplicationUserDataPath, "data", "temp", "cache", "profiles") + "\\" + publicProfileDeviceToken + ".json";
+			string publicProfileToLoad = Path.Combine(ApplicationDataStorage.ApplicationUserDataPath, "data", "temp", "cache", "profiles") + "\\" + publicProfileDeviceToken + ProfileManager.ProfileExtension;
 
 			var oemProfile = JsonConvert.DeserializeObject<PrinterSettings>(File.ReadAllText(publicProfileToLoad));
 			oemProfile.ID = profile.ID;

--- a/SlicerConfiguration/Settings/ProfileManager.cs
+++ b/SlicerConfiguration/Settings/ProfileManager.cs
@@ -371,12 +371,12 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		{
 			string deviceToken = OemSettings.Instance.OemProfiles[make][model];
 			return MatterControlApplication.LoadCacheable<PrinterSettings>(
-				String.Format("{0}.json", deviceToken),
+				String.Format("{0}{1}", deviceToken, ProfileManager.ProfileExtension),
 				"profiles",
 				() =>
 				{
 					string responseText = null;
-					if(!File.Exists(Path.Combine(ApplicationDataStorage.ApplicationUserDataPath, "data", "temp", "cache", "profiles",String.Format("{0}.json",deviceToken))))
+					if(!File.Exists(Path.Combine(ApplicationDataStorage.ApplicationUserDataPath, "data", "temp", "cache", "profiles",String.Format("{0}{1}",deviceToken, ProfileManager.ProfileExtension))))
 					{
 						responseText = RetrievePublicProfileRequest.DownloadPrinterProfile(deviceToken);
 					}

--- a/Tests/MatterControl.AutomationTests/RetrievePublicProfileTest.cs
+++ b/Tests/MatterControl.AutomationTests/RetrievePublicProfileTest.cs
@@ -15,25 +15,23 @@ using MatterHackers.GuiAutomation;
 using MatterHackers.Agg.UI;
 using Newtonsoft.Json;
 using MatterHackers.Agg.PlatformAbstract;
+using MatterHackers.MatterControl.SlicerConfiguration;
 
 namespace MatterControl.Tests.MatterControl
 {
-	[TestFixture, RunInApplicationDomain]
+	[TestFixture]
 	public class RetrievePublicProfileTest
 	{
 		private string deviceToken = null;
 
-		[Test,RunInApplicationDomain]
+		[Test]
 		public void RetrievePrinterProfileListWorking()
 		{
 
 			StaticData.Instance = new MatterHackers.Agg.FileSystemStaticData(Path.Combine("..", "..", "..", "..", "StaticData"));
 
 			string profilePath = Path.Combine(ApplicationDataStorage.ApplicationUserDataPath, "data", "temp", "cache", "profiles", "oemprofiles.json");
-			if(File.Exists(profilePath))
-			{
-				File.Delete(profilePath);
-			}
+
 			//MatterControlUtilities.OverrideAppDataLocation();
 			AutoResetEvent requestCompleteWaiter = new AutoResetEvent(false);
 			PublicProfilesRequest retrieveProfiles = new PublicProfilesRequest();
@@ -44,8 +42,8 @@ namespace MatterControl.Tests.MatterControl
 
 			retrieveProfiles.Request();
 			Assert.IsTrue(requestCompleteWaiter.WaitOne());
-
-			Assert.IsTrue(File.Exists(profilePath));
+			//Ensures we got success and a list of profiles
+			Assert.IsTrue(retrieveProfiles.ResponseValues.Count == 2);
 
 			//Call Retrieve Profile next
 			RetrievePrinterProfileWorking();
@@ -57,7 +55,7 @@ namespace MatterControl.Tests.MatterControl
 			string make = OemSettings.Instance.OemProfiles.First().Key;
 			string model = OemSettings.Instance.OemProfiles[make].First().Key;
 			deviceToken = OemSettings.Instance.OemProfiles[make][model];
-			string expectedProfilePath = Path.Combine(ApplicationDataStorage.ApplicationUserDataPath, "Profiles", string.Format("{0}.json", deviceToken));
+			string expectedProfilePath = Path.Combine(ApplicationDataStorage.ApplicationUserDataPath, "Profiles", string.Format("{0}{1}", deviceToken, ProfileManager.ProfileExtension));
 			if (File.Exists(expectedProfilePath))
 			{
 				File.Delete(expectedProfilePath);

--- a/VersionManagement/RetrievePublicProfileRequest.cs
+++ b/VersionManagement/RetrievePublicProfileRequest.cs
@@ -1,5 +1,6 @@
 ﻿using MatterHackers.MatterControl.DataStorage;
 using MatterHackers.MatterControl.SettingsManagement;
+using MatterHackers.MatterControl.SlicerConfiguration;
 using System.IO;
 using System.Net;
 
@@ -18,7 +19,7 @@ namespace MatterHackers.MatterControl.VersionManagement
 			// Keep track of version. When retrieving check version
 			string url = DownloadBaseUrl + string.Format("/{0}",deviceToken);
 
-			string profilePath = Path.Combine(ApplicationDataStorage.ApplicationUserDataPath,"Profiles",string.Format("{0}.json",deviceToken));
+			string profilePath = Path.Combine(ApplicationDataStorage.ApplicationUserDataPath,"Profiles",string.Format("{0}{1}",deviceToken, ProfileManager.ProfileExtension));
 
 			WebClient client = new WebClient();
 


### PR DESCRIPTION
Updated to test to reflect the actions actually done by the request (not sure why they were not failing before)