### PR TITLE
Load public profiles from Static Data before launching request to webserver in new task

### DIFF
--- a/MatterControlApplication.cs
+++ b/MatterControlApplication.cs
@@ -125,7 +125,7 @@ namespace MatterHackers.MatterControl
 		/// </summary>
 		/// <param name="collector">The custom collector function to load the content</param>
 		/// <returns></returns>
-		internal static T LoadCacheable<T>(string cacheKey, string cacheScope, Func<string> collector) where T : class
+		internal static T LoadCacheable<T>(string cacheKey, string cacheScope, Func<string> collector, string staticDataFallbackPath = null) where T : class
 		{
 			string cacheDirectory = Path.Combine(ApplicationDataStorage.ApplicationUserDataPath, "data", "temp", "cache", cacheScope);
 			string cachePath = Path.Combine(cacheDirectory, cacheKey);
@@ -159,8 +159,18 @@ namespace MatterHackers.MatterControl
 			}
 			catch
 			{
+				//Fallback to Static Data
+			}
+
+			try
+			{
+				return JsonConvert.DeserializeObject<T>(StaticData.Instance.ReadAllText(staticDataFallbackPath));
+			}
+			catch
+			{
 				return default(T);
 			}
+
 		}
 
 		private MatterControlApplication(double width, double height)

--- a/SlicerConfiguration/Settings/ProfileManager.cs
+++ b/SlicerConfiguration/Settings/ProfileManager.cs
@@ -381,7 +381,8 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 						responseText = RetrievePublicProfileRequest.DownloadPrinterProfile(deviceToken);
 					}
 					return responseText;
-				});
+				},
+				Path.Combine("Profiles",make,String.Format("{0}{1}",model,ProfileManager.ProfileExtension)));
 		}
 
 		public void EnsurePrintersImported()


### PR DESCRIPTION
This reduced loading time for public profiles from 5200-5300ms to 2ms

Loadcacheable can now fall back to Static data if passed a path for it