### PR TITLE
Fixed bug where would try to write to a OemProfile Twice throwing an exception

### DIFF
--- a/SettingsManagement/OemSettings.cs
+++ b/SettingsManagement/OemSettings.cs
@@ -132,8 +132,6 @@ namespace MatterHackers.MatterControl.SettingsManagement
 
 			var manufacturesList = OemProfiles.Keys.ToDictionary(oem => oem).ToList();
 			SetManufacturers(manufacturesList);
-
-			ApplicationController.Load += (s,e) =>  ReloadOemProfiles();
 		}
 
 		public async Task ReloadOemProfiles()
@@ -157,7 +155,7 @@ namespace MatterHackers.MatterControl.SettingsManagement
 				var manufactures = oemProfiles.Keys.ToDictionary(oem => oem);
 				SetManufacturers(manufactures);
 
-				Task.Run((Action)DownloadMissingProfiles);
+				DownloadMissingProfiles();
 			}
 		}
 


### PR DESCRIPTION


 - Removed ReloadOemProfiles form on load (ReloadOemProfiles is called in sync and sync is called on start up so two calls were going out at once)
 - DownloadMissingProfiles is no longer a separate task so that we don't resync and try to run a second download of missing profiles