### PR TITLE
DownloadPrinterProfile should return an instance of PrinterSettings

### DIFF
--- a/ApplicationView/MainApplicationWidget.cs
+++ b/ApplicationView/MainApplicationWidget.cs
@@ -179,7 +179,7 @@ namespace MatterHackers.MatterControl
 		public static event EventHandler Load;
 
 		public static Func<string, Task<Dictionary<string, string>>> GetProfileHistory;
-		public static Func<PrinterInfo,string, Task> GetPrinterProfile;
+		public static Func<PrinterInfo,string, Task<PrinterSettings>> GetPrinterProfileAsync;
 		public static Func<Task> SyncPrinterProfiles;
 		public static Func<Task<OemProfileDictionary>> GetPublicProfileList;
 		public static Func<string, Task<PrinterSettings>> DownloadPublicProfileAsync;

--- a/SetupWizard/PrinterProfileHistoryPage.cs
+++ b/SetupWizard/PrinterProfileHistoryPage.cs
@@ -45,13 +45,16 @@ namespace MatterHackers.MatterControl.SetupWizard
 					var activeProfile = ProfileManager.Instance.ActiveProfile;
 
 					// Download the specified json profile
-					await ApplicationController.GetPrinterProfile(activeProfile, profileToken);
+					var jsonProfile = await ApplicationController.GetPrinterProfileAsync(activeProfile, profileToken);
+					if (jsonProfile != null)
+					{
+						// Persist downloaded profile
+						jsonProfile.Save();
 
-					// TODO: handle errors...
-
-					// Update the active instance to the newly downloaded item
-					var jsonProfile = ProfileManager.LoadProfile(activeProfile.ID, false);
-					ActiveSliceSettings.RefreshActiveInstance(jsonProfile);
+						// Update active instance without calling ReloadAll
+						ActiveSliceSettings.RefreshActiveInstance(jsonProfile);
+					}
+					
 					UiThread.RunOnIdle(WizardWindow.Close);
 				}
 			};

--- a/SlicerConfiguration/Settings/ActiveSliceSettings.cs
+++ b/SlicerConfiguration/Settings/ActiveSliceSettings.cs
@@ -167,9 +167,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			{
 				var printerInfo = ProfileManager.Instance[printerID];
 
-				await ApplicationController.GetPrinterProfile(printerInfo, null);
-
-				profile = ProfileManager.LoadProfile(printerID);
+				profile = await ApplicationController.GetPrinterProfileAsync(printerInfo, null);
 			}
 
 			Instance = profile ?? ProfileManager.LoadEmptyProfile();


### PR DESCRIPTION
 - Persistence of profile moves to caller
 - Rename to GetPrinterProfileAsync
 - Expose PrinterSettings.Save for use in external assemblies
 - Issue MatterHackers/MCCentral#227,  MatterHackers/MCCentral#242