### PR TITLE
Importing a printer/settings from a file will now  notify the user if the file contains no valid user settings

### DIFF
--- a/SetupWizard/ImportSettingsPage.cs
+++ b/SetupWizard/ImportSettingsPage.cs
@@ -594,7 +594,7 @@ namespace MatterHackers.MatterControl
 								if(activeSettings.Contains(item.Key))
 								{
 									containsValidSetting = true;
-									string currentValue = activeSettings.GetValue(item.Key, null).Trim();
+									string currentValue = activeSettings.GetValue(item.Key).Trim();
 									// Compare the value to import to the layer cascade value and only set if different
 									if (currentValue != item.Value)
 									{

--- a/SlicerConfiguration/Settings/PrinterSettings.cs
+++ b/SlicerConfiguration/Settings/PrinterSettings.cs
@@ -371,6 +371,23 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			return "";
 		}
 
+		public bool Contains(string sliceSetting, IEnumerable<PrinterSettingsLayer> layerCascade = null)
+		{
+			if (layerCascade == null)
+			{
+				layerCascade = defaultLayerCascade;
+			}
+			foreach (PrinterSettingsLayer layer in layerCascade)
+			{
+				string value;
+				if (layer.TryGetValue(sliceSetting, out value))
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
 		[JsonIgnore]
 		public PrinterSettingsLayer BaseLayer
 		{

--- a/SlicerConfiguration/Settings/PrinterSettings.cs
+++ b/SlicerConfiguration/Settings/PrinterSettings.cs
@@ -379,8 +379,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			}
 			foreach (PrinterSettingsLayer layer in layerCascade)
 			{
-				string value;
-				if (layer.TryGetValue(sliceSetting, out value))
+				if (layer.ContainsKey(sliceSetting))
 				{
 					return true;
 				}

--- a/StaticData/Translations/Master.txt
+++ b/StaticData/Translations/Master.txt
@@ -5311,3 +5311,6 @@ Translated:There is a required update available.
 English:Import Printer
 Translated:Import Printer
 
+English:Oops! Settings file '{0}' did not contain any settings we could import.
+Translated:Oops! Settings file '{0}' did not contain any settings we could import.
+


### PR DESCRIPTION

 - ImportFomEisting now returns a bool of whether or not it succeeded
 - PrinterSettings now has a Contains method
 - merging or importing quality/material settings check to make sure at least one setting was importable and notifies user if not