### PR TITLE
Revise ChangeCloudSyncStatus

### DIFF
--- a/ApplicationView/MainApplicationWidget.cs
+++ b/ApplicationView/MainApplicationWidget.cs
@@ -492,12 +492,14 @@ namespace MatterHackers.MatterControl
 			}
 		}
 
-		public void ChangeCloudSyncStatus(bool userAuthenticated)
+		public void ChangeCloudSyncStatus(bool userAuthenticated, string reason = "")
 		{
+			UserSettings.Instance.set(UserSettingsKey.CredentialsInvalid, userAuthenticated ? "false" : "true");
+			UserSettings.Instance.set(UserSettingsKey.CredentialsInvalidReason, userAuthenticated ? "" : reason);
+
 			CloudSyncStatusChanged.CallEvents(this, new CloudSyncEventArgs() { IsAuthenticated = userAuthenticated });
 
 			string activeUserName = ApplicationController.Instance.GetSessionUsernameForFileSystem();
-
 			string currentUserName = UserSettings.Instance.get("ActiveUserName");
 
 			UserSettings.Instance.set("ActiveUserName", activeUserName);

--- a/SettingsManagement/UserSettings.cs
+++ b/SettingsManagement/UserSettings.cs
@@ -13,6 +13,8 @@ namespace MatterHackers.MatterControl
 		public const string defaultRenderSetting = nameof(defaultRenderSetting);
 		public const string ActiveThemeName = nameof(ActiveThemeName);
 		public const string ThumbnailRenderingMode = nameof(ThumbnailRenderingMode);
+		public const string CredentialsInvalid = nameof(CredentialsInvalid);
+		public const string CredentialsInvalidReason = nameof(CredentialsInvalidReason);
 	}
 
 	public class UserSettings

--- a/VersionManagement/WebRequestHandler.cs
+++ b/VersionManagement/WebRequestHandler.cs
@@ -321,12 +321,8 @@ namespace MatterHackers.MatterControl.VersionManagement
 					string errorMessage;
 					if (responseValues.TryGetValue("ErrorMessage", out errorMessage) && errorMessage.IndexOf("expired session") != -1)
 					{
-						// TODO: Map more error conditions (beyond just session expired) to CredentialsInvalid status
-						UserSettings.Instance.set("CredentialsInvalid", "true");
-						UserSettings.Instance.set("CredentialsInvalidReason", "Session Expired".Localize());
-
 						// Notify connection status changed and now invalid
-						ApplicationController.Instance.ChangeCloudSyncStatus(false);
+						ApplicationController.Instance.ChangeCloudSyncStatus(userAuthenticated: false, reason: "Session Expired".Localize());
 					}
 				}
 				catch


### PR DESCRIPTION
- Add UserSettingKeys for CredentialsInvalid, CredentialsInvalidReason
- Move CredentialsInvalid, CredentialsInvalidReason setters into ChangeCloudSyncStatus
- Update method to take string parameter for invalid reason
- Toggle state when Connected value changes
- Clear invalid flag if connected, set invalid flag and reason if not
- Issue MatterHackers/MCCentral#354