### PR TITLE
Revise ClientToken use for multi-instanced MatterControl

### DIFF
--- a/MatterControl.csproj
+++ b/MatterControl.csproj
@@ -266,6 +266,7 @@
     <Compile Include="SlicerConfiguration\Settings\ActiveSliceSettings.cs" />
     <Compile Include="SlicerConfiguration\Settings\PrinterSettings.cs" />
     <Compile Include="DataStorage\Classic\ClassicSqlitePrinterProfiles.cs" />
+    <Compile Include="Utilities\AuthenticationData.cs" />
     <Compile Include="Utilities\LimitCallFrequency.cs" />
     <Compile Include="Utilities\SelectedListItems.cs" />
     <Compile Include="Queue\OptionsMenu\ExportToFolderFeedbackWindow.cs" />

--- a/SettingsManagement/ApplicationSettings.cs
+++ b/SettingsManagement/ApplicationSettings.cs
@@ -2,6 +2,8 @@
 using MatterHackers.MatterControl.SettingsManagement;
 using System.Collections.Generic;
 using System;
+using Newtonsoft.Json;
+using System.Linq;
 
 namespace MatterHackers.MatterControl
 {
@@ -60,31 +62,132 @@ namespace MatterHackers.MatterControl
 			return oemName;
 		}
 
-		private string GetClientTokenKeyName()
-		{
-			string keyName = "ClientToken";
-#if DEBUG
-			keyName += "_Test";
-#endif
-			if(ApplicationController.ApplicationInstanceCount > 1)
-			{
-				keyName += "_" + ApplicationController.ApplicationInstanceCount.ToString();
-			}
+		private string runningTokensKeyName = $"{ApplicationController.EnvironmentName}ClientToken_RunningTokens";
 
-			return keyName;
-		}
+		private string claimedClientToken = null;
 
 		public string GetClientToken()
 		{
-			return get(GetClientTokenKeyName());
+			if (!string.IsNullOrEmpty(claimedClientToken))
+			{
+				return claimedClientToken;
+			}
+
+			// This code should only run once per application and get cached in a local property (claimedClientToken)
+			List<string> allocatedClientTokens = GetAllocatedClientTokens();
+			HashSet<string> runningClientTokens = GetRunningClientTokens();
+
+			if (ApplicationController.ApplicationInstanceCount == 1
+				&& !string.IsNullOrEmpty(AuthenticationData.Instance.ActiveClientToken))
+			{
+				claimedClientToken = AuthenticationData.Instance.ActiveClientToken;
+				AuthenticationData.Instance.LoadFirstInstance();
+			}
+			else
+			{
+				var availableTokens = allocatedClientTokens.Except(runningClientTokens);
+				claimedClientToken = availableTokens.FirstOrDefault();
+			}
+
+			// Claim ClientToken
+			if (!string.IsNullOrEmpty(claimedClientToken))
+			{
+				runningClientTokens.Add(claimedClientToken);
+			}
+
+			SetRunningClientTokens(runningClientTokens);
+
+			return claimedClientToken;
+		}
+
+		public void ReleaseClientToken()
+		{
+			// Release ClientToken
+			HashSet<string> runningClientTokens = GetRunningClientTokens();
+			runningClientTokens.Remove(claimedClientToken);
+
+			SetRunningClientTokens(runningClientTokens);
+		}
+
+		private List<string> GetAllocatedClientTokens()
+		{
+			List<string> allocatedClientTokens = new List<string>();
+			string clientToken;
+			int allocatedCount = 0;
+			do
+			{
+				string keyName = $"{ApplicationController.EnvironmentName}ClientToken";
+
+				if (allocatedCount > 0)
+				{
+					keyName += "_" + allocatedCount;
+				}
+
+				clientToken = get(keyName);
+				if (!string.IsNullOrEmpty(clientToken))
+				{
+					allocatedClientTokens.Add(clientToken);
+				}
+
+				allocatedCount++;
+
+			} while (!string.IsNullOrEmpty(clientToken));
+			return allocatedClientTokens;
+		}
+
+		private HashSet<string> GetRunningClientTokens()
+		{
+			var  runningClientTokens = new HashSet<string>();
+
+			// Only deserialize if greater than one
+			if (ApplicationController.ApplicationInstanceCount > 1)
+			{
+				try
+				{
+					string json = get(runningTokensKeyName);
+					if (!string.IsNullOrEmpty(json))
+					{
+						runningClientTokens = JsonConvert.DeserializeObject<HashSet<string>>(json);
+					}
+				}
+				catch { }
+			}
+
+			return runningClientTokens;
+		}
+
+		private void SetRunningClientTokens(HashSet<string> runningClientTokens)
+		{
+			set(runningTokensKeyName, JsonConvert.SerializeObject(runningClientTokens));
 		}
 
 		public void SetClientToken(string clientToken)
 		{
 			// Clear credentials anytime we are allocated a new client token
-			ApplicationController.ClearCachedCredentials();
+			AuthenticationData.Instance.ClearActiveSession();
 
-			set(GetClientTokenKeyName(), clientToken);
+			int allocatedCount = 0;
+
+			bool firstEmptySlot = false;
+
+			do
+			{
+				string keyName = $"{ApplicationController.EnvironmentName}ClientToken";
+
+				if (allocatedCount > 0)
+				{
+					keyName += "_" + allocatedCount;
+				}
+
+				firstEmptySlot = string.IsNullOrEmpty(get(keyName));
+				if (firstEmptySlot)
+				{
+					set(keyName, clientToken);
+				}
+
+				allocatedCount++;
+
+			} while (!firstEmptySlot);
 		}
 
 		public string get(string key)

--- a/SetupWizard/AndroidSetupOptionsPage.cs
+++ b/SetupWizard/AndroidSetupOptionsPage.cs
@@ -186,7 +186,7 @@ namespace MatterHackers.MatterControl
 			this.textImageButtonFactory = textImageButtonFactory;
 
 			bool signedIn = true;
-			string username = ApplicationController.Instance.GetSessionUsername();
+			string username = AuthenticationData.Instance.ActiveSessionUsername;
 			if (username == null)
 			{
 				signedIn = false;

--- a/SlicerConfiguration/Settings/ProfileManager.cs
+++ b/SlicerConfiguration/Settings/ProfileManager.cs
@@ -89,13 +89,13 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		{
 			get
 			{
-				string username = UserSettings.Instance.get("ActiveUserName");
+				string username = ApplicationController.Instance.GetSessionUsernameForFileSystem();
 				if (string.IsNullOrEmpty(username))
 				{ 
 					username = GuestDBPath;
 
 					// If ActiveUserName is empty or invalid and the credentials file exists, delete local credentials, resetting to unauthenticated guest mode
-					ApplicationController.ClearCachedCredentials();
+					AuthenticationData.Instance.ClearActiveSession();
 				}
 				else
 				{
@@ -217,7 +217,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		{
 			get
 			{
-				string activeUserName = UserSettings.Instance.get("ActiveUserName");
+				string activeUserName = ApplicationController.Instance.GetSessionUsernameForFileSystem();
 				return UserSettings.Instance.get($"ActiveProfileID-{activeUserName}");
 			}
 		}
@@ -231,7 +231,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 		public void SetLastProfile(string printerID)
 		{
-			string activeUserName = UserSettings.Instance.get("ActiveUserName");
+			string activeUserName = ApplicationController.Instance.GetSessionUsernameForFileSystem();
 			UserSettings.Instance.set($"ActiveProfileID-{activeUserName}", printerID);
 		}
 

--- a/SlicerConfiguration/SliceSettingsDetailControl.cs
+++ b/SlicerConfiguration/SliceSettingsDetailControl.cs
@@ -115,7 +115,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			MenuItem settingsHistory = sliceOptionsMenuDropList.AddItem("Settings History".Localize());
 			settingsHistory.Selected += (s, e) => { WizardWindow.Show<PrinterProfileHistoryPage>("PrinterProfileHistory", "Settings History"); };
 
-			settingsHistory.Enabled = ApplicationController.Instance.GetSessionUsername() != null;
+			settingsHistory.Enabled = !string.IsNullOrEmpty(AuthenticationData.Instance.ActiveSessionUsername);
 
 			sliceOptionsMenuDropList.AddItem("Reset to defaults".Localize()).Selected += (s, e) => { UiThread.RunOnIdle(ResetToDefaults); };
 

--- a/Utilities/AuthenticationData.cs
+++ b/Utilities/AuthenticationData.cs
@@ -1,0 +1,160 @@
+﻿using MatterHackers.Agg;
+using MatterHackers.MatterControl.DataStorage;
+using MatterHackers.MatterControl.SettingsManagement;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Runtime.Serialization.Formatters.Binary;
+using MatterHackers.Localizations;
+
+namespace MatterHackers.MatterControl
+{
+	public class AuthenticationData
+	{
+		public RootedObjectEventHandler SessionUpdateTrigger = new RootedObjectEventHandler();
+		static int failedRequestCount = int.MaxValue;
+
+		public bool IsConnected
+		{
+			get
+			{
+				if(failedRequestCount > 5)
+				{
+					return false;
+				}
+
+				return true;
+			}
+		}
+
+		public void OutboundRequest(bool success)
+		{
+			if (success)
+			{
+				failedRequestCount = 0;
+			}
+			else
+			{
+				failedRequestCount++;
+			}
+		}
+
+		public static AuthenticationData Instance { get; } = new AuthenticationData();
+
+		public void SessionRefresh()
+		{
+			//Called after completing a purchase (for example)
+			SessionUpdateTrigger.CallEvents(null, null);
+		}
+
+		public void ClearActiveSession()
+		{
+			this.ActiveSessionKey = null;
+			this.ActiveSessionUsername = null;
+			this.ActiveSessionEmail = null;
+			this.ActiveClientToken = null;
+			// this.LastSessionUsername = null;
+
+			ApplicationController.Instance.ChangeCloudSyncStatus(userAuthenticated: false, reason: "Session Cleared".Localize());
+			SessionUpdateTrigger.CallEvents(null, null);
+		}
+
+		public void SetActiveSession(string userName, string userEmail, string sessionKey, string clientToken)
+		{
+			this.ActiveSessionKey = sessionKey;
+			this.ActiveSessionUsername = userName;
+			this.ActiveSessionEmail = userEmail;
+			this.ActiveClientToken = clientToken;
+
+			ApplicationController.Instance.ChangeCloudSyncStatus(userAuthenticated: true);
+			SessionUpdateTrigger.CallEvents(null, null);
+		}
+		
+		public bool ClientAuthenticatedSessionValid
+		{
+			get
+			{
+				return !string.IsNullOrEmpty(this.ActiveSessionKey)
+					&& UserSettings.Instance.get(UserSettingsKey.CredentialsInvalid) != "true";
+			}
+		}
+
+		private string activeSessionKey;
+		public string ActiveSessionKey
+		{
+			get
+			{
+				return activeSessionKey;
+			}
+			private set
+			{
+				activeSessionKey = value;
+				ApplicationSettings.Instance.set($"{ApplicationController.EnvironmentName}ActiveSessionKey", value);
+			}
+		}
+
+		private string activeSessionUsername;
+		public string ActiveSessionUsername
+		{
+			get
+			{
+				// Only return the ActiveSessionUserName if the ActiveSessionKey field is not empty
+				return string.IsNullOrEmpty(ActiveSessionKey) ? null : activeSessionUsername;
+			}
+			private set
+			{
+				activeSessionUsername = value;
+				ApplicationSettings.Instance.set($"{ApplicationController.EnvironmentName}ActiveSessionUsername", value);
+			}
+		}
+
+		internal void LoadFirstInstance()
+		{
+			activeSessionKey = ApplicationSettings.Instance.get($"{ApplicationController.EnvironmentName}ActiveSessionKey");
+			activeSessionUsername = ApplicationSettings.Instance.get($"{ApplicationController.EnvironmentName}ActiveSessionUsername");
+			activeSessionEmail = ApplicationSettings.Instance.get($"{ApplicationController.EnvironmentName}ActiveSessionEmail");
+			lastSessionUsername = ApplicationSettings.Instance.get($"{ApplicationController.EnvironmentName}LastSessionUsername");
+		}
+
+		private string activeSessionEmail;
+		public string ActiveSessionEmail
+		{
+			get
+			{
+				return activeSessionEmail;
+			}
+			private set
+			{
+				activeSessionEmail = value;
+				ApplicationSettings.Instance.set($"{ApplicationController.EnvironmentName}ActiveSessionEmail", value);
+			}
+		}
+
+		public string ActiveClientToken
+		{
+			get
+			{
+				return ApplicationSettings.Instance.get($"{ApplicationController.EnvironmentName}ActiveClientToken");
+			}
+			private set
+			{
+				ApplicationSettings.Instance.set($"{ApplicationController.EnvironmentName}ActiveClientToken", value);
+			}
+		}
+
+		private string lastSessionUsername;
+		public string LastSessionUsername
+		{
+			get
+			{
+				return lastSessionUsername;
+			}
+			set
+			{
+				lastSessionUsername = value;
+				ApplicationSettings.Instance.set($"{ApplicationController.EnvironmentName}LastSessionUsername", value);
+			}
+		}
+	}
+}


### PR DESCRIPTION
- Add public const EnvironmentName for Services environment
- Remove GetSessionUsername method
- Remove ClearCachedCredentials
- Pull in AuthData type
- Add system to store and use ClientTokens
- Add using statements for common namespaces
- Issue MatterHackers/MCCentral#488