### PR TITLE
Refine ManualPrinterControls scrollable behavior

### DIFF
--- a/ApplicationView/TouchscreenTabView.cs
+++ b/ApplicationView/TouchscreenTabView.cs
@@ -123,11 +123,8 @@ namespace MatterHackers.MatterControl
 
 			string printerControlsLabel = LocalizedString.Get("Controls").ToUpper();
 
-#if __ANDROID__
-			manualControlsPage = new TabPage(new ManualControlsWidget(), printerControlsLabel);
-#else
-			manualControlsPage = new TabPage(CreateManualControlsTab(), printerControlsLabel);
-#endif
+			manualControlsPage = new TabPage(new ManualPrinterControls(), printerControlsLabel);
+
 			//Add the tab contents for 'Advanced Controls'
 			this.AddTab(new SimpleTextTabWidget(manualControlsPage, "Controls Tab", TabTextSize,
 				ActiveTheme.Instance.SecondaryAccentColor, new RGBA_Bytes(), unselectedTextColor, new RGBA_Bytes()));
@@ -229,18 +226,6 @@ namespace MatterHackers.MatterControl
 		}
 		private event EventHandler unregisterEvents;
 
-		private ScrollableWidget CreateManualControlsTab()
-		{
-			GuiWidget manualPrinterControls = new ManualControlsWidget();
-
-			ScrollableWidget manualPrinterControlsScrollArea = new ScrollableWidget(true);
-			manualPrinterControlsScrollArea.ScrollArea.HAnchor |= Agg.UI.HAnchor.ParentLeftRight;
-			manualPrinterControlsScrollArea.AnchorAll();
-			manualPrinterControlsScrollArea.AddChild(manualPrinterControls);
-
-			return manualPrinterControlsScrollArea;
-		}
-
 		public override void OnClosed(EventArgs e)
 		{
 			unregisterEvents?.Invoke(this, null);
@@ -280,8 +265,7 @@ namespace MatterHackers.MatterControl
 		{
 			// ReloadControlsWidget
 			manualControlsPage.RemoveAllChildren();
-			ScrollableWidget manualScroll = CreateManualControlsTab();
-			manualControlsPage.AddChild(manualScroll);
+			manualControlsPage.AddChild(new ManualPrinterControls());
 
 			// ReloadConfigurationWidget
 			optionsPage.RemoveAllChildren();

--- a/PrinterControls/ManualPrinterControls.cs
+++ b/PrinterControls/ManualPrinterControls.cs
@@ -37,19 +37,7 @@ using System;
 
 namespace MatterHackers.MatterControl
 {
-	public class ManualControlsWidget : GuiWidget
-	{
-		public ManualControlsWidget()
-			: base()
-		{
-			this.AnchorAll();
-            VAnchor = Agg.UI.VAnchor.Max_FitToChildren_ParentHeight;
-			this.BackgroundColor = ActiveTheme.Instance.SecondaryBackgroundColor;
-			this.AddChild(new ManualPrinterControls());
-		}
-	}
-
-	public class ManualPrinterControls : GuiWidget
+	public class ManualPrinterControls : ScrollableWidget
 	{
 		static public RootedObjectEventHandler AddPluginControls = new RootedObjectEventHandler();
 
@@ -69,6 +57,10 @@ namespace MatterHackers.MatterControl
 
 		public ManualPrinterControls()
 		{
+			ScrollArea.HAnchor |= Agg.UI.HAnchor.ParentLeftRight;
+			AnchorAll();
+			AutoScroll = true;
+
 			SetDisplayAttributes();
 
 			FlowLayoutWidget controlsTopToBottomLayout = new FlowLayoutWidget(FlowDirection.TopToBottom);
@@ -110,11 +102,7 @@ namespace MatterHackers.MatterControl
 
 		public override void OnClosed(EventArgs e)
 		{
-			if (unregisterEvents != null)
-			{
-				unregisterEvents(this, null);
-			}
-
+			unregisterEvents?.Invoke(this, null);
 			base.OnClosed(e);
 		}
 


### PR DESCRIPTION
- Use ScrollableWidget for ManualPrinterControls base
- Remove conditional Android compilation
- Remove ManualControlsWidget type
- Rebuild ManualControls widget on ReloadAdvancedControls
- Issue MatterHackers/MCCentral#536