### PR TITLE
Add LazyTabs for Touchscreen view

### DIFF
--- a/ActionBar/PrinterConnectAndSelectControl.cs
+++ b/ActionBar/PrinterConnectAndSelectControl.cs
@@ -98,18 +98,11 @@ namespace MatterHackers.MatterControl.ActionBar
 
 			// connect and disconnect buttons
 			{
-				string connectString = "Connect".Localize().ToUpper();
-				connectPrinterButton = actionBarButtonFactory.Generate(connectString, "icon_power_32x32.png");
+				connectPrinterButton = actionBarButtonFactory.Generate("Connect".Localize().ToUpper(), "icon_power_32x32.png");
 				connectPrinterButton.Name = "Connect to printer button";
 				connectPrinterButton.ToolTipText = "Connect to the currently selected printer".Localize();
-				if (ApplicationController.Instance.WidescreenMode)
-				{
-					connectPrinterButton.Margin = new BorderDouble(0, 0, 3, 3);
-				}
-				else
-				{
-					connectPrinterButton.Margin = new BorderDouble(6, 0, 3, 3);
-				}
+				connectPrinterButton.Margin = new BorderDouble(6, 0, 3, 3);
+
 				connectPrinterButton.VAnchor = VAnchor.ParentTop;
 				connectPrinterButton.Cursor = Cursors.Hand;
 				connectPrinterButton.Click += (s, e) =>
@@ -124,17 +117,10 @@ namespace MatterHackers.MatterControl.ActionBar
 					}
 				};
 
-				string disconnectString = "Disconnect".Localize().ToUpper();
-				disconnectPrinterButton = actionBarButtonFactory.Generate(disconnectString, "icon_power_32x32.png");
+				disconnectPrinterButton = actionBarButtonFactory.Generate("Disconnect".Localize().ToUpper(), "icon_power_32x32.png");
 				disconnectPrinterButton.ToolTipText = "Disconnect from current printer".Localize();
-				if (ApplicationController.Instance.WidescreenMode)
-				{
-					disconnectPrinterButton.Margin = new BorderDouble(0, 0, 3, 3);
-				}
-				else
-				{
-					disconnectPrinterButton.Margin = new BorderDouble(6, 0, 3, 3);
-				}
+				disconnectPrinterButton.Margin = new BorderDouble(6, 0, 3, 3);
+
 				disconnectPrinterButton.VAnchor = VAnchor.ParentTop;
 				disconnectPrinterButton.Cursor = Cursors.Hand;
 				disconnectPrinterButton.Click += (s, e) => UiThread.RunOnIdle(OnIdleDisconnect);
@@ -158,12 +144,11 @@ namespace MatterHackers.MatterControl.ActionBar
 					HAnchor = HAnchor.ParentLeftRight,
 				};
 
-				int rightMarginForWideScreenMode = ApplicationController.Instance.WidescreenMode ? 6 : 0;
 				printerSelector = new PrinterSelector()
 				{
 					HAnchor = HAnchor.ParentLeftRight,
 					Cursor = Cursors.Hand,
-					Margin = new BorderDouble(0, 6, rightMarginForWideScreenMode, 3)
+					Margin = new BorderDouble(0, 6, 0, 3)
 				};
 				printerSelector.AddPrinter += (s, e) => WizardWindow.ShowPrinterSetup(true);
 				// make sure the control can get smaller but maintains its height
@@ -192,14 +177,7 @@ namespace MatterHackers.MatterControl.ActionBar
 			{
 				string resetConnectionText = "Reset\nConnection".Localize().ToUpper();
 				Button resetConnectionButton = actionBarButtonFactory.Generate(resetConnectionText, "e_stop4.png");
-				if (ApplicationController.Instance.WidescreenMode)
-				{
-					resetConnectionButton.Margin = new BorderDouble(0, 0, 3, 3);
-				}
-				else
-				{
-					resetConnectionButton.Margin = new BorderDouble(6, 0, 3, 3);
-				}
+				resetConnectionButton.Margin = new BorderDouble(6, 0, 3, 3);
 				this.AddChild(resetConnectionButton);
 
 				resetConnectionButton.Click += new EventHandler((s,e) => PrinterConnectionAndCommunication.Instance.RebootBoard());

--- a/ApplicationView/MainApplicationWidget.cs
+++ b/ApplicationView/MainApplicationWidget.cs
@@ -215,8 +215,6 @@ namespace MatterHackers.MatterControl
 
 		private event EventHandler unregisterEvents;
 
-		public bool WidescreenMode { get; set; }
-
 		static int applicationInstanceCount = 0;
 		public static int ApplicationInstanceCount
 		{

--- a/ApplicationView/WidescreenPanel.cs
+++ b/ApplicationView/WidescreenPanel.cs
@@ -42,7 +42,7 @@ namespace MatterHackers.MatterControl
 	public class WidescreenPanel : FlowLayoutWidget
 	{
 		private static readonly int ColumnOneFixedWidth = 590;
-		private static int lastNumberOfVisiblePanels = 0;
+		private int lastNumberOfVisiblePanels = 0;
 
 		private TextImageButtonFactory advancedControlsButtonFactory = new TextImageButtonFactory();
 		private RGBA_Bytes unselectedTextColor = ActiveTheme.Instance.TabLabelUnselected;

--- a/CustomWidgets/PopOutTextTab.cs
+++ b/CustomWidgets/PopOutTextTab.cs
@@ -59,7 +59,7 @@ namespace MatterHackers.Agg.UI
 			AddText(tabPageControledByTab.Text, selectedWidget, selectedTextColor, selectedBackgroundColor, pointSize);
 			AddText(tabPageControledByTab.Text, normalWidget, normalTextColor, normalBackgroundColor, pointSize);
 
-			tabPageControledByTab.TextChanged += new EventHandler(tabPageControledByTab_TextChanged);
+			tabPageControledByTab.TextChanged += tabPageControledByTab_TextChanged;
 
 			SetBoundsToEncloseChildren();
 

--- a/Library/Provider/LibraryProviderSqlite.cs
+++ b/Library/Provider/LibraryProviderSqlite.cs
@@ -303,6 +303,8 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 				{
 					string thumbnailDestFile = PartThumbnailWidget.GetImageFileName(printItemToAdd);
 
+					Directory.CreateDirectory(Path.GetDirectoryName(thumbnailDestFile));
+
 					// copy it to the right place
 					File.Copy(thumbnailSourceFile, thumbnailDestFile);
 				}

--- a/SlicerConfiguration/Settings/ProfileManager.cs
+++ b/SlicerConfiguration/Settings/ProfileManager.cs
@@ -150,11 +150,19 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 					// Load or download on a background thread
 					var lastProfile = await LoadProfileAsync(Instance.LastProfileID);
 
-					UiThread.RunOnIdle(() =>
+					if (MatterControlApplication.IsLoading)
 					{
 						// Assign on the UI thread
 						ActiveSliceSettings.Instance = lastProfile ?? LoadEmptyProfile();
-					});
+					}
+					else
+					{
+						UiThread.RunOnIdle(() =>
+						{
+							// Assign on the UI thread
+							ActiveSliceSettings.Instance = lastProfile ?? LoadEmptyProfile();
+						});
+					}
 				});
 			}
 


### PR DESCRIPTION
- Remove unset ApplicationControler.WidescreenMode variable
- Add local AddTab function to TouchScreenTabView for LazyTab creation
- Use common AddTab function for tab creation in TouchScreenTabView
- Refactor WidescreenPanel for clarity
  - Use OnBoundsChanged instead of event
  - obj.NumberOfVisiblePanels() becomes obj.VisiblePanelCount
- Fix thumbnail exception experienced by ensuring Directory exists
- Run ActiveSliceSettings.Instance assignment on UI thread if loading
  - Prevents extra ReloadAll right at the completion of form Load
- Issue MatterHackers/MCCentral#536