### PR TITLE
Fix Regression in user color preservation

### DIFF
--- a/CustomWidgets/ThemeColorSelectorWidget.cs
+++ b/CustomWidgets/ThemeColorSelectorWidget.cs
@@ -91,6 +91,7 @@ namespace MatterHackers.MatterControl
 				// save it for this printer
 				ActiveSliceSettings.Instance.SetValue(SettingsKey.active_theme_name, themeName);
 
+				UserSettings.Instance.set(UserSettingsKey.ActiveThemeName, themeName);
 				ActiveTheme.Instance = ActiveTheme.GetThemeColors(themeName);
 			};
 

--- a/MatterControlApplication.cs
+++ b/MatterControlApplication.cs
@@ -425,7 +425,16 @@ namespace MatterHackers.MatterControl
 		{
 			if (string.IsNullOrEmpty(UserSettings.Instance.get(UserSettingsKey.ActiveThemeName)))
 			{
-				ActiveTheme.Instance = ActiveTheme.GetThemeColors("Blue - Light");
+				string oemColor = OemSettings.Instance.ThemeColor;
+				if(string.IsNullOrEmpty(oemColor))
+				{
+					ActiveTheme.Instance = ActiveTheme.GetThemeColors("Blue - Light");
+				}
+				else
+				{
+					UserSettings.Instance.set(UserSettingsKey.ActiveThemeName, oemColor);
+					ActiveTheme.Instance = ActiveTheme.GetThemeColors(oemColor);
+				}
 			}
 			else
 			{

--- a/SlicerConfiguration/Settings/ActiveSliceSettings.cs
+++ b/SlicerConfiguration/Settings/ActiveSliceSettings.cs
@@ -123,7 +123,12 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			{
 				if (ActiveSliceSettings.Instance.PrinterSelected)
 				{
-					string activeThemeName = "Blue - Light";
+					//Attempt to load userSetting theme as default
+					string activeThemeName = UserSettings.Instance.get(UserSettingsKey.ActiveThemeName);
+					if(string.IsNullOrEmpty(activeThemeName))
+					{
+						activeThemeName = "Blue - Light";
+					}
 					if (ActiveSliceSettings.Instance.Contains(SettingsKey.active_theme_name))
 					{
 						activeThemeName = ActiveSliceSettings.Instance.GetValue(SettingsKey.active_theme_name);
@@ -136,7 +141,11 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 							ActiveTheme.SuspendEvents();
 						}
 					}
-
+					else
+					{
+						//If the active printer has no theme we set it to the default so that it does not suddenly change colors later when another printer's color is changed
+						ActiveSliceSettings.Instance.SetValue(SettingsKey.active_theme_name, activeThemeName);
+					}
 					ActiveTheme.Instance = ActiveTheme.GetThemeColors(activeThemeName);
 					ActiveTheme.ResumeEvents();
 				}


### PR DESCRIPTION
 - Setting color for a printer sets value in user settings
 - use UserSetting color as default for loading theme color
 - if Active slice settings dont have an active theme set it to default
 - If user setting  theme is null attempt to load OemColor preference and set as user setting theme