### PR TITLE
Prevent false positives when assemblies are missing

### DIFF
--- a/Tests/MatterControl.AutomationTests/MatterControl.AutomationTests.csproj
+++ b/Tests/MatterControl.AutomationTests/MatterControl.AutomationTests.csproj
@@ -77,10 +77,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Plugins\CloudServices\CloudServices\CloudServices.csproj">
-      <Project>{6782bf37-8139-4dc6-885e-98d22d1fb258}</Project>
-      <Name>CloudServices</Name>
-    </ProjectReference>
     <ProjectReference Include="..\..\MatterControl.csproj">
       <Project>{0b8d6f56-bd7f-4426-b858-d9292b084656}</Project>
       <Name>MatterControl</Name>

--- a/Tests/MatterControl.Tests/MatterControl/ReleaseBuildTests.cs
+++ b/Tests/MatterControl.Tests/MatterControl/ReleaseBuildTests.cs
@@ -33,7 +33,13 @@ namespace MatterControl.Tests
 		[Test, Category("ReleaseQuality")]
 		public void MatterControlKnownAssembliesAreOptimized()
 		{
-			// Rebuild at any time with rebuildDependencies() below
+#if DEBUG
+			string configuration = "Debug";
+#else
+			string configuration = "Release";
+#endif
+
+			// This list can be refreshed via the rebuildDependencies() helper function below
 			string knownAssemblies = @"MatterHackers.VectorMath.dll
 						AGG.dll
 						PlatfromAbstract.dll
@@ -56,27 +62,23 @@ namespace MatterControl.Tests
 						MatterHackers.Agg.ImageProcessing.dll
 						MatterHackers.MarchingSquares.dll
 						GuiAutomation.dll
-						../../../../bin/Release/MatterControlAuth.dll
-						../../../../bin/Release/PictureCreator.dll
-						../../../../bin/Release/PrintNotifications.dll
-						../../../../bin/Release/CloudServices.dll
-						../../../../bin/Release/X3GDriver.dll
-						../../../../bin/Release/Mono.Nat.dll
-						../../../../bin/Release/BrailBuilder.dll
+						MatterControlAuth.dll
+						PictureCreator.dll
+						PrintNotifications.dll
+						CloudServices.dll
+						X3GDriver.dll
+						Mono.Nat.dll
+						BrailBuilder.dll
 						TextCreator.dll";
 
 			foreach (string assemblyName in knownAssemblies.Split('\n').Select(s => s.Trim()))
 			{
-				var assemblyPath = Path.GetFullPath(assemblyName);
-				if (!File.Exists(assemblyPath))
-				{
-					Console.WriteLine("Skipping missing file: " + assemblyPath);
-					continue;
-				}
+				var assemblyPath = TestContext.CurrentContext.ResolveProjectPath(4, "bin", configuration, assemblyName);
 
-				var assembly = Assembly.LoadFrom(assemblyPath);
-
+				// Missing/renamed assemblies should fail the test and force a correction
+				Assert.IsTrue(File.Exists(assemblyPath));
 #if (!DEBUG)
+				var assembly = Assembly.LoadFrom(assemblyPath);
 				IsAssemblyOptimized(assembly);
 #endif
 			}

--- a/Tests/MatterControl.Tests/MatterControl/ReleaseBuildTests.cs
+++ b/Tests/MatterControl.Tests/MatterControl/ReleaseBuildTests.cs
@@ -76,7 +76,7 @@ namespace MatterControl.Tests
 				var assemblyPath = TestContext.CurrentContext.ResolveProjectPath(4, "bin", configuration, assemblyName);
 
 				// Missing/renamed assemblies should fail the test and force a correction
-				Assert.IsTrue(File.Exists(assemblyPath));
+				Assert.IsTrue(File.Exists(assemblyPath), "Assembly missing: " + assemblyPath);
 #if (!DEBUG)
 				var assembly = Assembly.LoadFrom(assemblyPath);
 				IsAssemblyOptimized(assembly);

--- a/Tests/MatterControl.Tests/MatterControl/ReleaseBuildTests.cs
+++ b/Tests/MatterControl.Tests/MatterControl/ReleaseBuildTests.cs
@@ -62,12 +62,6 @@ namespace MatterControl.Tests
 						MatterHackers.Agg.ImageProcessing.dll
 						MatterHackers.MarchingSquares.dll
 						GuiAutomation.dll
-						MatterControlAuth.dll
-						PictureCreator.dll
-						PrintNotifications.dll
-						CloudServices.dll
-						X3GDriver.dll
-						Mono.Nat.dll
 						BrailBuilder.dll
 						TextCreator.dll";
 

--- a/Tests/MatterControl.Tests/MatterControl/ReleaseBuildTests.cs
+++ b/Tests/MatterControl.Tests/MatterControl/ReleaseBuildTests.cs
@@ -80,7 +80,7 @@ namespace MatterControl.Tests
 
 		private void rebuildDependencies()
 		{
-			// Update to point to resent buildagent results file
+			// Modify path to point at a recent BuildAgent results file
 			var elem = XElement.Load(@"C:\Data\Sources\MatterHackers\BuildAndDeployment\MatterControl\build_sln.xml");
 			var items = elem.Descendants().Where(e => e.Name == "target" && "CopyFilesToOutputDirectory" == (string)e.Attribute("name")).SelectMany(e => e.Elements("message").Select(e2 => e2.Value.TrimEnd('.')).Where(s => s.Contains("Copying") && s.Contains(".dll")));
 


### PR DESCRIPTION
- Use the MatterControl output directory in all cases
- Only load assemblies for testing in Release builds
- Use conditional comp. for path resolution
- Issue MatterHackers/MCCentral#550
