### PR TITLE
Fixed color behavior for users with unset default

### DIFF
--- a/ApplicationView/MainApplicationWidget.cs
+++ b/ApplicationView/MainApplicationWidget.cs
@@ -457,7 +457,9 @@ namespace MatterHackers.MatterControl
 				string oemColor = OemSettings.Instance.ThemeColor;
 				if (string.IsNullOrEmpty(oemColor))
 				{
-					ActiveTheme.Instance = ActiveTheme.GetThemeColors("Blue - Light");
+					string mCDefaultColor = "Blue - Light";
+					ActiveTheme.Instance = ActiveTheme.GetThemeColors(mCDefaultColor);
+					UserSettings.Instance.set(UserSettingsKey.ActiveThemeName, mCDefaultColor);
 				}
 				else
 				{

--- a/CustomWidgets/ThemeColorSelectorWidget.cs
+++ b/CustomWidgets/ThemeColorSelectorWidget.cs
@@ -90,7 +90,7 @@ namespace MatterHackers.MatterControl
 
 				// save it for this printer
 				ActiveSliceSettings.Instance.SetValue(SettingsKey.active_theme_name, themeName);
-
+				//Set new user selected Default
 				UserSettings.Instance.set(UserSettingsKey.ActiveThemeName, themeName);
 				ActiveTheme.Instance = ActiveTheme.GetThemeColors(themeName);
 			};

--- a/SlicerConfiguration/Settings/ActiveSliceSettings.cs
+++ b/SlicerConfiguration/Settings/ActiveSliceSettings.cs
@@ -132,10 +132,6 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 					if (ActiveSliceSettings.Instance.Contains(SettingsKey.active_theme_name))
 					{
 						activeThemeName = ActiveSliceSettings.Instance.GetValue(SettingsKey.active_theme_name);
-						if (string.IsNullOrEmpty(activeThemeName))
-						{
-							activeThemeName = "Blue - Light";
-						}
 						if (!doReloadEvent)
 						{
 							ActiveTheme.SuspendEvents();


### PR DESCRIPTION
 -  When both the user and oem settings are unset we now both set the active theme color to be blue and set this as the user default
 - Removed redundant null check/fallback.