### PR TITLE
Refactor ProfileManager to prefer isolated instances

### DIFF
--- a/DataStorage/Classic/ClassicSqlitePrinterProfiles.cs
+++ b/DataStorage/Classic/ClassicSqlitePrinterProfiles.cs
@@ -105,7 +105,7 @@ namespace MatterHackers.MatterControl.DataStorage.ClassicDB
 
 			if (string.IsNullOrEmpty(ProfileManager.Instance.LastProfileID))
 			{
-				ProfileManager.Instance.SetLastProfile(printer.Id.ToString());
+				ProfileManager.Instance.LastProfileID = printer.Id.ToString();
 			}
 
 			printerSettings.UserLayer[SettingsKey.active_theme_name] = UserSettings.Instance.get(UserSettingsKey.ActiveThemeName);

--- a/SlicerConfiguration/Settings/ActiveSliceSettings.cs
+++ b/SlicerConfiguration/Settings/ActiveSliceSettings.cs
@@ -141,12 +141,12 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		static ActiveSliceSettings()
 		{
 			// Load last profile or fall back to empty
-			Instance = ProfileManager.Instance?.LoadLastProfileWithoutRecovery() ?? ProfileManager.LoadEmptyProfile();
+			Instance = ProfileManager.Instance?.LoadWithoutRecovery(ProfileManager.Instance.LastProfileID) ?? ProfileManager.LoadEmptyProfile();
 		}
 
 		internal static async Task SwitchToProfile(string printerID)
 		{
-			ProfileManager.Instance.SetLastProfile(printerID);
+			ProfileManager.Instance.LastProfileID = printerID;
 			Instance = (await ProfileManager.LoadProfileAsync(printerID)) ?? ProfileManager.LoadEmptyProfile();
 		}
 

--- a/Utilities/AuthenticationData.cs
+++ b/Utilities/AuthenticationData.cs
@@ -7,6 +7,8 @@ using System.IO;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Formatters.Binary;
 using MatterHackers.Localizations;
+using System.Text.RegularExpressions;
+using Newtonsoft.Json;
 
 namespace MatterHackers.MatterControl
 {
@@ -155,6 +157,22 @@ namespace MatterHackers.MatterControl
 				lastSessionUsername = value;
 				ApplicationSettings.Instance.set($"{ApplicationController.EnvironmentName}LastSessionUsername", value);
 			}
+		}
+
+		[JsonIgnore]
+		public string FileSystemSafeUserName => MakeValidFileName(this.ActiveSessionUsername);
+
+		private static string MakeValidFileName(string name)
+		{
+			if (string.IsNullOrEmpty(name))
+			{
+				return name;
+			}
+
+			string invalidChars = Regex.Escape(new string(Path.GetInvalidFileNameChars()));
+			string invalidRegStr = string.Format(@"([{0}]*\.+$)|([{0}]+)", invalidChars);
+
+			return Regex.Replace(name, invalidRegStr, "_");
 		}
 	}
 }


### PR DESCRIPTION
- Replace DB nomenclatures with ProfilesDoc/Profiles terms
- Convert SetLastProfile() to LastProfileID property
- Remove LoadLastProfileWithoutRecovery function
  - Use LoadWithoutRecovery(LastProfileID)
  - One caller, far more clear with only one LoadWithout function
- Move safe FileSystem UserName to AuthenticationData, like UserName
- Skip importing guest profiles that are missing PrinterSettings files

- Issue MatterHackers/MCCentral#597
