### PR TITLE
Always call UserChanged when ChangeCloudSyncStatus

### DIFF
--- a/ApplicationView/MainApplicationWidget.cs
+++ b/ApplicationView/MainApplicationWidget.cs
@@ -521,15 +521,14 @@ namespace MatterHackers.MatterControl
 			CloudSyncStatusChanged.CallEvents(this, new CloudSyncEventArgs() { IsAuthenticated = userAuthenticated });
 
 			// Only fire UserChanged if it actually happened - prevents runaway positive feedback loop
-			if (AuthenticationData.Instance.ActiveSessionUsername != AuthenticationData.Instance.LastSessionUsername)
+			if (!string.IsNullOrEmpty(AuthenticationData.Instance.ActiveSessionUsername)
+				&& AuthenticationData.Instance.ActiveSessionUsername != AuthenticationData.Instance.LastSessionUsername)
 			{
 				// only set it if it is an actual user name
-				if (!string.IsNullOrEmpty(AuthenticationData.Instance.ActiveSessionUsername))
-				{
-					AuthenticationData.Instance.LastSessionUsername = AuthenticationData.Instance.ActiveSessionUsername;
-				}
-				UserChanged();
+				AuthenticationData.Instance.LastSessionUsername = AuthenticationData.Instance.ActiveSessionUsername;
 			}
+
+			UserChanged();
 		}
 
 		// Called after every startup and at the completion of every authentication change

--- a/PartPreviewWindow/ViewGcodeWidget.cs
+++ b/PartPreviewWindow/ViewGcodeWidget.cs
@@ -356,7 +356,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 					//using (new PerformanceTimer("GCode Timer", "Render"))
 					{
-						gCodeRenderer.Render(graphics2D, renderInfo);
+						gCodeRenderer?.Render(graphics2D, renderInfo);
 					}
 				}
 			}

--- a/Utilities/AuthenticationData.cs
+++ b/Utilities/AuthenticationData.cs
@@ -64,7 +64,6 @@ namespace MatterHackers.MatterControl
 			this.ActiveSessionUsername = null;
 			this.ActiveSessionEmail = null;
 			this.ActiveClientToken = null;
-			this.LastSessionUsername = null;
 
 			ApplicationController.Instance.ChangeCloudSyncStatus(userAuthenticated: false, reason: "Session Cleared".Localize());
 			SessionUpdateTrigger.CallEvents(null, null);


### PR DESCRIPTION
Don't clear the LastSessionUserName
It should only be used in the name field of the login screen and nowhere else.