### PR TITLE
Revise failing RaftEnabledPassedToSliceEngine test

### DIFF
--- a/Tests/MatterControl.AutomationTests/SliceSetingsTests.cs
+++ b/Tests/MatterControl.AutomationTests/SliceSetingsTests.cs
@@ -25,26 +25,37 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 				MatterControlUtilities.AddAndSelectPrinter(testRunner, "Airwolf 3D", "HD");
 
-				//Navigate to Local Library 
+				// Navigate to Local Library 
 				testRunner.ClickByName("Library Tab");
 				testRunner.NavigateToFolder("Local Library Row Item Collection");
 				testRunner.Wait(1);
+
 				testRunner.ClickByName("Row Item Calibration - Box");
+				testRunner.Wait(.2);
+
+				// Add the Calibration box to the queue and selects it
 				testRunner.ClickByName("Row Item Calibration - Box Print Button");
 				testRunner.Wait(1);
 
 				testRunner.ClickByName("Layer View Tab");
+				testRunner.Wait(.2);
 
 				testRunner.ClickByName("Bread Crumb Button Home", 1);
+				testRunner.Wait(.2);
 
 				MatterControlUtilities.SwitchToAdvancedSettings(testRunner);
+				testRunner.Wait(.2);
 
 				testRunner.ClickByName("Raft / Priming Tab", 1);
+				testRunner.Wait(.2);
 
 				testRunner.ClickByName("Create Raft Checkbox", 1);
 				testRunner.Wait(1.5);
+
 				testRunner.ClickByName("Generate Gcode Button", 1);
-				testRunner.Wait(5);
+				testRunner.Wait(2);
+
+				testRunner.WaitUntil(() => MatterControlUtilities.CompareExpectedSliceSettingValueWithActualVaue("enableRaft", "True"), 10);
 
 				//Call compare slice settings method here
 				Assert.IsTrue(MatterControlUtilities.CompareExpectedSliceSettingValueWithActualVaue("enableRaft", "True"));

--- a/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
+++ b/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
@@ -42,6 +42,7 @@ using MatterHackers.Agg.UI.Tests;
 using MatterHackers.GuiAutomation;
 using MatterHackers.MatterControl.DataStorage;
 using MatterHackers.MatterControl.PrintLibrary.Provider;
+using MatterHackers.MatterControl.SlicerConfiguration;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using NUnit.Framework;
@@ -183,34 +184,15 @@ namespace MatterHackers.MatterControl.Tests.Automation
 		{
 			string fullPath = TestContext.CurrentContext.ResolveProjectPath(4, "Tests", "temp", runName, "Test0", "data", "gcode");
 
-			foreach (string file in Directory.GetFiles(fullPath))
+			foreach (string iniPath in Directory.GetFiles(fullPath, "*.ini"))
 			{
-				if (file.Contains(".ini"))
+				var settings = PrinterSettingsLayer.LoadFromIni(iniPath);
+
+				string currentValue;
+
+				if (settings.TryGetValue(sliceSetting, out currentValue))
 				{
-
-					FileInfo f = new FileInfo(file);
-					string fullName = f.FullName;
-					string[] lines = File.ReadAllLines(fullName);
-					foreach (string line in lines)
-					{
-
-						if (line.Contains(sliceSetting))
-						{
-							line.Trim(' ');
-							string[] settingNameAndValue = line.Split('=');
-							string settingName = settingNameAndValue[0].Trim();
-							string settingValue = string.Empty;
-							if (settingNameAndValue.Length == 2)
-							{
-								settingValue = settingNameAndValue[1].Trim();
-							}
-
-							if (settingValue == expectedValue)
-							{
-								return true;
-							}
-						}
-					}
+					return currentValue.Trim() == expectedValue;
 				}
 			}
 
@@ -230,24 +212,26 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 		public static void AddAndSelectPrinter(AutomationRunner testRunner, string make, string model)
 		{
-			string manufacturer = make + " Menu Item";
-			string printer = model + " Menu Item";
-			string printerProfile = String.Format("{0} {1} Profile", make, model);
-
 			testRunner.ClickByName("Printers... Menu", 2);
+			testRunner.Wait(.2);
 
 			testRunner.ClickByName("Add New Printer... Menu Item", 2);
+			testRunner.Wait(.2);
 
 			testRunner.ClickByName("Connection Wizard Skip Sign In Button", 2);
+			testRunner.Wait(.2);
 
 			testRunner.ClickByName("Select Make", 2);
-
 			testRunner.Wait(.2);
+
 			testRunner.Type(make);
 			testRunner.Type("{Enter}");
 
 			testRunner.ClickByName("Select Model", 2);
-			testRunner.ClickByName(printer, 2);
+			testRunner.Wait(.2);
+
+			testRunner.ClickByName(model + " Menu Item", 2);
+			testRunner.Wait(.2);
 
 			testRunner.ClickByName("Save & Continue Button", 2);
 			testRunner.Wait(2);


### PR DESCRIPTION
- Add Wait calls after clicks
- After slicing, wait for expected result, up to 10 seconds
- Use utility functions for parsing .ini files
- Refactor AddAdSelectPrinter - remove unused variables, add Waits