### PR TITLE
Reduce the margin when on small touch screen

### DIFF
--- a/ApplicationView/TouchscreenTabView.cs
+++ b/ApplicationView/TouchscreenTabView.cs
@@ -110,7 +110,9 @@ namespace MatterHackers.MatterControl
 						return sliceSettingsWidget;
 				});
 
-			this.TabBar.AddChild(new HorizontalLine() { Margin = new BorderDouble(4, 10) });
+			BorderDouble horizontalSpacerMargin = new BorderDouble(4, 10);
+
+			this.TabBar.AddChild(new HorizontalLine() { Margin = horizontalSpacerMargin });
 
 			this.AddTab(
 				"Controls Tab",
@@ -120,7 +122,7 @@ namespace MatterHackers.MatterControl
 			// TODO: How to handle reload? Create .Reload on LazyTab? Create accessor for tabs["Controls Tab"].Reload()?
 			//manualControlsPage = new TabPage(, printerControlsLabel);
 
-			this.TabBar.AddChild(new HorizontalLine() { Margin = new BorderDouble(4, 10) });
+			this.TabBar.AddChild(new HorizontalLine() { Margin = horizontalSpacerMargin });
 
 			this.AddTab(
 				"Queue Tab",
@@ -142,7 +144,18 @@ namespace MatterHackers.MatterControl
 				() => new PrintHistoryWidget());
 			}
 
-			this.TabBar.AddChild(new HorizontalLine() { Margin = new BorderDouble(4, 10) });
+			this.TabBar.AddChild(new HorizontalLine() { Margin = horizontalSpacerMargin });
+
+			this.Load += (s, e) =>
+			{
+				if (!simpleMode && !TouchScreenIsTall)
+				{
+					foreach (GuiWidget horizontalLine in this.TabBar.Children<HorizontalLine>())
+					{
+						horizontalLine.Margin = new BorderDouble(4, 5);
+					}
+				}
+			};
 
 			// Make sure we have the right scroll position when we create this view
 			// This is not working well enough. So, I disabled it until it can be fixed.
@@ -219,6 +232,23 @@ namespace MatterHackers.MatterControl
 				};
 			}
 		}
+
+		public bool TouchScreenIsTall
+		{
+			get
+			{
+				foreach(GuiWidget topParent in this.Parents<SystemWindow>())
+				{
+					if(topParent.Height < 610)
+					{
+						return false;
+					}
+				}
+
+				return true;
+			}
+		}
+
 		private event EventHandler unregisterEvents;
 
 		public override void OnClosed(EventArgs e)


### PR DESCRIPTION
fixes: MatterHackers/MCCentral#748
T7 widget scaling does not match classic product and is no longer valid