### PR TITLE
Made the queue always populate on touch

### DIFF
--- a/ApplicationView/MainApplicationWidget.cs
+++ b/ApplicationView/MainApplicationWidget.cs
@@ -468,6 +468,9 @@ namespace MatterHackers.MatterControl
 
 						if (UserSettings.Instance.DisplayMode == ApplicationDisplayType.Touchscreen)
 						{
+							// make sure that on touchscreen (due to lazy tabs) we initialize our stating parts and queue
+							var temp = new LibraryProviderSQLite(null, null, null, null);
+							// now bulid the ui
 							globalInstance.MainView = new TouchscreenView();
 						}
 						else

--- a/ConfigurationPage/ApplicationSettings/ApplicationSettingsView.cs
+++ b/ConfigurationPage/ApplicationSettings/ApplicationSettingsView.cs
@@ -223,8 +223,8 @@ namespace MatterHackers.MatterControl.ConfigurationPage
 			optionsContainer.AddChild(interfaceOptionsDropList);
 			optionsContainer.Width = 200;
 
-			MenuItem responsizeOptionsDropDownItem = interfaceOptionsDropList.AddItem("Normal".Localize(), "responsive");
-			MenuItem touchscreenOptionsDropDownItem = interfaceOptionsDropList.AddItem("Touchscreen".Localize(), "touchscreen");
+			interfaceOptionsDropList.AddItem("Normal".Localize(), "responsive");
+			interfaceOptionsDropList.AddItem("Touchscreen".Localize(), "touchscreen");
 
 			List<string> acceptableUpdateFeedTypeValues = new List<string>() { "responsive", "touchscreen" };
 			string currentDisplayModeType = UserSettings.Instance.get(UserSettingsKey.ApplicationDisplayMode);
@@ -237,10 +237,10 @@ namespace MatterHackers.MatterControl.ConfigurationPage
 			interfaceOptionsDropList.SelectedValue = UserSettings.Instance.get(UserSettingsKey.ApplicationDisplayMode);
 			interfaceOptionsDropList.SelectionChanged += (sender, e) =>
 			{
-				string releaseCode = ((DropDownList)sender).SelectedValue;
-				if (releaseCode != UserSettings.Instance.get(UserSettingsKey.ApplicationDisplayMode))
+				string displayMode = ((DropDownList)sender).SelectedValue;
+				if (displayMode != UserSettings.Instance.get(UserSettingsKey.ApplicationDisplayMode))
 				{
-					UserSettings.Instance.set(UserSettingsKey.ApplicationDisplayMode, releaseCode);
+					UserSettings.Instance.set(UserSettingsKey.ApplicationDisplayMode, displayMode);
 					displayControlRestartButton.Visible = true;
 				}
 			};


### PR DESCRIPTION
Fixes: MatterHackers/MCCentral#769
Make sure we pre-load the queue and initialize the library selector prior to navigating to it.