### PR TITLE
Ensure changes are persisted to disk and synced to the cloud

### DIFF
--- a/SlicerConfiguration/SettingsControlSelectors.cs
+++ b/SlicerConfiguration/SettingsControlSelectors.cs
@@ -248,6 +248,9 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				}
 			}
 
+			// Ensure that activated or deactivated user overrides are always persisted to disk
+			activeSettings.Save();
+
 			UiThread.RunOnIdle(() =>
 			{
 				ApplicationController.Instance.ReloadAdvancedControlsPanel();


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#919
Deactivated user overrides are only persisted to disk via manual user edits