### PR TITLE
Adjust window width to ensure popout window -> Edit is targeted

### DIFF
--- a/Tests/MatterControl.AutomationTests/SqLiteLibraryProvider.cs
+++ b/Tests/MatterControl.AutomationTests/SqLiteLibraryProvider.cs
@@ -58,7 +58,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				return Task.FromResult(0);
 			};
 
-			await MatterControlUtilities.RunTest(testToRun, queueItemFolderToAdd: QueueTemplate.Three_Queue_Items);
+			await MatterControlUtilities.RunTest(testToRun, queueItemFolderToAdd: QueueTemplate.Three_Queue_Items, overrideWidth: 600);
 		}
 	}
 }


### PR DESCRIPTION
- MatterHackers/MCCentral#926
Revise LibraryQueueViewRefreshesOnAddItem to use popout rather than embedded editor