### PR TITLE
Prevent unexpected ActivePrinter changes

### DIFF
--- a/ActionBar/PrinterSelector.cs
+++ b/ActionBar/PrinterSelector.cs
@@ -58,7 +58,9 @@ namespace MatterHackers.MatterControl
 			this.SelectionChanged += (s, e) =>
 			{
 				string printerID = this.SelectedValue;
-				if (printerID == "new" || string.IsNullOrEmpty(printerID))
+				if (printerID == "new" 
+					|| string.IsNullOrEmpty(printerID) 
+					|| printerID == ActiveSliceSettings.Instance.ID)
 				{
 					// do nothing
 				}
@@ -106,28 +108,25 @@ namespace MatterHackers.MatterControl
 				this.mainControlText.Text = ActiveSliceSettings.Instance.GetValue(SettingsKey.printer_name);
 			}
 
-			this.AddItem(
-				StaticData.Instance.LoadIcon("icon_plus.png", 32, 32),
-				"Add New Printer...",
-				"new").Click += (s, e) =>
+			var menuItem = this.AddItem(StaticData.Instance.LoadIcon("icon_plus.png", 32, 32), "Add New Printer...", "new");
+			menuItem.Selectable = false;
+			menuItem.Click += (s, e) =>
+			{
+				if (AddPrinter != null)
 				{
-					if (AddPrinter != null)
+					if (PrinterConnectionAndCommunication.Instance.PrinterIsPrinting
+						|| PrinterConnectionAndCommunication.Instance.PrinterIsPaused)
 					{
-						if (PrinterConnectionAndCommunication.Instance.PrinterIsPrinting
-							|| PrinterConnectionAndCommunication.Instance.PrinterIsPaused)
-						{
-							UiThread.RunOnIdle(() =>
+						UiThread.RunOnIdle(() =>
 							StyledMessageBox.ShowMessageBox(null, "Please wait until the print has finished and try again.".Localize(), "Can't add printers while printing".Localize())
-							);
-							this.SelectedIndex = lastSelectedIndex;
-						}
-						else
-						{
-							this.SelectedIndex = lastSelectedIndex; 
-							UiThread.RunOnIdle(() => AddPrinter(this, null));
-						}
+						);
 					}
-				};
+					else
+					{
+						UiThread.RunOnIdle(() => AddPrinter(this, null));
+					}
+				}
+			};
 		}
 
 		private void SettingChanged(object sender, EventArgs e)

--- a/SlicerConfiguration/Settings/ActiveSliceSettings.cs
+++ b/SlicerConfiguration/Settings/ActiveSliceSettings.cs
@@ -60,7 +60,9 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			}
 			set
 			{
-				if (activeInstance != value)
+				// EmptyProfile instances may differ but IDs are always be the same. Only process if instance and IDs differ
+				if (activeInstance != value 
+					&& activeInstance?.ID != value.ID)
 				{
 					// If we have an active printer, run Disable otherwise skip to prevent empty ActiveSliceSettings due to null ActivePrinter
 					if (activeInstance != null)


### PR DESCRIPTION
- Prevent selection changes on "Add New Printer..." menu item
- Prevent ActivePrinterChanged on differing EmptyProfile instances
- Prevent calling SwitchToProfile on PrinterSelector change if already
  on instance
- Issue MatterHackers/MCCentral/#943
- Issue MatterHackers/MCCentral#908