### PR TITLE
Improve startup state initialization

### DIFF
--- a/ApplicationView/MainApplicationWidget.cs
+++ b/ApplicationView/MainApplicationWidget.cs
@@ -434,18 +434,9 @@ namespace MatterHackers.MatterControl
 			ApplicationClosed?.Invoke(null, null);
 		}
 
-		static void LoadUITheme()
+		static void LoadOemOrDefaultTheme()
 		{
-			// if the user setting has a theme color assume it is correct and use it right away
-			if (UserSettings.Instance != null)
-			{
-				var themeName = UserSettings.Instance.get(UserSettingsKey.ActiveThemeName);
-				if (!string.IsNullOrEmpty(themeName))
-				{
-					ActiveTheme.Instance = ActiveTheme.GetThemeColors(themeName);
-					return;
-				}
-			}
+			ActiveTheme.SuspendEvents();
 
 			// if not check for the oem color and use it if set
 			// else default to "Blue - Light"
@@ -456,9 +447,10 @@ namespace MatterHackers.MatterControl
 			}
 			else
 			{
-				UserSettings.Instance.set(UserSettingsKey.ActiveThemeName, oemColor);
 				ActiveTheme.Instance = ActiveTheme.GetThemeColors(oemColor);
 			}
+
+			ActiveTheme.ResumeEvents();
 		}
 
 		public static ApplicationController Instance
@@ -471,11 +463,10 @@ namespace MatterHackers.MatterControl
 					{
 						globalInstance = new ApplicationController();
 
-						// set the colors
-						LoadUITheme();
+						// Set the default theme colors
+						LoadOemOrDefaultTheme();
 
-						// We previously made a call to Reload, which fired the method twice due to it being in the static constructor. Accessing
-						// any property will run the static constructor and perform the Reload behavior without the overhead of duplicate calls
+						// Accessing any property on ProfileManager will run the static constructor and spin up the ProfileManager instance
 						bool na = ProfileManager.Instance.IsGuestProfile;
 
 						if (UserSettings.Instance.DisplayMode == ApplicationDisplayType.Touchscreen)

--- a/DataStorage/Classic/ClassicSqlitePrinterProfiles.cs
+++ b/DataStorage/Classic/ClassicSqlitePrinterProfiles.cs
@@ -108,8 +108,6 @@ namespace MatterHackers.MatterControl.DataStorage.ClassicDB
 				ProfileManager.Instance.LastProfileID = printer.Id.ToString();
 			}
 
-			printerSettings.UserLayer[SettingsKey.active_theme_name] = UserSettings.Instance.get(UserSettingsKey.ActiveThemeName);
-
 			// Import macros from the database
 			var allMacros =  Datastore.Instance.dbSQLite.Query<CustomCommands>("SELECT * FROM CustomCommands WHERE PrinterId = " + printer.Id);
 			printerSettings.Macros = allMacros.Select(macro => new GCodeMacro()

--- a/SettingsManagement/UserSettings.cs
+++ b/SettingsManagement/UserSettings.cs
@@ -11,7 +11,6 @@ namespace MatterHackers.MatterControl
 		public const string UpdateFeedType = nameof(UpdateFeedType);
 		public const string ApplicationDisplayMode = nameof(ApplicationDisplayMode);
 		public const string defaultRenderSetting = nameof(defaultRenderSetting);
-		public const string ActiveThemeName = nameof(ActiveThemeName);
 		public const string ThumbnailRenderingMode = nameof(ThumbnailRenderingMode);
 		public const string CredentialsInvalid = nameof(CredentialsInvalid);
 		public const string CredentialsInvalidReason = nameof(CredentialsInvalidReason);

--- a/SlicerConfiguration/Settings/PrinterSettings.cs
+++ b/SlicerConfiguration/Settings/PrinterSettings.cs
@@ -357,7 +357,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				{
 					// If we still have failed to recover a profile, create an empty profile with
 					// just enough data to delete the printer
-					printerSettings = ProfileManager.LoadEmptyProfile();
+					printerSettings = ProfileManager.EmptyProfile;
 					printerSettings.ID = printerInfo.ID;
 					printerSettings.UserLayer[SettingsKey.device_token] = printerInfo.DeviceToken;
 					printerSettings.Helpers.SetComPort(printerInfo.ComPort);
@@ -548,6 +548,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		}
 		[JsonIgnore]
 		public SettingsHelpers Helpers { get; set; }
+
 		[JsonIgnore]
 		public bool PrinterSelected => OemLayer?.Keys.Count > 0;
 
@@ -977,12 +978,6 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		public void SetValue(string settingsKey, string settingsValue, PrinterSettingsLayer layer = null)
 		{
 			var persistenceLayer = layer ?? UserLayer;
-
-			if(settingsKey == SettingsKey.active_theme_name)
-			{
-				// also save it to the user settings so we can load it first thing on startup before a profile is loaded.
-				UserSettings.Instance.set(UserSettingsKey.ActiveThemeName, settingsValue);
-			}
 
 			// If the setting exists and is set the requested value, exit without setting or saving
 			string existingValue;

--- a/SlicerConfiguration/Settings/PrinterSettings.cs
+++ b/SlicerConfiguration/Settings/PrinterSettings.cs
@@ -59,6 +59,8 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 		private static PrinterSettingsLayer baseLayerCache;
 
+		public static PrinterSettings Empty { get; }
+
 		public int DocumentVersion { get; set; } = LatestVersion;
 
 		public string ID { get; set; }
@@ -74,6 +76,12 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		internal PrinterSettingsLayer MaterialLayer { get; private set; }
 
 		public PrinterSettingsLayer StagedUserSettings { get; set; } = new PrinterSettingsLayer();
+
+		static PrinterSettings()
+		{
+			Empty = new PrinterSettings() { ID = "EmptyProfile" };
+			Empty.UserLayer[SettingsKey.printer_name] = "Printers...".Localize();
+		}
 
 		public PrinterSettings()
 		{
@@ -91,6 +99,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				}
 			}
 		}
+
 		public IEnumerable<GCodeMacro> ActionMacros()
 		{
 			foreach (var macro in Macros)
@@ -357,7 +366,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				{
 					// If we still have failed to recover a profile, create an empty profile with
 					// just enough data to delete the printer
-					printerSettings = ProfileManager.EmptyProfile;
+					printerSettings = PrinterSettings.Empty;
 					printerSettings.ID = printerInfo.ID;
 					printerSettings.UserLayer[SettingsKey.device_token] = printerInfo.DeviceToken;
 					printerSettings.Helpers.SetComPort(printerInfo.ComPort);

--- a/SlicerConfiguration/Settings/ProfileManager.cs
+++ b/SlicerConfiguration/Settings/ProfileManager.cs
@@ -29,20 +29,18 @@ either expressed or implied, of the FreeBSD Project.
 
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
+using MatterHackers.Agg;
 using MatterHackers.Agg.UI;
+using MatterHackers.MatterControl.DataStorage;
+using MatterHackers.MatterControl.SettingsManagement;
 using Newtonsoft.Json;
 
 namespace MatterHackers.MatterControl.SlicerConfiguration
 {
-	using System.Collections.ObjectModel;
-	using System.Threading.Tasks;
-	using Agg;
-	using DataStorage;
-	using Localizations;
-	using SettingsManagement;
-
 	public class ProfileManager
 	{
 		public static RootedObjectEventHandler ProfilesListChanged = new RootedObjectEventHandler();
@@ -66,14 +64,14 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 					if (MatterControlApplication.IsLoading)
 					{
-						ActiveSliceSettings.Instance = lastProfile ?? EmptyProfile;
+						ActiveSliceSettings.Instance = lastProfile ?? PrinterSettings.Empty;
 					}
 					else
 					{
 						UiThread.RunOnIdle(() =>
 						{
 							// Assign on the UI thread
-							ActiveSliceSettings.Instance = lastProfile ?? EmptyProfile;
+							ActiveSliceSettings.Instance = lastProfile ?? PrinterSettings.Empty;
 						});
 					}
 				}
@@ -90,9 +88,6 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 		static ProfileManager()
 		{
-			EmptyProfile = new PrinterSettings() { ID = "EmptyProfile" };
-			EmptyProfile.UserLayer[SettingsKey.printer_name] = "Printers...".Localize();
-
 			ActiveSliceSettings.SettingChanged.RegisterEvent(SettingsChanged, ref unregisterEvents);
 			ReloadActiveUser();
 		}
@@ -216,8 +211,6 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				return Profiles.Where(p => p.ID == profileID).FirstOrDefault();
 			}
 		}
-
-		public static PrinterSettings EmptyProfile { get; }
 
 		[JsonIgnore]
 		public string LastProfileID

--- a/SlicerConfiguration/Settings/SettingsHelpers.cs
+++ b/SlicerConfiguration/Settings/SettingsHelpers.cs
@@ -196,7 +196,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 			UiThread.RunOnIdle(() =>
 			{
-				ActiveSliceSettings.Instance = ProfileManager.LoadEmptyProfile();
+				ActiveSliceSettings.Instance = ProfileManager.EmptyProfile;
 
 				// Notify listeners of a ProfileListChange event due to this printers removal
 				ProfileManager.ProfilesListChanged.CallEvents(this, null);

--- a/SlicerConfiguration/Settings/SettingsHelpers.cs
+++ b/SlicerConfiguration/Settings/SettingsHelpers.cs
@@ -196,7 +196,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 			UiThread.RunOnIdle(() =>
 			{
-				ActiveSliceSettings.Instance = ProfileManager.EmptyProfile;
+				ActiveSliceSettings.Instance = PrinterSettings.Empty;
 
 				// Notify listeners of a ProfileListChange event due to this printers removal
 				ProfileManager.ProfilesListChanged.CallEvents(this, null);


### PR DESCRIPTION
- Use single instance for .EmptyProfile
- Remove ActiveSliceSettings static constructor, rely on ProfileManager
- Remove SettingsKey.active_theme_name and db usage
- Revise LoadUITheme to only load oem or default color theme
- Only assign ActiveSliceSettings.Instance during ProfileManager assign