### PR TITLE
Revise timings, extend wait before aborting ClickByName

### DIFF
--- a/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
+++ b/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
@@ -459,13 +459,14 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 		public static void SwitchToAdvancedSettings(AutomationRunner testRunner)
 		{
-			if (testRunner.NameExists("SettingsAndControls"))
+			if (testRunner.WaitForName("SettingsAndControls", .2))
 			{
-				testRunner.ClickByName("SettingsAndControls", 1);
+				testRunner.ClickByName("SettingsAndControls");
 				testRunner.Wait(.5);
 			}
-			testRunner.ClickByName("User Level Dropdown", 1);
-			testRunner.ClickByName("Advanced Menu Item", 1);
+
+			testRunner.ClickByName("User Level Dropdown");
+			testRunner.ClickByName("Advanced Menu Item");
 			testRunner.Wait(.5);
 		}
 	}


### PR DESCRIPTION
- Failure in ClearingCheckBoxClearsUserOverride due to slow env
- Advanced Menu Item not found
- Wait a few cycles for SettingsAndControls
- Default to new five second wait in ClickByName
- Issue MatterHackers/MCCentral#999
Investigate ClearingCheckBoxClearsUserOverride failure