### PR TITLE
Convert public EventHandler fields to events

### DIFF
--- a/ApplicationView/MainApplicationWidget.cs
+++ b/ApplicationView/MainApplicationWidget.cs
@@ -296,8 +296,6 @@ namespace MatterHackers.MatterControl
 
 				return monoSpacedTypeFace;
 			}
-
-			private set { }
 		}
 
 		/// <summary>

--- a/ControlElements/RegisteredCreators.cs
+++ b/ControlElements/RegisteredCreators.cs
@@ -45,19 +45,20 @@ namespace MatterHackers.MatterControl.CreatorPlugins
 		public delegate void UnlockRegisterFunction(EventHandler functionToCallOnEvent, ref EventHandler functionThatWillBeCalledToUnregisterEvent);
 
 		public UnlockRegisterFunction unlockRegisterFunction;
-		public EventHandler functionToLaunchCreator;
+		public Action Show;
 		public string iconPath;
 		public string description;
 		public bool paidAddOnFlag;
 
-		public CreatorInformation(EventHandler functionToLaunchCreator,
+		public CreatorInformation(
+			Action showFunction,
 			string iconPath, string description,
 			bool paidAddOnFlag = false,
 			UnlockFunction unlockFunction = null,
 			PermissionFunction permissionFunction = null,
 			UnlockRegisterFunction unlockRegisterFunction = null)
 		{
-			this.functionToLaunchCreator = functionToLaunchCreator;
+			this.Show = showFunction;
 			this.iconPath = iconPath;
 			this.description = description;
 			this.paidAddOnFlag = paidAddOnFlag;

--- a/CustomWidgets/PluginChooserWindow.cs
+++ b/CustomWidgets/PluginChooserWindow.cs
@@ -259,13 +259,11 @@ namespace MatterHackers.MatterControl.CreatorPlugins
 		private void CloseOnIdle(object state)
 		{
 			Close();
-			CreatorInformation callCorrectFunctionHold = state as CreatorInformation;
-			if (callCorrectFunctionHold != null)
+
+			CreatorInformation creatorInfo = state as CreatorInformation;
+			if (creatorInfo != null)
 			{
-				UiThread.RunOnIdle(() =>
-				{
-					callCorrectFunctionHold.functionToLaunchCreator(null, null);
-				});
+				UiThread.RunOnIdle(creatorInfo.Show);
 			}
 		}
 	}

--- a/PartPreviewWindow/ViewGcodeWidget.cs
+++ b/PartPreviewWindow/ViewGcodeWidget.cs
@@ -45,7 +45,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 {
 	public class ViewGcodeWidget : GuiWidget
 	{
-		public EventHandler DoneLoading;
+		public event EventHandler DoneLoading;
 
 		public ProgressChangedEventHandler LoadingProgressChanged;
 

--- a/Tests/MatterControl.AutomationTests/SliceSetingsTests.cs
+++ b/Tests/MatterControl.AutomationTests/SliceSetingsTests.cs
@@ -121,7 +121,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			testRunner.Wait(.1);
 		}
 
-		[Test, Apartment(ApartmentState.STA)]
+		[Test, Apartment(ApartmentState.STA) /* Test will fail if screen size is and "HeatBeforeHoming" falls below the fold */]
 		public async Task ClearingCheckBoxClearsUserOverride()
 		{
 			AutomationTest testToRun = (testRunner) =>

--- a/TextCreator/TextCreator.cs
+++ b/TextCreator/TextCreator.cs
@@ -37,17 +37,14 @@ namespace MatterHackers.MatterControl.Plugins.TextCreator
 {
 	public class TextCreatorPlugin : MatterControlPlugin
 	{
-		public TextCreatorPlugin()
-		{
-		}
-
-		private GuiWidget mainApplication;
-
 		public override void Initialize(GuiWidget application)
 		{
-			CreatorInformation information = new CreatorInformation(LaunchNewTextCreator, "TC_32x32.png", "Text Creator".Localize());
+			var information = new CreatorInformation(
+				() => new TextCreatorMainWindow(), 
+				"TC_32x32.png", 
+				"Text Creator".Localize());
+
 			RegisteredCreators.Instance.RegisterLaunchFunction(information);
-			mainApplication = application;
 		}
 
 		public override string GetPluginInfoJSon()
@@ -59,11 +56,6 @@ namespace MatterHackers.MatterControl.Plugins.TextCreator
 				"\"Developer\": \"MatterHackers, Inc.\"," +
 				"\"URL\": \"https://www.matterhackers.com\"" +
 				"}";
-		}
-
-		public void LaunchNewTextCreator(object sender, EventArgs e)
-		{
-			TextCreatorMainWindow mainWindow = new TextCreatorMainWindow();
 		}
 	}
 }


### PR DESCRIPTION
- Use Action instead of EventHandler
- Convert FunctionToCallOnSave to instance member named RefreshMacros
- Remove empty private setter
- Rename functionToLaunchCreator to Show()
- Issue MatterHackers/MCCentral#1118
Add "event" keyword to all public EventHandler fields