### PR TITLE
Change EnsureSamplePartsExist to call synchronous .AddItem() signature

### DIFF
--- a/AboutPage/AboutWidget.cs
+++ b/AboutPage/AboutWidget.cs
@@ -211,7 +211,6 @@ namespace MatterHackers.MatterControl
 
 			foreach (string file in Directory.EnumerateFiles(path, "*.*"))
 			{
-				bool loadingCalibrationParts = (LibraryProviderSQLite.PreloadingCalibrationFiles && Path.GetDirectoryName(file).Contains("calibration-parts"));
 				bool fileIsNew = new FileInfo(file).LastAccessTime > DateTime.Now.AddDays(-daysOldToDelete);
 
 				switch (Path.GetExtension(file).ToUpper())
@@ -222,7 +221,7 @@ namespace MatterHackers.MatterControl
 					case ".PNG":
 					case ".TGA":
 						if (referencedFilePaths.Contains(file)
-							|| loadingCalibrationParts
+							|| LibraryProviderSQLite.PreloadingCalibrationFiles
 							|| fileIsNew)
 						{
 							contentCount++;


### PR DESCRIPTION
- Use streams instead of file paths
- Copy directly from StaticData stream to Library
- Issue MatterHackers/MCCentral#993
IndexOutOfRange exception during initial run of MatterControl Touch