### PR TITLE
Guard for null reference

### DIFF
--- a/ApplicationView/MenuRow/MenuOptionFile.cs
+++ b/ApplicationView/MenuRow/MenuOptionFile.cs
@@ -31,9 +31,10 @@ namespace MatterHackers.MatterControl
 		{
 			return new List<MenuItemAction>
 			{
-				// TODO: Helper while building printing window prototype... remove once finalized
+#if DEBUG
 				new MenuItemAction("Printing Window...".Localize(), () => PrintingWindow.Show()),
 				new MenuItemAction("------------------------", null),
+#endif
 				new MenuItemAction("Add Printer".Localize(), AddPrinter_Click),
 				new MenuItemAction("Import Printer".Localize(), ImportPrinter),
 				new MenuItemAction("Add File To Queue".Localize(), importFile_Click),

--- a/SlicerConfiguration/Settings/ProfileManager.cs
+++ b/SlicerConfiguration/Settings/ProfileManager.cs
@@ -511,7 +511,8 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 					// The collector specifically returns null to ensure LoadCacheable skips writing the
 					// result to the cache. After this result is returned, it will attempt to load from
 					// the local cache if the collector yielded no result
-					if(File.Exists(cachePath))
+					if(File.Exists(cachePath) 
+						|| ApplicationController.DownloadPublicProfileAsync == null)
 					{
 						return null;
 					}


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#1267
Null reference exception in LoadCacheable when running automation tests on vanilla MatterControl