### PR TITLE
Don't let the selection change while printing.

### DIFF
--- a/Queue/QueueDataView.cs
+++ b/Queue/QueueDataView.cs
@@ -327,7 +327,8 @@ namespace MatterHackers.MatterControl.PrintQueue
 		{
 			// we can only change the queue selection when we are not printing
 			if(PrinterConnectionAndCommunication.Instance.PrinterIsPrinting 
-				|| PrinterConnectionAndCommunication.Instance.PrinterIsPaused)
+				|| PrinterConnectionAndCommunication.Instance.PrinterIsPaused
+				|| PrinterConnectionAndCommunication.Instance.CommunicationState == PrinterConnectionAndCommunication.CommunicationStates.PreparingToPrint)
 			{
 				return;
 			}

--- a/Queue/QueueDataView.cs
+++ b/Queue/QueueDataView.cs
@@ -325,6 +325,13 @@ namespace MatterHackers.MatterControl.PrintQueue
 
 		private void itemHolder_MouseDownInBounds(object sender, MouseEventArgs mouseEvent)
 		{
+			// we can only change the queue selection when we are not printing
+			if(PrinterConnectionAndCommunication.Instance.PrinterIsPrinting 
+				|| PrinterConnectionAndCommunication.Instance.PrinterIsPaused)
+			{
+				return;
+			}
+
 			// Hard-coded processing rule to avoid changing the SelectedIndex when clicks occur
 			// with the thumbnail region - aka the first 55 pixels
 			if (!EditMode && mouseEvent.X < 56) return;


### PR DESCRIPTION
Fixes: MatterHackers/MatterControl#2008
Clicking "Done" removes the part highlighted in the queue, not necessarily the one that was just printed.
