### PR TITLE
Fix list item names, use DoubleClickByName to automate library items

### DIFF
--- a/ApplicationView/AdvancedControlsPanel.cs
+++ b/ApplicationView/AdvancedControlsPanel.cs
@@ -104,8 +104,14 @@ namespace MatterHackers.MatterControl
 			RGBA_Bytes unselectedTextColor = ActiveTheme.Instance.TabLabelUnselected;
 
 			var libraryTabPage = new TabPage(new PrintLibraryWidget(), "Library".Localize().ToUpper());
-			advancedControls.AddTab(new SimpleTextTabWidget(libraryTabPage, "Library Tab", 15,
-					ActiveTheme.Instance.TabLabelSelected, new RGBA_Bytes(), unselectedTextColor, new RGBA_Bytes()));
+			advancedControls.AddTab(new SimpleTextTabWidget(
+				libraryTabPage, 
+				"Library Tab", 
+				15,
+				ActiveTheme.Instance.TabLabelSelected, 
+				new RGBA_Bytes(), 
+				unselectedTextColor, 
+				new RGBA_Bytes()));
 
 			if (ActiveSliceSettings.Instance.PrinterSelected)
 			{

--- a/Library/Widgets/ListView/ListView.cs
+++ b/Library/Widgets/ListView/ListView.cs
@@ -160,43 +160,26 @@ if (hasID
 			int width = itemsContentView.ThumbWidth;
 			int height = itemsContentView.ThumbHeight;
 
-			// TODO: Disabled to consider upfolder on breadcrumb bar
-			if (sourceContainer.Parent != null && false)
-			{
-				var icon = LibraryProviderHelpers.LoadInvertIcon("FileDialog", "up_folder.png");
-				icon = ResizeCanvas(icon, width, height);
-
-				// Up folder item
-				var item = new DynamicContainerLink("..", icon, null);
-				var listViewItem = new ListViewItem(item, this)
-				{
-					Text = "..",
-				};
-
-				listViewItem.DoubleClick += listViewItem_DoubleClick;
-
-				items.Add(listViewItem);
-				itemsContentView.AddItem(listViewItem);
-			}
-
 			// Folder items
 			foreach (var childContainer in sourceContainer.ChildContainers.Where(c => c.IsVisible))
 			{
-					var listViewItem = new ListViewItem(childContainer, this);
-					listViewItem.DoubleClick += listViewItem_DoubleClick;
+				var listViewItem = new ListViewItem(childContainer, this);
+				listViewItem.DoubleClick += listViewItem_DoubleClick;
+				items.Add(listViewItem);
 
-					items.Add(listViewItem);
-					itemsContentView.AddItem(listViewItem);
-				}
+				itemsContentView.AddItem(listViewItem);
+				listViewItem.ViewWidget.Name = childContainer.Name + " Row Item Collection";
+			}
 
 			// List items
 			foreach (var item in sourceContainer.Items.Where(i => i.IsVisible))
 			{
 				var listViewItem = new ListViewItem(item, this);
 				listViewItem.DoubleClick += listViewItem_DoubleClick;
-
 				items.Add(listViewItem);
+
 				itemsContentView.AddItem(listViewItem);
+				listViewItem.ViewWidget.Name = "Row Item " + item.Name;
 			}
 		}
 

--- a/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
+++ b/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
@@ -357,10 +357,9 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 		public static void NavigateToFolder(this AutomationRunner testRunner, string libraryRowItemName)
 		{
-			SearchRegion libraryRowItemRegion = testRunner.GetRegionByName(libraryRowItemName, 3);
 			testRunner.ClickByName(libraryRowItemName);
 			testRunner.Delay(.5);
-			testRunner.ClickByName("Open Collection", searchRegion: libraryRowItemRegion);
+			testRunner.DoubleClickByName(libraryRowItemName);
 			testRunner.Delay(.5);
 		}
 


### PR DESCRIPTION
- Remove unused 'up folder' list view item code