### PR TITLE
More tests updated and passing

### DIFF
--- a/ActionBar/PrintActionRow.cs
+++ b/ActionBar/PrintActionRow.cs
@@ -378,30 +378,11 @@ namespace MatterHackers.MatterControl.ActionBar
 			WizardWindow.Show<SetupWizardTroubleshooting>("TroubleShooting", "Trouble Shooting");
 		}
 
-		string unsavedChangesCaption = "Unsaved Changes";
-		string unsavedChangesMessage = "You have unsaved changes to your part. Are you sure you want to start this print?";
 		private void onStartButton_Click(object sender, EventArgs mouseEvent)
 		{
 			UiThread.RunOnIdle(() =>
 			{
-				var view3D = ApplicationController.Instance.ActiveView3DWidget;
-
-				if (view3D != null && false)
-					//&& view3D.ShouldBeSaved)
-				{
-					StyledMessageBox.ShowMessageBox((bool startPrint) =>
-					{
-						if (startPrint)
-						{
-							PrinterConnectionAndCommunication.Instance.PrintActivePartIfPossible();
-						}
-
-					}, unsavedChangesMessage, unsavedChangesCaption, StyledMessageBox.MessageType.YES_NO, "Start Print", "Cancel");
-				}
-				else
-				{
-					PrinterConnectionAndCommunication.Instance.PrintActivePartIfPossible();
-				}
+				PrinterConnectionAndCommunication.Instance.PrintActivePartIfPossible();
 			});
 		}
 

--- a/ActionBar/PrintActionRow.cs
+++ b/ActionBar/PrintActionRow.cs
@@ -322,6 +322,7 @@ namespace MatterHackers.MatterControl.ActionBar
 						break;
 
 					case PrinterConnectionAndCommunication.CommunicationStates.FinishedPrint:
+						this.activePrintButtons.Add(startButton);
 						EnableActiveButtons();
 						break;
 

--- a/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/PartPreviewWindow/View3D/View3DWidget.cs
@@ -2371,6 +2371,15 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			Invalidate();
 		}
 
+		// Before printing persist any changes to disk
+		internal void PersistPlateIfNeeded()
+		{
+			if (partHasBeenEdited)
+			{
+				SaveChanges(null);
+			}
+		}
+
 		public void UnlockEditControls()
 		{
 			buttonRightPanelDisabledCover.Visible = false;

--- a/PrinterCommunication/PrinterConnectionAndCommunication.cs
+++ b/PrinterCommunication/PrinterConnectionAndCommunication.cs
@@ -1341,6 +1341,9 @@ namespace MatterHackers.MatterControl.PrinterCommunication
 					}
 				}
 
+				// Save any pending changes before starting the print
+				ApplicationController.Instance.ActiveView3DWidget.PersistPlateIfNeeded();
+
 				if (ActivePrintItem != null)
 				{
 					string pathAndFile = ActivePrintItem.FileLocation;

--- a/PrinterEmulator/Emulator.cs
+++ b/PrinterEmulator/Emulator.cs
@@ -239,7 +239,7 @@ namespace MatterHackers.PrinterEmulator
 			shutDown = true;
 		}
 
-		public void SimulateRebot()
+		public void SimulateReboot()
 		{
 			commandIndex = 1;
 			recievedCount = 0;

--- a/Tests/MatterControl.AutomationTests/HardwareLevelingUITests.cs
+++ b/Tests/MatterControl.AutomationTests/HardwareLevelingUITests.cs
@@ -21,7 +21,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				//Add printer that has hardware leveling
 				MatterControlUtilities.AddAndSelectPrinter(testRunner, "Airwolf 3D", "HD");
 
-				MatterControlUtilities.SwitchToAdvancedSettings(testRunner);
+				testRunner.SwitchToAdvancedSliceSettings();
 
 				testRunner.ClickByName("Printer Tab", 1);
 				testRunner.Delay(1);
@@ -80,7 +80,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					Assert.IsTrue(!testRunner.WaitForName("Finish Setup Button", 1), "Finish Setup hidden");
 
 					// reset to defaults and make sure print leveling is cleared
-					MatterControlUtilities.SwitchToAdvancedSettings(testRunner);
+					testRunner.SwitchToAdvancedSliceSettings();
 
 					testRunner.ClickByName("Slice Settings Options Menu", 1);
 					testRunner.ClickByName("Reset to Defaults Menu Item", 1);

--- a/Tests/MatterControl.AutomationTests/HardwareLevelingUITests.cs
+++ b/Tests/MatterControl.AutomationTests/HardwareLevelingUITests.cs
@@ -55,7 +55,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				testRunner.CloseSignInAndPrinterSelect();
 
 				// make a jump start printer
-				using (var emulatorProcess = testRunner.LaunchAndConnectToPrinterEmulator("JumpStart", "V1", runSlow: false))
+				using (var emulator = testRunner.LaunchAndConnectToPrinterEmulator("JumpStart", "V1", runSlow: false))
 				{
 					// make sure it is showing the correct button
 					Assert.IsTrue(!testRunner.WaitForName("Start Print Button", .5), "Start Print hidden");

--- a/Tests/MatterControl.AutomationTests/LocalLibraryTests.cs
+++ b/Tests/MatterControl.AutomationTests/LocalLibraryTests.cs
@@ -510,7 +510,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			{
 				testRunner.WaitForName("Cancel Wizard Button", 1);
 
-				using (var emulatorDisposable = testRunner.LaunchAndConnectToPrinterEmulator())
+				using (var emulator = testRunner.LaunchAndConnectToPrinterEmulator())
 				{
 					// Navigate to Local Library
 					testRunner.ClickByName("Library Tab");

--- a/Tests/MatterControl.AutomationTests/PrinterDropDownTests.cs
+++ b/Tests/MatterControl.AutomationTests/PrinterDropDownTests.cs
@@ -21,7 +21,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 				MatterControlUtilities.AddAndSelectPrinter(testRunner, "Airwolf 3D", "HD");
 
-				MatterControlUtilities.SwitchToAdvancedSettings(testRunner);
+				testRunner.SwitchToAdvancedSliceSettings();
 
 				testRunner.ClickByName("Printer Tab", 1);
 

--- a/Tests/MatterControl.AutomationTests/PrintingTests.cs
+++ b/Tests/MatterControl.AutomationTests/PrintingTests.cs
@@ -27,9 +27,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				{
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
-					testRunner.ClickByName("Slice Settings Tab");
-
-					MatterControlUtilities.SwitchToAdvancedSettings(testRunner);
+					testRunner.SwitchToAdvancedSliceSettings();
 
 					testRunner.ClickByName("Printer Tab", 1);
 					testRunner.ClickByName("Custom G-Code Tab", 1);
@@ -80,7 +78,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					// close the finish setup window
 					testRunner.ClickByName("Cancel Button");
 
-					MatterControlUtilities.SwitchToAdvancedSettings(testRunner);
+					testRunner.SwitchToAdvancedSliceSettings();
 
 					testRunner.ClickByName("General Tab", 1);
 					testRunner.ClickByName("Single Print Tab", 1);
@@ -233,7 +231,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					var emulator = emulatorDisposable as Emulator;
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
-					MatterControlUtilities.SwitchToAdvancedSettings(testRunner);
+					testRunner.SwitchToAdvancedSliceSettings();
 
 					testRunner.ClickByName("General Tab", 1);
 					testRunner.ClickByName("Single Print Tab", 1);

--- a/Tests/MatterControl.AutomationTests/PrintingTests.cs
+++ b/Tests/MatterControl.AutomationTests/PrintingTests.cs
@@ -23,7 +23,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			{
 				testRunner.WaitForName("Cancel Wizard Button", 1);
 
-				using (var emulatorDisposable = testRunner.LaunchAndConnectToPrinterEmulator())
+				using (var emulator = testRunner.LaunchAndConnectToPrinterEmulator())
 				{
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
@@ -65,9 +65,8 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			{
 				testRunner.WaitForName("Cancel Wizard Button", 1);
 
-				using (var emulatorDisposable = testRunner.LaunchAndConnectToPrinterEmulator("Pulse", "A-134"))
+				using (var emulator = testRunner.LaunchAndConnectToPrinterEmulator("Pulse", "A-134"))
 				{
-					var emulator = emulatorDisposable as Emulator;
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
 					// close the finish setup window
@@ -221,9 +220,8 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			{
 				testRunner.WaitForName("Cancel Wizard Button", 1);
 
-				using (var emulatorDisposable = testRunner.LaunchAndConnectToPrinterEmulator())
+				using (var emulator = testRunner.LaunchAndConnectToPrinterEmulator())
 				{
-					var emulator = emulatorDisposable as Emulator;
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
 					testRunner.SwitchToAdvancedSliceSettings();
@@ -276,7 +274,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 				testRunner.WaitForName("Cancel Wizard Button", 1);
 
-				using (var emulatorDisposable = testRunner.LaunchAndConnectToPrinterEmulator())
+				using (var emulator = testRunner.LaunchAndConnectToPrinterEmulator())
 				{
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
@@ -371,7 +369,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				ExtrusionMultiplyerStream.ExtrusionRatio = initialExtrusionRate;
 
 				// Then validate that they are picked up
-				using (var emulatorDisposable = testRunner.LaunchAndConnectToPrinterEmulator())
+				using (var emulator = testRunner.LaunchAndConnectToPrinterEmulator())
 				{
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
@@ -451,10 +449,8 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			{
 				testRunner.WaitForName("Cancel Wizard Button", 1);
 
-				using (var emulatorDisposable = testRunner.LaunchAndConnectToPrinterEmulator())
+				using (var emulator = testRunner.LaunchAndConnectToPrinterEmulator())
 				{
-					Emulator emulator = (Emulator)emulatorDisposable;
-
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
 					testRunner.ClickByName("Queue... Menu", 2);
@@ -499,10 +495,8 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			{
 				testRunner.WaitForName("Cancel Wizard Button", 1);
 
-				using (var emulatorDisposable = testRunner.LaunchAndConnectToPrinterEmulator())
+				using (var emulator = testRunner.LaunchAndConnectToPrinterEmulator())
 				{
-					Emulator emulator = (Emulator)emulatorDisposable;
-
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
 					testRunner.ClickByName("Start Print Button", 1);

--- a/Tests/MatterControl.AutomationTests/PrintingTests.cs
+++ b/Tests/MatterControl.AutomationTests/PrintingTests.cs
@@ -19,7 +19,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 		[Test, Apartment(ApartmentState.STA)]
 		public async Task CompletingPrintTurnsoffHeat()
 		{
-			AutomationTest testToRun = (testRunner) =>
+			await MatterControlUtilities.RunTest((testRunner) =>
 			{
 				testRunner.WaitForName("Cancel Wizard Button", 1);
 
@@ -53,9 +53,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				}
 
 				return Task.FromResult(0);
-			};
-
-			await MatterControlUtilities.RunTest(testToRun, maxTimeToRun: 200);
+			}, maxTimeToRun: 200);
 		}
 
 		[Test, Apartment(ApartmentState.STA)]

--- a/Tests/MatterControl.AutomationTests/PrintingTests.cs
+++ b/Tests/MatterControl.AutomationTests/PrintingTests.cs
@@ -59,7 +59,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 		[Test, Apartment(ApartmentState.STA)]
 		public async Task PulseRequiresLevelingAndLevelingWorks()
 		{
-			AutomationTest testToRun = (testRunner) =>
+			await MatterControlUtilities.RunTest((testRunner) =>
 			{
 				testRunner.WaitForName("Cancel Wizard Button", 1);
 
@@ -98,22 +98,19 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					testRunner.Delay(1);
 
 					// print a part
+					testRunner.AddDefaultFileToBedPlate();
 					testRunner.ClickByName("Start Print Button", 1);
 
-					// assert the leveling is working
-					testRunner.WaitForName("Yes Button", 200);
-					// close the pause dialog pop-up
-					testRunner.ClickByName("Yes Button");
+					testRunner.Delay(() => emulator.ZPosition > 5, 3);
 
+					// assert the leveling is working
 					Assert.Greater(emulator.ZPosition, 5);
 
 					testRunner.ClickByName("Cancel Print Button", 1);
 				}
 
 				return Task.FromResult(0);
-			};
-
-			await MatterControlUtilities.RunTest(testToRun, maxTimeToRun: 300);
+			}, maxTimeToRun: 90);
 		}
 
 		[Test, Apartment(ApartmentState.STA)]

--- a/Tests/MatterControl.AutomationTests/PrintingTests.cs
+++ b/Tests/MatterControl.AutomationTests/PrintingTests.cs
@@ -36,12 +36,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					testRunner.Type("{BACKSPACE}");
 					testRunner.Type("G28");
 
-					testRunner.ClickByName("Library Tab");
-					testRunner.NavigateToFolder("Calibration Parts Row Item Collection");
-					testRunner.ClickByName("Row Item Calibration - Box.stl", 1);
-
-					testRunner.ClickByName("Print Library Overflow Menu", 1);
-					testRunner.ClickByName("Add to Plate MenuItem");
+					testRunner.AddDefaultFileToBedPlate();
 
 					testRunner.ClickByName("Start Print Button", 1);
 

--- a/Tests/MatterControl.AutomationTests/PrintingTests.cs
+++ b/Tests/MatterControl.AutomationTests/PrintingTests.cs
@@ -438,7 +438,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 		[Test, Apartment(ApartmentState.STA)]
 		public async Task CancelingSdCardPrintLeavesHeatAndFanOn()
 		{
-			AutomationTest testToRun = (testRunner) =>
+			await MatterControlUtilities.RunTest((testRunner) =>
 			{
 				testRunner.WaitForName("Cancel Wizard Button", 1);
 
@@ -476,15 +476,13 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				}
 
 				return Task.FromResult(0);
-			};
-
-			await MatterControlUtilities.RunTest(testToRun, overrideHeight: 900, maxTimeToRun: 990);
+			}, overrideHeight: 900, maxTimeToRun: 90);
 		}
 
 		[Test, Apartment(ApartmentState.STA)]
 		public async Task CancelingNormalPrintTurnsHeatAndFanOff()
 		{
-			AutomationTest testToRun = (testRunner) =>
+			await MatterControlUtilities.RunTest((testRunner) =>
 			{
 				testRunner.WaitForName("Cancel Wizard Button", 1);
 
@@ -492,6 +490,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				{
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
+					testRunner.AddDefaultFileToBedPlate();
 					testRunner.ClickByName("Start Print Button", 1);
 					testRunner.Delay(5);
 
@@ -511,9 +510,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				}
 
 				return Task.FromResult(0);
-			};
-
-			await MatterControlUtilities.RunTest(testToRun, overrideHeight: 900, maxTimeToRun: 990);
+			}, overrideHeight: 900, maxTimeToRun: 90);
 		}
 
 		private static void ConfirmExpectedSpeeds(AutomationRunner testRunner, double targetExtrusionRate, double targetFeedRate)

--- a/Tests/MatterControl.AutomationTests/PrintingTests.cs
+++ b/Tests/MatterControl.AutomationTests/PrintingTests.cs
@@ -41,7 +41,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					testRunner.ClickByName("Start Print Button", 1);
 
 					// Wait for print to finish
-					testRunner.Delay(() => PrinterConnectionAndCommunication.Instance.CommunicationState == PrinterConnectionAndCommunication.CommunicationStates.FinishedPrint, 120);
+					testRunner.WaitForPrintFinished();
 
 					// Wait for expected temp
 					testRunner.Delay(() => PrinterConnectionAndCommunication.Instance.GetActualExtruderTemperature(0) <= 0, 5);
@@ -211,7 +211,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 		[Test, Apartment(ApartmentState.STA)]
 		public async Task PrinterRequestsResumeWorkingAsExpected()
 		{
-			AutomationTest testToRun = (testRunner) =>
+			await MatterControlUtilities.RunTest((testRunner) =>
 			{
 				testRunner.WaitForName("Cancel Wizard Button", 1);
 
@@ -230,6 +230,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					testRunner.ClickByName("Controls Tab");
 
 					// print a part
+					testRunner.AddDefaultFileToBedPlate();
 					testRunner.ClickByName("Start Print Button", 1);
 
 					// turn on line error simulation
@@ -239,20 +240,17 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					testRunner.ClickByName("No Button", 200);
 
 					// simulate board reboot
-					emulator.SimulateRebot();
+					emulator.SimulateReboot();
 
 					// close the pause dialog pop-up (resume)
 					testRunner.ClickByName("No Button", 200);
 
 					// Wait for done
-					testRunner.WaitForName("Done Button", 60);
-					testRunner.WaitForName("Print Again Button", 1);
+					testRunner.WaitForPrintFinished();
 				}
 
 				return Task.FromResult(0);
-			};
-
-			await MatterControlUtilities.RunTest(testToRun, maxTimeToRun: 300);
+			}, maxTimeToRun: 90);
 		}
 
 		private EventHandler unregisterEvents;

--- a/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
+++ b/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
@@ -73,7 +73,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			{
 				testRunner.WaitForName("Cancel Wizard Button", 1);
 
-				using (var emulatorDisposable = testRunner.LaunchAndConnectToPrinterEmulator())
+				using (var emulator = testRunner.LaunchAndConnectToPrinterEmulator())
 				{
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
@@ -113,7 +113,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			{
 				testRunner.WaitForName("Cancel Wizard Button", 1);
 
-				using (var emulatorDisposable = testRunner.LaunchAndConnectToPrinterEmulator())
+				using (var emulator = testRunner.LaunchAndConnectToPrinterEmulator())
 				{
 					ActiveSliceSettings.Instance.SetValue(SettingsKey.cancel_gcode, "G28 ; Cancel GCode");
 

--- a/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
+++ b/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
@@ -43,7 +43,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				testRunner.ClickByName("Bread Crumb Button Home", 1);
 				testRunner.Delay(.2);
 
-				MatterControlUtilities.SwitchToAdvancedSettings(testRunner);
+				testRunner.SwitchToAdvancedSliceSettings();
 				testRunner.Delay(.2);
 
 				testRunner.ClickByName("Raft / Priming Tab", 1);
@@ -77,7 +77,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				{
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
-					MatterControlUtilities.SwitchToAdvancedSettings(testRunner);
+					testRunner.SwitchToAdvancedSliceSettings();
 
 					testRunner.ClickByName("General Tab", 1);
 					testRunner.ClickByName("Single Print Tab", 1);
@@ -119,7 +119,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
-					MatterControlUtilities.SwitchToAdvancedSettings(testRunner);
+					testRunner.SwitchToAdvancedSliceSettings();
 
 					testRunner.ClickByName("General Tab", 1);
 					testRunner.ClickByName("Single Print Tab", 1);
@@ -191,7 +191,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				MatterControlUtilities.AddAndSelectPrinter(testRunner, "Airwolf 3D", "HD");
 
 				//Navigate to Local Library 
-				MatterControlUtilities.SwitchToAdvancedSettings(testRunner);
+				testRunner.SwitchToAdvancedSliceSettings();
 
 				testRunner.ClickByName("Printer Tab", 1);
 				testRunner.ClickByName("Features Tab", 1);
@@ -230,7 +230,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				MatterControlUtilities.AddAndSelectPrinter(testRunner, "Airwolf 3D", "HD");
 
 				//Navigate to Local Library 
-				MatterControlUtilities.SwitchToAdvancedSettings(testRunner);
+				testRunner.SwitchToAdvancedSliceSettings();
 
 				testRunner.ClickByName("General Tab", 1);
 				testRunner.ClickByName("Layers / Surface Tab", 1);
@@ -308,7 +308,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				MatterControlUtilities.AddAndSelectPrinter(testRunner, "Airwolf 3D", "HD");
 
 				//Navigate to Settings Tab and make sure Bed Temp Text box is visible 
-				MatterControlUtilities.SwitchToAdvancedSettings(testRunner);
+				testRunner.SwitchToAdvancedSliceSettings();
 
 				testRunner.ClickByName("Filament Tab", 1);
 				testRunner.ClickByName("Temperatures Tab", 1);
@@ -351,8 +351,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 				// Add Guest printers
 				MatterControlUtilities.AddAndSelectPrinter(testRunner, "Airwolf 3D", "HD");
-				MatterControlUtilities.SwitchToAdvancedSettings(testRunner);
-
+				testRunner.SwitchToAdvancedSliceSettings();
 
 				testRunner.ClickByName("Layer Height Textbox", 2);
 				testRunner.Type(".5\n");

--- a/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
+++ b/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
@@ -368,6 +368,16 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			testRunner.Delay(.5);
 		}
 
+		public static void AddDefaultFileToBedPlate(this AutomationRunner testRunner, string containerName = "Calibration Parts Row Item Collection", string partName = "Row Item Calibration - Box.stl")
+		{
+			testRunner.ClickByName("Library Tab");
+			testRunner.NavigateToFolder(containerName);
+			testRunner.ClickByName(partName, 1);
+
+			testRunner.ClickByName("Print Library Overflow Menu", 1);
+			testRunner.ClickByName("Add to Plate MenuItem");
+		}
+
 		public static async Task RunTest(
 			AutomationTest testMethod,
 			string staticDataPathOverride = null,

--- a/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
+++ b/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
@@ -41,6 +41,7 @@ using MatterHackers.Agg.PlatformAbstract;
 using MatterHackers.Agg.UI;
 using MatterHackers.GuiAutomation;
 using MatterHackers.MatterControl.DataStorage;
+using MatterHackers.MatterControl.PrinterCommunication;
 using MatterHackers.MatterControl.SlicerConfiguration;
 using MatterHackers.PrinterEmulator;
 using Newtonsoft.Json;
@@ -376,6 +377,11 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 			testRunner.ClickByName("Print Library Overflow Menu", 1);
 			testRunner.ClickByName("Add to Plate MenuItem");
+		}
+
+		public static void WaitForPrintFinished(this AutomationRunner testRunner)
+		{
+			testRunner.Delay(() => PrinterConnectionAndCommunication.Instance.CommunicationState == PrinterConnectionAndCommunication.CommunicationStates.FinishedPrint, 120);
 		}
 
 		public static async Task RunTest(

--- a/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
+++ b/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
@@ -473,8 +473,12 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			Environment.CurrentDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
 		}
 
-		public static void SwitchToAdvancedSettings(AutomationRunner testRunner)
+		public static void SwitchToAdvancedSliceSettings(this AutomationRunner testRunner)
 		{
+			// Switch to Slice Settings Tab
+			testRunner.ClickByName("Slice Settings Tab");
+
+			// Change to Advanced view
 			testRunner.ClickByName("User Level Dropdown");
 			testRunner.ClickByName("Advanced Menu Item");
 			testRunner.Delay(.5);

--- a/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
+++ b/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
@@ -187,7 +187,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			}
 		}
 
-		public static IDisposable LaunchAndConnectToPrinterEmulator(this AutomationRunner testRunner, string make = "Airwolf 3D", string model = "HD", bool runSlow = false)
+		public static Emulator LaunchAndConnectToPrinterEmulator(this AutomationRunner testRunner, string make = "Airwolf 3D", string model = "HD", bool runSlow = false)
 		{
 			// Load the TestEnv config
 			var config = TestAutomationConfig.Load();
@@ -195,7 +195,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			// Create the printer
 			MatterControlUtilities.AddAndSelectPrinter(testRunner, make, model);
 
-			Emulator emulator = new Emulator();
+			var emulator = new Emulator();
 
 			emulator.PortName = config.Printer;
 			emulator.RunSlow = runSlow;


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#1556
Determine if false constant was accidentally checked in and revert
- Issue MatterHackers/MCCentral#1505
Tests assume 'Start Print' is available but that behavior was coupled with Queue Selection/ActivePrintItem
