### PR TITLE
Fix LibrarySelection -> Rename

### DIFF
--- a/Library/Providers/FileSystem/FileSystemContainer.cs
+++ b/Library/Providers/FileSystem/FileSystemContainer.cs
@@ -346,37 +346,34 @@ namespace MatterHackers.MatterControl.Library
 
 		public override void Rename(ILibraryItem item, string revisedName)
 		{
-			/*
-			 * var fileSystemContainer = container as FileSystemContainer;
-			if (fileSystemContainer != null
-				&& Directory.Exists(fileSystemContainer.fullPath))
+			if (item is ContainerLink directoryLink)
 			{
-				string destPath = Path.Combine(Path.GetDirectoryName(fileSystemContainer.fullPath), revisedName);
-				Directory.Move(fileSystemContainer.fullPath, destPath);
-
-				await Task.Delay(150);
-
-				GetFilesAndCollectionsInCurrentDirectory();
-			}*/
-
-			/*
-			string sourceFile = Path.Combine(rootPath, currentDirectoryFiles[itemIndexToRename]);
-			if (File.Exists(sourceFile))
-			{
-				string extension = Path.GetExtension(sourceFile);
-				string destFile = Path.Combine(Path.GetDirectoryName(sourceFile), newName);
-				destFile = Path.ChangeExtension(destFile, extension);
-				File.Move(sourceFile, destFile);
-				Stopwatch time = Stopwatch.StartNew();
-				// Wait for up to some amount of time for the directory to be gone.
-				while (File.Exists(destFile)
-					&& time.ElapsedMilliseconds < 100)
+				if (Directory.Exists(directoryLink.Path))
 				{
-					Thread.Sleep(1); // make sure we are not eating all the cpu time.
+					//string destPath = Path.Combine(Path.GetDirectoryName(fileSystemContainer.fullPath), revisedName);
+					//Directory.Move(fileSystemContainer.fullPath, destPath);
+
+					//await Task.Delay(150);
+
+					//GetFilesAndCollectionsInCurrentDirectory();
 				}
-				//				GetFilesAndCollectionsInCurrentDirectory();
 			}
-			*/
+			else if (item is FileSystemFileItem fileItem)
+			{
+				string sourceFile = fileItem.Path;
+				if (File.Exists(sourceFile))
+				{
+					string extension = Path.GetExtension(sourceFile);
+					string destFile = Path.Combine(Path.GetDirectoryName(sourceFile), revisedName);
+					destFile = Path.ChangeExtension(destFile, extension);
+
+					File.Move(sourceFile, destFile);
+
+					fileItem.Path = destFile;
+
+					this.OnReloaded();
+				}
+			}
 		}
 
 		#endregion

--- a/Library/Providers/FileSystem/FileSystemItem.cs
+++ b/Library/Providers/FileSystem/FileSystemItem.cs
@@ -36,6 +36,8 @@ namespace MatterHackers.MatterControl.Library
 	/// </summary>
 	public class FileSystemItem : ILibraryItem
 	{
+		private string fileName;
+
 		public string Path { get; set; }
 		public string Category { get; set; }
 		public string ThumbnailKey { get; set; } = "";
@@ -45,11 +47,22 @@ namespace MatterHackers.MatterControl.Library
 		public FileSystemItem(string path)
 		{
 			this.Path = path;
-			this.Name = System.IO.Path.GetFileName(path);
 		}
 
 		public string ID => this.Path.GetHashCode().ToString();
 
-		public virtual string Name { get; set; }
+		public virtual string Name
+		{
+			get
+			{
+				if (fileName == null)
+				{
+					fileName = System.IO.Path.GetFileName(this.Path);
+				}
+
+				return fileName;
+			}
+			set { }
+		}
 	}
 }

--- a/Library/Widgets/PrintLibraryWidget.cs
+++ b/Library/Widgets/PrintLibraryWidget.cs
@@ -631,7 +631,7 @@ namespace MatterHackers.MatterControl.PrintLibrary
 				else
 				{
 					item.MenuItem = dropDownMenu.AddItem(item.Title);
-					item.MenuItem.Name = $"{item.Title} MenuItem";
+					item.MenuItem.Name = $"{item.Title} Menu Item";
 				}
 
 				item.MenuItem.Enabled = item.Action != null;
@@ -694,7 +694,7 @@ namespace MatterHackers.MatterControl.PrintLibrary
 				if (renameItemWindow == null)
 				{
 					renameItemWindow = new RenameItemWindow(
-						selectedItem.Text,
+						selectedItem.Model.Name,
 						(returnInfo) =>
 						{
 							var model = libraryView.SelectedItems.FirstOrDefault()?.Model;
@@ -785,14 +785,13 @@ namespace MatterHackers.MatterControl.PrintLibrary
 
 		private void deleteFromLibraryButton_Click(object sender, EventArgs e)
 		{
-			// TODO: If we don't filter to non-container content here, then the providers could be passed a container to move to some other container
-			var libraryItems = libraryView.SelectedItems.Where(item => item is ILibraryContentItem);
+			var libraryItems = libraryView.SelectedItems.Select(p => p.Model);
 			if (libraryItems.Any())
 			{
 				var container = libraryView.ActiveContainer as ILibraryWritableContainer;
 				if (container != null)
 				{
-					container.Remove(libraryItems.Select(p => p.Model));
+					container.Remove(libraryItems);
 				}
 			}
 

--- a/Tests/MatterControl.AutomationTests/LibraryDownloadsTest.cs
+++ b/Tests/MatterControl.AutomationTests/LibraryDownloadsTest.cs
@@ -164,7 +164,9 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				//Rename added item
 				testRunner.ClickByName("Library Edit Button", .5);
 				testRunner.ClickByName("Row Item Batman");
-				MatterControlUtilities.LibraryRenameSelectedItem(testRunner);
+
+				testRunner.LibraryRenameSelectedItem();
+
 				testRunner.Delay(.5);
 				testRunner.Type("Batman Renamed");
 				testRunner.ClickByName("Rename Button");

--- a/Tests/MatterControl.AutomationTests/LocalLibraryTests.cs
+++ b/Tests/MatterControl.AutomationTests/LocalLibraryTests.cs
@@ -135,7 +135,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 		[Test]
 		public async Task RenameButtonRenameLocalLibraryItem()
 		{
-			AutomationTest testToRun = (testRunner) =>
+			await MatterControlUtilities.RunTest((testRunner) =>
 			{
 				testRunner.CloseSignInAndPrinterSelect();
 
@@ -143,31 +143,31 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				testRunner.ClickByName("Library Tab");
 				testRunner.NavigateToFolder("Local Library Row Item Collection");
 
-				testRunner.Delay(1);
-
-				string rowItemToRename = "Row Item Calibration - Box";
-				testRunner.ClickByName("Library Edit Button");
-				testRunner.Delay(1);
-				testRunner.ClickByName(rowItemToRename);
-				MatterControlUtilities.LibraryRenameSelectedItem(testRunner);
-
+				// Add Library item
+				testRunner.ClickByName("Library Add Button", 5);
 				testRunner.Delay(2);
+				testRunner.Type(MatterControlUtilities.GetTestItemPath("Rook.amf"));
+				testRunner.Delay(1);
+				testRunner.Type("{Enter}");
 
-				testRunner.Type("Library Item Renamed");
+				testRunner.ClickByName("Row Item Rook", 2);
 
+				// Open and wait rename window
+				testRunner.LibraryRenameSelectedItem();
+				testRunner.WaitForName("Rename Button");
+
+				testRunner.Delay(1);
+
+				// Rename item
+				testRunner.Type("Rook Renamed");
 				testRunner.ClickByName("Rename Button");
 
-				string renamedRowItem = "Row Item Library Item Renamed";
-				bool libraryItemWasRenamed = testRunner.WaitForName(renamedRowItem, 2);
-				bool libraryItemBeforeRenameExists = testRunner.WaitForName(rowItemToRename, 2);
-
-				Assert.IsTrue(libraryItemWasRenamed == true);
-				Assert.IsTrue(libraryItemBeforeRenameExists == false);
+				// Confirm
+				Assert.IsTrue(testRunner.WaitForName("Row Item Rook Renamed", 5));
+				Assert.IsFalse(testRunner.WaitForName("Row Item Rook", 2));
 
 				return Task.FromResult(0);
-			};
-
-			await MatterControlUtilities.RunTest(testToRun, overrideWidth: 600);
+			}, overrideWidth: 600);
 		}
 
 		[Test]
@@ -201,7 +201,8 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				testRunner.ClickByName("New Folder Row Item Collection");
 				testRunner.Delay(.2);
 
-				MatterControlUtilities.LibraryRenameSelectedItem(testRunner);
+				testRunner.LibraryRenameSelectedItem();
+
 				testRunner.Delay(.5);
 				testRunner.Type("Renamed Library Folder");
 

--- a/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
+++ b/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
@@ -378,7 +378,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			testRunner.ClickByName(partName, 1);
 
 			testRunner.ClickByName("Print Library Overflow Menu", 1);
-			testRunner.ClickByName("Add to Plate MenuItem");
+			testRunner.ClickByName("Add to Plate Menu Item");
 		}
 
 		public static void WaitForPrintFinished(this AutomationRunner testRunner)
@@ -445,28 +445,28 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 		public static void LibraryAddSelectionToQueue(AutomationRunner testRunner)
 		{
-			testRunner.ClickByName("LibraryActionMenu");
+			testRunner.ClickByName("Print Library Overflow Menu");
 			testRunner.ClickByName("Add to Queue Menu Item", 1);
 		}
 
 		public static void LibraryEditSelectedItem(AutomationRunner testRunner)
 		{
-			testRunner.ClickByName("LibraryActionMenu");
 			testRunner.ClickByName("Edit Menu Item", 1);
 			testRunner.Delay(1); // wait for the new window to open
 		}
 
-		public static void LibraryRenameSelectedItem(AutomationRunner testRunner)
+		public static void LibraryRenameSelectedItem(this AutomationRunner testRunner)
 		{
-			testRunner.ClickByName("LibraryActionMenu");
+			testRunner.ClickByName("Print Library Overflow Menu");
 			testRunner.ClickByName("Rename Menu Item", 1);
 		}
 
 		public static void LibraryRemoveSelectedItem(AutomationRunner testRunner)
 		{
-			testRunner.ClickByName("LibraryActionMenu");
+			testRunner.ClickByName("Print Library Overflow Menu");
 			testRunner.ClickByName("Remove Menu Item", 1);
 		}
+
 		public static string ResolveProjectPath(this TestContext context, int stepsToProjectRoot, params string[] relativePathSteps)
 		{
 			string assemblyPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);

--- a/Tests/MatterControl.Tests/MatterControl/PerformanceTests.cs
+++ b/Tests/MatterControl.Tests/MatterControl/PerformanceTests.cs
@@ -141,7 +141,6 @@ namespace MatterHackers.MatterControl
 				container.BeforeDraw -= beforeDraw;
 			};
 			container.BeforeDraw += beforeDraw;
-			
 		}
 
 		public static void AddLocalLibraryItemToQueue(GuiWidget container, double secondsBetweenClicks = .1)
@@ -182,7 +181,9 @@ namespace MatterHackers.MatterControl
 					testRunner.ClickByName("Library Edit Button");
 					testRunner.ClickByName("Row Item Calibration - Box");
 					testRunner.Delay(.5);
-					MatterControlUtilities.LibraryRenameSelectedItem(testRunner);
+
+					testRunner.LibraryRenameSelectedItem();
+
 					testRunner.Delay(.5);
 					testRunner.Type("Renamed Calibration Cube");
 					testRunner.ClickByName("Rename Button");
@@ -211,7 +212,9 @@ namespace MatterHackers.MatterControl
 					testRunner.ClickByName("Create Folder Button");
 					testRunner.ClickByName("Library Edit Button");
 					testRunner.ClickByName("Row Item New Folder");
-					MatterControlUtilities.LibraryRenameSelectedItem(testRunner);
+
+					testRunner.LibraryRenameSelectedItem();
+
 					testRunner.Delay(.5);
 					testRunner.Type("Renamed Folder");
 					testRunner.ClickByName("Rename Button");


### PR DESCRIPTION
- RenameButtonRenameLocalLibraryItem test passing
- Get LibrarySelection->Remove action to compile after refactoring
- Make LibraryRenameSelectedItem an extension method and update callers
- Issue MatterHackers/MCCentral#1559
Library Selection -> Rename does nothing
- Issue MatterHackers/MCCentral#1505