### PR TITLE
Design tools

### DIFF
--- a/ApplicationView/AdvancedControlsPanel.cs
+++ b/ApplicationView/AdvancedControlsPanel.cs
@@ -92,6 +92,10 @@ namespace MatterHackers.MatterControl
 		private TabControl CreateTabControl()
 		{
 			var newTabControl = ApplicationController.Instance.Theme.CreateTabControl();
+			newTabControl.TabBar.TabIndexChanged += (s, e) =>
+			{
+				ApplicationController.Instance.ActiveAdvancedControlsTab = newTabControl.SelectedTabIndex;
+			};
 
 			RGBA_Bytes unselectedTextColor = ActiveTheme.Instance.TabLabelUnselected;
 
@@ -129,14 +133,6 @@ namespace MatterHackers.MatterControl
 			newTabControl.AddTab(sliceSettingPopOut);
 			newTabControl.AddTab(controlsPopOut);
 
-#if !__ANDROID__
-			if (!UserSettings.Instance.IsTouchScreen)
-			{
-				MenuOptionSettings.sliceSettingsPopOut = sliceSettingPopOut;
-				MenuOptionSettings.controlsPopOut = controlsPopOut;
-			}
-#endif
-
 			newTabControl.AddTab(
 				new SimpleTextTabWidget(
 					new TabPage(new PrinterConfigurationScrollWidget(), "Options".Localize().ToUpper()), 
@@ -144,9 +140,15 @@ namespace MatterHackers.MatterControl
 					newTabControl.TextPointSize,
 					ActiveTheme.Instance.PrimaryTextColor, new RGBA_Bytes(), unselectedTextColor, new RGBA_Bytes()));
 
-			// MatterControl historically started with the queue selected, force to 0 to remain consistent
-			newTabControl.SelectedTabIndex = 0;
+			newTabControl.SelectedTabIndex = ApplicationController.Instance.ActiveAdvancedControlsTab;
 
+#if !__ANDROID__
+			if (!UserSettings.Instance.IsTouchScreen)
+			{
+				MenuOptionSettings.sliceSettingsPopOut = sliceSettingPopOut;
+				MenuOptionSettings.controlsPopOut = controlsPopOut;
+			}
+#endif
 			return newTabControl;
 		}
 	}

--- a/ApplicationView/ApplicationController.cs
+++ b/ApplicationView/ApplicationController.cs
@@ -263,7 +263,6 @@ namespace MatterHackers.MatterControl
 			}
 		}
 
-
 		private async void ThumbGeneration()
 		{
 			while(true)
@@ -710,6 +709,7 @@ namespace MatterHackers.MatterControl
 		public MeshViewState PartPreviewState { get; set; } = new MeshViewState();
 
 		public View3DWidget ActiveView3DWidget { get; internal set; }
+		public int ActiveAdvancedControlsTab { get; internal set; }
 
 		public string CachePath(ILibraryItem libraryItem)
 		{

--- a/ControlElements/SplitButtonFactory.cs
+++ b/ControlElements/SplitButtonFactory.cs
@@ -79,6 +79,7 @@ namespace MatterHackers.MatterControl
 			};
 
 			Button button = buttonFactory.Generate(primaryAction.Title, normalImageName: imageName, centerText: true);
+			button.Name = $"{primaryAction.Title} Button";
 			button.Click += (s, e) =>
 			{
 				primaryAction.Action();

--- a/Library/Widgets/ListView/ListViewItemBase.cs
+++ b/Library/Widgets/ListView/ListViewItemBase.cs
@@ -184,6 +184,8 @@ namespace MatterHackers.MatterControl.CustomWidgets
 				//var iconWithOverlay = ActiveContainer.DrawOverlay()
 
 				this.imageWidget.Image = thumbnail;
+
+				this.Invalidate();
 			}
 		}
 

--- a/PartPreviewWindow/OverflowDropdown.cs
+++ b/PartPreviewWindow/OverflowDropdown.cs
@@ -28,7 +28,6 @@ either expressed or implied, of the FreeBSD Project.
 */
 
 using System;
-using System.Collections.Generic;
 using System.IO;
 using MatterHackers.Agg;
 using MatterHackers.Agg.ImageProcessing;
@@ -81,23 +80,6 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			this.buttonView = buttonView;
 
 			this.AddChild(buttonView);
-
-			// After the buttonView looses focus, wait a moment for the mouse to arrive at the target and if not found, close the menu
-			buttonView.MouseLeaveBounds += (s, e) =>
-			{
-				if (menuVisible)
-				{
-					UiThread.RunOnIdle(() =>
-					{
-						if (this.PopupContent?.UnderMouseState != UnderMouseState.NotUnderMouse)
-						{
-							return;
-						}
-
-						popupWidget?.CloseMenu();
-					}, 0.1);
-				}
-			};
 		}
 
 		public Direction PopDirection { get; set; } = Direction.Down;

--- a/PartPreviewWindow/ViewControls3D.cs
+++ b/PartPreviewWindow/ViewControls3D.cs
@@ -164,6 +164,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 			iconPath = Path.Combine("ViewTransformControls", "layers.png");
 			var layersButton = buttonFactory.Generate("", StaticData.Instance.LoadIcon(iconPath, 32, 32).InvertLightness());
+			layersButton.Name = "Toggle Layer View Button";
 			layersButton.ToolTipText = "Layers".Localize();
 			layersButton.Margin = 3;
 			layersButton.Click += (s, e) =>

--- a/SlicerConfiguration/Settings/SettingsHelpers.cs
+++ b/SlicerConfiguration/Settings/SettingsHelpers.cs
@@ -215,8 +215,8 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				// Notify listeners of a ProfileListChange event due to this printers removal
 				ProfileManager.ProfilesListChanged.CallEvents(this, null);
 
-				// Force sync after marking for delete
-				ApplicationController.SyncPrinterProfiles("SettingsHelpers.SetMarkedForDelete()", null);
+				// Force sync after marking for delete if assigned
+				ApplicationController.SyncPrinterProfiles?.Invoke("SettingsHelpers.SetMarkedForDelete()", null);
 			});
 		}
 

--- a/Tests/MatterControl.AutomationTests/PrintingTests.cs
+++ b/Tests/MatterControl.AutomationTests/PrintingTests.cs
@@ -13,10 +13,10 @@ using NUnit.Framework;
 
 namespace MatterHackers.MatterControl.Tests.Automation
 {
-	[TestFixture, Category("MatterControl.UI.Automation"), RunInApplicationDomain]
+	[TestFixture, Category("MatterControl.UI.Automation"), RunInApplicationDomain, Apartment(ApartmentState.STA)]
 	public class PrintingTests
 	{
-		[Test, Apartment(ApartmentState.STA)]
+		[Test]
 		public async Task CompletingPrintTurnsoffHeat()
 		{
 			await MatterControlUtilities.RunTest((testRunner) =>
@@ -56,7 +56,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			}, maxTimeToRun: 200);
 		}
 
-		[Test, Apartment(ApartmentState.STA)]
+		[Test]
 		public async Task PulseRequiresLevelingAndLevelingWorks()
 		{
 			await MatterControlUtilities.RunTest((testRunner) =>
@@ -113,7 +113,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			}, maxTimeToRun: 90);
 		}
 
-		[Test, Apartment(ApartmentState.STA)]
+		[Test]
 		public void ExpectedEmulatorResponses()
 		{
 			string[] test1 = new string[]
@@ -208,7 +208,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			}
 		}
 
-		[Test, Apartment(ApartmentState.STA)]
+		[Test]
 		public async Task PrinterRequestsResumeWorkingAsExpected()
 		{
 			await MatterControlUtilities.RunTest((testRunner) =>
@@ -255,7 +255,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 		private EventHandler unregisterEvents;
 
-		[Test, Apartment(ApartmentState.STA)]
+		[Test]
 		public async Task TuningAdjustmentsDefaultToOneAndPersists()
 		{
 			double targetExtrusionRate = 1.5;
@@ -342,7 +342,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			}, overrideHeight:900, maxTimeToRun: 120);
 		}
 
-		[Test, Apartment(ApartmentState.STA)]
+		[Test]
 		public async Task TuningAdjustmentControlsBoundToStreamValues()
 		{
 			double targetExtrusionRate = 1.5;
@@ -435,7 +435,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			}, overrideHeight: 900, maxTimeToRun: 120);
 		}
 
-		[Test, Apartment(ApartmentState.STA)]
+		[Test]
 		public async Task CancelingSdCardPrintLeavesHeatAndFanOn()
 		{
 			await MatterControlUtilities.RunTest((testRunner) =>
@@ -479,7 +479,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			}, overrideHeight: 900, maxTimeToRun: 90);
 		}
 
-		[Test, Apartment(ApartmentState.STA)]
+		[Test]
 		public async Task CancelingNormalPrintTurnsHeatAndFanOff()
 		{
 			await MatterControlUtilities.RunTest((testRunner) =>

--- a/Tests/MatterControl.AutomationTests/PrintingTests.cs
+++ b/Tests/MatterControl.AutomationTests/PrintingTests.cs
@@ -36,7 +36,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					testRunner.Type("{BACKSPACE}");
 					testRunner.Type("G28");
 
-					testRunner.AddDefaultFileToBedPlate();
+					testRunner.AddDefaultFileToBedplate();
 
 					testRunner.ClickByName("Start Print Button", 1);
 
@@ -98,7 +98,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					testRunner.Delay(1);
 
 					// print a part
-					testRunner.AddDefaultFileToBedPlate();
+					testRunner.AddDefaultFileToBedplate();
 					testRunner.ClickByName("Start Print Button", 1);
 
 					testRunner.Delay(() => emulator.ZPosition > 5, 3);
@@ -230,7 +230,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					testRunner.ClickByName("Controls Tab");
 
 					// print a part
-					testRunner.AddDefaultFileToBedPlate();
+					testRunner.AddDefaultFileToBedplate();
 					testRunner.ClickByName("Start Print Button", 1);
 
 					// turn on line error simulation
@@ -271,7 +271,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				{
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
-					testRunner.AddDefaultFileToBedPlate();
+					testRunner.AddDefaultFileToBedplate();
 					
 					testRunner.ClickByName("Controls Tab", 1);
 
@@ -366,7 +366,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				{
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
-					testRunner.AddDefaultFileToBedPlate();
+					testRunner.AddDefaultFileToBedplate();
 
 					testRunner.ClickByName("Controls Tab", 1);
 
@@ -490,7 +490,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				{
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
-					testRunner.AddDefaultFileToBedPlate();
+					testRunner.AddDefaultFileToBedplate();
 					testRunner.ClickByName("Start Print Button", 1);
 					testRunner.Delay(5);
 

--- a/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
+++ b/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
@@ -181,10 +181,8 @@ namespace MatterHackers.MatterControl.Tests.Automation
 		[Test /* Test will fail if screen size is and "HeatBeforeHoming" falls below the fold */]
 		public async Task ClearingCheckBoxClearsUserOverride()
 		{
-			AutomationTest testToRun = (testRunner) =>
+			await MatterControlUtilities.RunTest((testRunner) =>
 			{
-				testRunner.CloseSignInAndPrinterSelect();
-
 				MatterControlUtilities.AddAndSelectPrinter(testRunner, "Airwolf 3D", "HD");
 
 				//Navigate to Local Library 
@@ -198,9 +196,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				CheckAndUncheckSetting(testRunner, SettingsKey.has_fan, "Has Fan Checkbox", true);
 
 				return Task.FromResult(0);
-			};
-
-			await MatterControlUtilities.RunTest(testToRun, overrideWidth: 1224, overrideHeight: 900);
+			}, overrideWidth: 1224, overrideHeight: 900);
 		}
 
 		[Test /* Test will fail if screen size is and "HeatBeforeHoming" falls below the fold */]

--- a/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
+++ b/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
@@ -13,10 +13,10 @@ using NUnit.Framework;
 
 namespace MatterHackers.MatterControl.Tests.Automation
 {
-	[TestFixture, Category("MatterControl.UI.Automation"), RunInApplicationDomain]
+	[TestFixture, Category("MatterControl.UI.Automation"), RunInApplicationDomain, Apartment(ApartmentState.STA)]
 	public class SliceSetingsTests
 	{
-		[Test, Apartment(ApartmentState.STA)]
+		[Test]
 		public async Task RaftEnabledPassedToSliceEngine()
 		{
 			AutomationTest testToRun = (testRunner) =>
@@ -66,7 +66,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			await MatterControlUtilities.RunTest(testToRun, overrideWidth: 1224, overrideHeight: 800);
 		}
 
-		[Test, Apartment(ApartmentState.STA)]
+		[Test]
 		public async Task PauseOnLayerDoesPauseOnPrint()
 		{
 			AutomationTest testToRun = (testRunner) =>
@@ -106,7 +106,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			await MatterControlUtilities.RunTest(testToRun, maxTimeToRun: 90);
 		}
 
-		[Test, Apartment(ApartmentState.STA)]
+		[Test]
 		public async Task CancelWorksAsExpected()
 		{
 			AutomationTest testToRun = (testRunner) =>
@@ -181,7 +181,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			testRunner.Delay(.1);
 		}
 
-		[Test, Apartment(ApartmentState.STA) /* Test will fail if screen size is and "HeatBeforeHoming" falls below the fold */]
+		[Test /* Test will fail if screen size is and "HeatBeforeHoming" falls below the fold */]
 		public async Task ClearingCheckBoxClearsUserOverride()
 		{
 			AutomationTest testToRun = (testRunner) =>
@@ -206,7 +206,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			await MatterControlUtilities.RunTest(testToRun, overrideWidth: 1224, overrideHeight: 900);
 		}
 
-		[Test, Apartment(ApartmentState.STA) /* Test will fail if screen size is and "HeatBeforeHoming" falls below the fold */]
+		[Test /* Test will fail if screen size is and "HeatBeforeHoming" falls below the fold */]
 		public async Task SwitchingMaterialsCausesSettingsChangedEvents()
 		{
 			AutomationTest testToRun = (testRunner) =>
@@ -249,7 +249,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			await MatterControlUtilities.RunTest(testToRun, overrideWidth: 1224, overrideHeight: 900);
 		}
 
-		[Test, Apartment(ApartmentState.STA)]
+		[Test]
 		public async Task DeleteProfileWorksForGuest()
 		{
 			AutomationTest testToRun = (testRunner) =>
@@ -298,7 +298,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			Assert.IsTrue(ActiveSliceSettings.Instance.UserLayer.ContainsKey(settingToChange) == false);
 		}
 
-		[Test, Apartment(ApartmentState.STA)]
+		[Test]
 		public async Task HasHeatedBedCheckedHidesBedTemperatureOptions()
 		{
 			AutomationTest testToRun = (testRunner) =>
@@ -337,18 +337,12 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 			await MatterControlUtilities.RunTest(testToRun, overrideWidth: 550);
 		}
-	}
-
-	[TestFixture, Category("MatterControl.UI.Automation"), RunInApplicationDomain]
-	public class QualitySettingsStayAsOverrides
-	{
-		[Test, Apartment(ApartmentState.STA)]
-		public async Task SettingsStayAsOverrides()
+	
+		[Test]
+		public async Task QualitySettingsStayAsOverrides()
 		{
-			AutomationTest testToRun = (testRunner) =>
+			await MatterControlUtilities.RunTest((testRunner) =>
 			{
-				testRunner.CloseSignInAndPrinterSelect();
-
 				// Add Guest printers
 				MatterControlUtilities.AddAndSelectPrinter(testRunner, "Airwolf 3D", "HD");
 				testRunner.SwitchToAdvancedSliceSettings();
@@ -369,20 +363,22 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				Assert.AreEqual(2, ProfileManager.Instance.ActiveProfiles.Count(), "ProfileManager has 2 Profiles");
 
 				// Check if Guest printer names exists in dropdown
+				testRunner.ClickByName("Printer Overflow Menu", 2);
 				testRunner.ClickByName("Printers... Menu", 2);
 				testRunner.ClickByName("Airwolf 3D HD Menu Item", 5);
 
 				testRunner.Delay(1);
 				Assert.AreEqual(ActiveSliceSettings.Instance.GetValue<double>(SettingsKey.layer_height), .1, "Layer height is the fine override");
 
+				// Switch to Slice Settings Tab
+				testRunner.ClickByName("Slice Settings Tab");
+
 				testRunner.ClickByName("Quality", 2);
 				testRunner.ClickByName("- none - Menu Item", 2, delayBeforeReturn: .5);
 				Assert.AreEqual(ActiveSliceSettings.Instance.GetValue<double>(SettingsKey.layer_height), .5, "Layer height is what we set it to");
 
 				return Task.FromResult(0);
-			};
-
-			await MatterControlUtilities.RunTest(testToRun, maxTimeToRun: 120);
+			}, maxTimeToRun: 120);
 		}
 	}
 }

--- a/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
+++ b/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
@@ -202,13 +202,14 @@ namespace MatterHackers.MatterControl.Tests.Automation
 		[Test /* Test will fail if screen size is and "HeatBeforeHoming" falls below the fold */]
 		public async Task SwitchingMaterialsCausesSettingsChangedEvents()
 		{
-			AutomationTest testToRun = (testRunner) =>
+			await MatterControlUtilities.RunTest((testRunner) =>
 			{
 				EventHandler unregisterEvents = null;
 				int layerHeightChangedCount = 0;
+
 				ActiveSliceSettings.SettingChanged.RegisterEvent((s, e) =>
 				{
-					StringEventArgs stringEvent = e as StringEventArgs;
+					var stringEvent = e as StringEventArgs;
 					if (stringEvent != null)
 					{
 						if (stringEvent.Data == SettingsKey.layer_height)
@@ -217,8 +218,6 @@ namespace MatterHackers.MatterControl.Tests.Automation
 						}
 					}
 				}, ref unregisterEvents);
-
-				testRunner.CloseSignInAndPrinterSelect();
 
 				MatterControlUtilities.AddAndSelectPrinter(testRunner, "Airwolf 3D", "HD");
 
@@ -237,9 +236,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				Assert.AreEqual(2, layerHeightChangedCount, "Changed to standard.");
 
 				return Task.FromResult(0);
-			};
-
-			await MatterControlUtilities.RunTest(testToRun, overrideWidth: 1224, overrideHeight: 900);
+			}, overrideWidth: 1224, overrideHeight: 900);
 		}
 
 		[Test]

--- a/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
+++ b/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
@@ -69,7 +69,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 		[Test]
 		public async Task PauseOnLayerDoesPauseOnPrint()
 		{
-			AutomationTest testToRun = (testRunner) =>
+			await MatterControlUtilities.RunTest((testRunner) =>
 			{
 				testRunner.WaitForName("Cancel Wizard Button", 1);
 
@@ -79,31 +79,30 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 					testRunner.SwitchToAdvancedSliceSettings();
 
-					testRunner.ClickByName("General Tab", 1);
-					testRunner.ClickByName("Single Print Tab", 1);
+					testRunner.ClickByName("General Tab");
+					testRunner.ClickByName("Single Print Tab");
 					testRunner.ClickByName("Layer(s) To Pause: Edit");
 					testRunner.Type("4;2;a;not;6");
 
-					testRunner.ClickByName("Layer View Tab");
+					testRunner.AddDefaultFileToBedplate();
 
-					testRunner.ClickByName("Generate Gcode Button", 1);
+					testRunner.ClickByName("Toggle Layer View Button");
+
+					testRunner.ClickByName("Generate Gcode Button");
 					testRunner.ClickByName("Display Checkbox", 10);
-					testRunner.ClickByName("Sync To Print Checkbox", 1);
+					testRunner.ClickByName("Sync To Print Checkbox");
 
-					testRunner.ClickByName("Start Print Button", 1);
+					testRunner.ClickByName("Start Print Button");
 
 					WaitForLayerAndResume(testRunner, 2);
 					WaitForLayerAndResume(testRunner, 4);
 					WaitForLayerAndResume(testRunner, 6);
 
-					testRunner.WaitForName("Done Button", 30);
-					testRunner.WaitForName("Print Again Button", 1);
+					testRunner.WaitForPrintFinished();
 				}
 
 				return Task.FromResult(0);
-			};
-
-			await MatterControlUtilities.RunTest(testToRun, maxTimeToRun: 90);
+			}, maxTimeToRun: 120);
 		}
 
 		[Test]

--- a/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
+++ b/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
@@ -242,27 +242,23 @@ namespace MatterHackers.MatterControl.Tests.Automation
 		[Test]
 		public async Task DeleteProfileWorksForGuest()
 		{
-			AutomationTest testToRun = (testRunner) =>
+			await MatterControlUtilities.RunTest((testRunner) =>
 			{
-				testRunner.CloseSignInAndPrinterSelect();
-
 				// assert no profiles
-				Assert.IsTrue(ProfileManager.Instance.ActiveProfiles.Count() == 0);
+				Assert.AreEqual(0, ProfileManager.Instance.ActiveProfiles.Count());
 
 				MatterControlUtilities.AddAndSelectPrinter(testRunner, "Airwolf 3D", "HD");
 
 				// assert one profile
-				Assert.IsTrue(ProfileManager.Instance.ActiveProfiles.Count() == 1);
+				Assert.AreEqual(1, ProfileManager.Instance.ActiveProfiles.Count(), "One profile should exist after add");
 
 				MatterControlUtilities.DeleteSelectedPrinter(testRunner);
 
 				// assert no profiles
-				Assert.IsTrue(ProfileManager.Instance.ActiveProfiles.Count() == 0);
+				Assert.AreEqual(0, ProfileManager.Instance.ActiveProfiles.Count(), "No profiles should exist after delete");
 
 				return Task.FromResult(0);
-			};
-
-			await MatterControlUtilities.RunTest(testToRun, overrideWidth: 1224, overrideHeight: 900);
+			}, overrideWidth: 1224, overrideHeight: 900);
 		}
 
 		private static void CheckAndUncheckSetting(AutomationRunner testRunner, string settingToChange, string checkBoxName, bool expected)

--- a/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
+++ b/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
@@ -108,10 +108,8 @@ namespace MatterHackers.MatterControl.Tests.Automation
 		[Test]
 		public async Task CancelWorksAsExpected()
 		{
-			AutomationTest testToRun = (testRunner) =>
+			await MatterControlUtilities.RunTest((testRunner) =>
 			{
-				testRunner.WaitForName("Cancel Wizard Button", 1);
-
 				using (var emulator = testRunner.LaunchAndConnectToPrinterEmulator())
 				{
 					ActiveSliceSettings.Instance.SetValue(SettingsKey.cancel_gcode, "G28 ; Cancel GCode");
@@ -125,7 +123,9 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					testRunner.ClickByName("Layer(s) To Pause: Edit");
 					testRunner.Type("2");
 
-					testRunner.ClickByName("Layer View Tab");
+					testRunner.AddDefaultFileToBedplate();
+
+					testRunner.ClickByName("Toggle Layer View Button");
 
 					testRunner.ClickByName("Generate Gcode Button", 1);
 					testRunner.ClickByName("Display Checkbox", 10);
@@ -157,9 +157,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				}
 
 				return Task.FromResult(0);
-			};
-
-			await MatterControlUtilities.RunTest(testToRun, maxTimeToRun: 110);
+			}, maxTimeToRun: 120);
 		}
 
 		private static void WaitForLayerAndResume(AutomationRunner testRunner, int indexToWaitFor)

--- a/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
+++ b/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
@@ -371,14 +371,18 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			testRunner.Delay(.5);
 		}
 
-		public static void AddDefaultFileToBedPlate(this AutomationRunner testRunner, string containerName = "Calibration Parts Row Item Collection", string partName = "Row Item Calibration - Box.stl")
+		public static void AddDefaultFileToBedplate(this AutomationRunner testRunner, string containerName = "Calibration Parts Row Item Collection", string partName = "Row Item Calibration - Box.stl")
 		{
 			testRunner.ClickByName("Library Tab");
 			testRunner.NavigateToFolder(containerName);
-			testRunner.ClickByName(partName, 1);
+			testRunner.ClickByName(partName);
 
-			testRunner.ClickByName("Print Library Overflow Menu", 1);
+			testRunner.ClickByName("Print Library Overflow Menu");
 			testRunner.ClickByName("Add to Plate Menu Item");
+
+			testRunner.ClickByName("Save Button");
+
+			testRunner.Delay(1);
 		}
 
 		public static void WaitForPrintFinished(this AutomationRunner testRunner)


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#1565
AdvancedControls tab should remember selected index after ReloadX events
- Issue MatterHackers/MCCentral#1505
Tests assume 'Start Print' is available but that behavior was coupled with Queue Selection/ActivePrintItem
