### PR TITLE
Refine library views for focused tasks

### DIFF
--- a/Library/Widgets/ListContainerBrowser.cs
+++ b/Library/Widgets/ListContainerBrowser.cs
@@ -1,0 +1,159 @@
+﻿/*
+Copyright (c) 2017, Kevin Pope, John Lewin
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the FreeBSD Project.
+*/
+
+using MatterHackers.Agg;
+using MatterHackers.Agg.PlatformAbstract;
+using MatterHackers.Agg.UI;
+using MatterHackers.Localizations;
+using MatterHackers.MatterControl.CustomWidgets;
+using MatterHackers.MatterControl.Library;
+
+namespace MatterHackers.MatterControl.PrintLibrary
+{
+	public class ListContainerBrowser : FlowLayoutWidget
+	{
+		private FolderBreadCrumbWidget breadCrumbWidget;
+		private GuiWidget searchInput;
+		private ILibraryContainer searchContainer;
+
+		private ListView libraryView;
+		public ListContainerBrowser(ListView libraryView)
+		{
+			this.libraryView = libraryView;
+			breadCrumbWidget = new FolderBreadCrumbWidget(libraryView);
+
+			this.AddChild(breadCrumbWidget);
+
+			var icon = StaticData.Instance.LoadIcon("icon_search_24x24.png", 16, 16);
+
+			var buttonFactory = ApplicationController.Instance.Theme.BreadCrumbButtonFactory;
+			var initialMargin = buttonFactory.Margin;
+			buttonFactory.Margin = new BorderDouble(8, 0);
+
+			var searchPanel = new SearchInputBox()
+			{
+				Visible = false,
+				Margin = new BorderDouble(10, 0, 5, 0)
+			};
+			searchPanel.searchInput.ActualTextEditWidget.EnterPressed += (s, e) =>
+			{
+				this.PerformSearch();
+			};
+			searchPanel.resetButton.Click += (s, e) =>
+			{
+				breadCrumbWidget.Visible = true;
+				searchPanel.Visible = false;
+
+				searchPanel.searchInput.Text = "";
+
+				this.ClearSearch();
+			};
+
+			// Store a reference to the input field
+			this.searchInput = searchPanel.searchInput;
+
+			this.AddChild(searchPanel);
+
+			Button searchButton = buttonFactory.Generate("", icon);
+			searchButton.ToolTipText = "Search".Localize();
+			searchButton.Name = "Search Library Button";
+			searchButton.Margin = 0;
+			searchButton.Click += (s, e) =>
+			{
+				if (searchPanel.Visible)
+				{
+					PerformSearch();
+				}
+				else
+				{
+					searchContainer = this.libraryView.ActiveContainer;
+
+					breadCrumbWidget.Visible = false;
+					searchPanel.Visible = true;
+					searchInput.Focus();
+				}
+			};
+			buttonFactory.Margin = initialMargin;
+			this.AddChild(searchButton);
+		}
+
+		private void PerformSearch()
+		{
+			UiThread.RunOnIdle(() =>
+			{
+				libraryView.ActiveContainer.KeywordFilter = searchInput.Text.Trim();
+				//breadCrumbWidget.SetBreadCrumbs(libraryView.ActiveContainer);
+			});
+		}
+
+		private void ClearSearch()
+		{
+			UiThread.RunOnIdle(() =>
+			{
+				searchContainer.KeywordFilter = "";
+
+				// Restore the original ActiveContainer before search started - some containers may change context
+				ApplicationController.Instance.Library.ActiveContainer = searchContainer;
+
+				//breadCrumbWidget.SetBreadCrumbs(libraryView.ActiveContainer);
+
+				searchContainer = null;
+			});
+		}
+
+		private class SearchInputBox : GuiWidget
+		{
+			internal MHTextEditWidget searchInput;
+			internal Button resetButton;
+
+			public SearchInputBox()
+			{
+				this.VAnchor = VAnchor.ParentCenter | VAnchor.FitToChildren;
+				this.HAnchor = HAnchor.ParentLeftRight;
+
+				searchInput = new MHTextEditWidget(messageWhenEmptyAndNotSelected: "Search Library".Localize())
+				{
+					Name = "Search Library Edit",
+					HAnchor = HAnchor.ParentLeftRight,
+					VAnchor = VAnchor.ParentCenter
+				};
+				this.AddChild(searchInput);
+
+				resetButton = ApplicationController.Instance.Theme.CreateSmallResetButton();
+				resetButton.HAnchor = HAnchor.ParentRight | HAnchor.FitToChildren;
+				resetButton.VAnchor = VAnchor.ParentCenter | VAnchor.FitToChildren;
+				resetButton.Name = "Close Search";
+				resetButton.ToolTipText = "Clear".Localize();
+
+				this.AddChild(resetButton);
+			}
+		}
+
+	}
+}

--- a/Library/Widgets/ListView/ListView.cs
+++ b/Library/Widgets/ListView/ListView.cs
@@ -53,7 +53,13 @@ namespace MatterHackers.MatterControl.CustomWidgets
 
 		private ILibraryContext LibraryContext;
 
+		// Default constructor uses IconListView
 		public ListView(ILibraryContext context)
+			: this(context, new IconListView())
+		{
+		}
+
+		public ListView(ILibraryContext context, GuiWidget libraryView)
 		{
 			this.LibraryContext = context;
 
@@ -78,7 +84,7 @@ namespace MatterHackers.MatterControl.CustomWidgets
 
 			AutoScroll = true;
 
-			this.ListContentView = new IconListView();
+			this.ListContentView = libraryView;
 			context.ContainerChanged += ActiveContainer_Changed;
 			context.ContainerReloaded += ActiveContainer_Reloaded;
 
@@ -93,6 +99,10 @@ namespace MatterHackers.MatterControl.CustomWidgets
 				}
 			}, ref unregisterEvents);
 		}
+
+		public bool ShowContainers { get; set; } = true;
+
+		public bool ShowItems { get; set; } = true;
 
 		public ILibraryContainer ActiveContainer => this.LibraryContext.ActiveContainer;
 
@@ -170,25 +180,31 @@ if (hasID
 			int height = itemsContentView.ThumbHeight;
 
 			// Folder items
-			foreach (var childContainer in sourceContainer.ChildContainers.Where(c => c.IsVisible))
+			if (this.ShowContainers)
 			{
-				var listViewItem = new ListViewItem(childContainer, this);
-				listViewItem.DoubleClick += listViewItem_DoubleClick;
-				items.Add(listViewItem);
+				foreach (var childContainer in sourceContainer.ChildContainers.Where(c => c.IsVisible))
+				{
+					var listViewItem = new ListViewItem(childContainer, this);
+					listViewItem.DoubleClick += listViewItem_DoubleClick;
+					items.Add(listViewItem);
 
-				itemsContentView.AddItem(listViewItem);
-				listViewItem.ViewWidget.Name = childContainer.Name + " Row Item Collection";
+					itemsContentView.AddItem(listViewItem);
+					listViewItem.ViewWidget.Name = childContainer.Name + " Row Item Collection";
+				}
 			}
 
 			// List items
-			foreach (var item in sourceContainer.Items.Where(i => i.IsVisible))
+			if (this.ShowItems)
 			{
-				var listViewItem = new ListViewItem(item, this);
-				listViewItem.DoubleClick += listViewItem_DoubleClick;
-				items.Add(listViewItem);
+				foreach (var item in sourceContainer.Items.Where(i => i.IsVisible))
+				{
+					var listViewItem = new ListViewItem(item, this);
+					listViewItem.DoubleClick += listViewItem_DoubleClick;
+					items.Add(listViewItem);
 
-				itemsContentView.AddItem(listViewItem);
-				listViewItem.ViewWidget.Name = "Row Item " + item.Name;
+					itemsContentView.AddItem(listViewItem);
+					listViewItem.ViewWidget.Name = "Row Item " + item.Name;
+				}
 			}
 		}
 

--- a/Library/Widgets/PrintLibraryWidget.cs
+++ b/Library/Widgets/PrintLibraryWidget.cs
@@ -34,6 +34,7 @@ using System.Linq;
 using MatterHackers.Agg;
 using MatterHackers.Agg.PlatformAbstract;
 using MatterHackers.Agg.UI;
+using MatterHackers.Agg.VertexSource;
 using MatterHackers.DataConverters3D;
 using MatterHackers.Localizations;
 using MatterHackers.MatterControl.CustomWidgets;
@@ -56,22 +57,20 @@ namespace MatterHackers.MatterControl.PrintLibrary
 		private TextImageButtonFactory textImageButtonFactory;
 		private TextImageButtonFactory editButtonFactory;
 
-		private FolderBreadCrumbWidget breadCrumbWidget;
-
 		private Button addToLibraryButton;
 		private Button createFolderButton;
 		private FlowLayoutWidget buttonPanel;
-		private MHTextEditWidget searchInput;
 		private ListView libraryView;
 		private GuiWidget providerMessageContainer;
 		private TextWidget providerMessageWidget;
 
 		private OverflowDropdown overflowDropdown;
 
+		private PopupButton activeContainerPopup;
+		private TextWidget activeContainerTitle;
+
 		//private DropDownMenu actionMenu;
 		private List<PrintItemAction> menuActions = new List<PrintItemAction>();
-
-		private ILibraryContainer searchContainer;
 
 		public PrintLibraryWidget()
 		{
@@ -105,7 +104,8 @@ namespace MatterHackers.MatterControl.PrintLibrary
 
 			libraryView = new ListView(ApplicationController.Instance.Library)
 			{
-				BackgroundColor = ActiveTheme.Instance.TertiaryBackgroundColor
+				BackgroundColor = ActiveTheme.Instance.TertiaryBackgroundColor,
+				ShowContainers = false
 			};
 
 			libraryView.SelectedItems.CollectionChanged += SelectedItems_CollectionChanged;
@@ -115,69 +115,63 @@ namespace MatterHackers.MatterControl.PrintLibrary
 			var breadCrumbBar = new FlowLayoutWidget()
 			{
 				HAnchor = HAnchor.ParentLeftRight,
-				Padding = new BorderDouble(bottom: 2),
-				Name = "Library Tab" // TODO: Short term workaround for automation tests - move name to tab once leftNav becomes dockable
+				VAnchor = VAnchor.FitToChildren,
+				Padding = 0,
 			};
 
-			breadCrumbWidget = new FolderBreadCrumbWidget(libraryView);
-			breadCrumbBar.AddChild(breadCrumbWidget);
+			int arrowHeight = 5;
 
-			var icon = StaticData.Instance.LoadIcon("icon_search_24x24.png", 16, 16);
+			var directionArrow = new PathStorage();
+			directionArrow.MoveTo(-arrowHeight, 0);
+			directionArrow.LineTo(arrowHeight, 0);
+			directionArrow.LineTo(0, -arrowHeight);
 
-			var buttonFactory = ApplicationController.Instance.Theme.BreadCrumbButtonFactory;
-			var initialMargin = buttonFactory.Margin;
-			buttonFactory.Margin = new BorderDouble(8, 0);
-
-			var searchPanel = new SearchInputBox()
+			var buttonView = new FlowLayoutWidget()
 			{
-				Visible = false,
-				Margin = new BorderDouble(10, 0, 5, 0)
+				HAnchor = HAnchor.ParentLeftRight,
+				VAnchor = VAnchor.FitToChildren,
+				Margin = 8
 			};
-			searchPanel.searchInput.ActualTextEditWidget.EnterPressed += (s, e) =>
+			buttonView.AfterDraw += (s, e) =>
 			{
-				this.PerformSearch();
-			};
-			searchPanel.resetButton.Click += (s, e) =>
-			{
-				breadCrumbWidget.Visible = true;
-				searchPanel.Visible = false;
-
-				searchPanel.searchInput.Text = "";
-
-				this.ClearSearch();
+				e.graphics2D.Render(directionArrow, buttonView.LocalBounds.Right - arrowHeight * 2 - 2, buttonView.LocalBounds.Center.y + arrowHeight / 2, ActiveTheme.Instance.SecondaryTextColor);
 			};
 
-			// Store a reference to the input field
-			this.searchInput = searchPanel.searchInput;
-
-			breadCrumbBar.AddChild(searchPanel);
-
-			Button searchButton = buttonFactory.Generate("", icon);
-			searchButton.ToolTipText = "Search".Localize();
-			searchButton.Name = "Search Library Button";
-			searchButton.Margin = 0;
-			searchButton.Click += (s, e) =>
+			activeContainerTitle = new TextWidget(ApplicationController.Instance.Library.ActiveContainer.Name)
 			{
-				if (searchPanel.Visible)
+				Margin = new BorderDouble(left: 6)
+			};
+			buttonView.AddChild(activeContainerTitle);
+
+			activeContainerPopup = new PopupButton(buttonView)
+			{
+				VAnchor = VAnchor.ParentCenter,
+				HAnchor = HAnchor.ParentLeftRight,
+				Margin = 0
+			};
+			activeContainerPopup.DynamicPopupContent = () =>
+			{
+				var container = new GuiWidget(400, this.Height)
 				{
-					PerformSearch();
-				}
-				else
-				{
-					searchContainer = this.libraryView.ActiveContainer;
+					BackgroundColor = ActiveTheme.Instance.SecondaryBackgroundColor
+				};
 
-					breadCrumbWidget.Visible = false;
-					searchPanel.Visible = true;
-					searchInput.Focus();
-				}
+				container.AddChild(new ListView(ApplicationController.Instance.Library)
+				{
+					HAnchor = HAnchor.ParentLeftRight,
+					ShowItems = false
+				});
+
+				return container;
 			};
-			buttonFactory.Margin = initialMargin;
-			breadCrumbBar.AddChild(searchButton);
+
+			breadCrumbBar.AddChild(activeContainerPopup);
 
 			overflowDropdown = new OverflowDropdown(allowLightnessInvert: true)
 			{
+				VAnchor = VAnchor.ParentCenter,
 				AlignToRightEdge = true,
-				Name = "Print Library Overflow Menu"
+				Name = "Print Library Overflow Menu",
 			};
 			breadCrumbBar.AddChild(overflowDropdown);
 
@@ -247,8 +241,10 @@ namespace MatterHackers.MatterControl.PrintLibrary
 			addToLibraryButton.Enabled = containerSupportsEdits;
 			createFolderButton.Enabled = containerSupportsEdits && writableContainer?.AllowAction(ContainerActions.AddContainers) == true;
 
-			searchInput.Text = activeContainer.KeywordFilter;
-			breadCrumbWidget.SetBreadCrumbs(activeContainer);
+			activeContainerTitle.Text = activeContainer.Name;
+
+			// searchInput.Text = activeContainer.KeywordFilter;
+			//breadCrumbWidget.SetBreadCrumbs(activeContainer);
 
 			activeContainer.Reloaded += UpdateStatus;
 
@@ -741,30 +737,6 @@ namespace MatterHackers.MatterControl.PrintLibrary
 			base.OnClosed(e);
 		}
 
-		private void PerformSearch()
-		{
-			UiThread.RunOnIdle(() =>
-			{
-				libraryView.ActiveContainer.KeywordFilter = searchInput.Text.Trim();
-				breadCrumbWidget.SetBreadCrumbs(libraryView.ActiveContainer);
-			});
-		}
-
-		private void ClearSearch()
-		{
-			UiThread.RunOnIdle(() =>
-			{
-				searchContainer.KeywordFilter = "";
-
-				// Restore the original ActiveContainer before search started - some containers may change context
-				ApplicationController.Instance.Library.ActiveContainer = searchContainer;
-
-				breadCrumbWidget.SetBreadCrumbs(libraryView.ActiveContainer);
-
-				searchContainer = null;
-			});
-		}
-
 		private async void addToQueueButton_Click(object sender, EventArgs e)
 		{
 			var selectedItems = libraryView.SelectedItems.Select(o => o.Model);
@@ -997,34 +969,5 @@ namespace MatterHackers.MatterControl.PrintLibrary
 
 			base.OnLoad(args);
 		}
-
-		private class SearchInputBox : GuiWidget
-		{
-			internal MHTextEditWidget searchInput;
-			internal Button resetButton;
-
-			public SearchInputBox()
-			{
-				this.VAnchor = VAnchor.ParentCenter | VAnchor.FitToChildren;
-				this.HAnchor = HAnchor.ParentLeftRight;
-
-				searchInput = new MHTextEditWidget(messageWhenEmptyAndNotSelected: "Search Library".Localize())
-				{
-					Name = "Search Library Edit",
-					HAnchor = HAnchor.ParentLeftRight,
-					VAnchor = VAnchor.ParentCenter
-				};
-				this.AddChild(searchInput);
-
-				resetButton = ApplicationController.Instance.Theme.CreateSmallResetButton();
-				resetButton.HAnchor = HAnchor.ParentRight | HAnchor.FitToChildren;
-				resetButton.VAnchor = VAnchor.ParentCenter | VAnchor.FitToChildren;
-				resetButton.Name = "Close Search";
-				resetButton.ToolTipText = "Clear".Localize();
-
-				this.AddChild(resetButton);
-			}
-		}
-
 	}
 }

--- a/MatterControl.csproj
+++ b/MatterControl.csproj
@@ -186,6 +186,7 @@
     <Compile Include="Library\Providers\CreatorsContainer.cs" />
     <Compile Include="Library\Providers\LibraryConfig.cs" />
     <Compile Include="Library\Providers\MatterControl\CalibrationPartsContainer.cs" />
+    <Compile Include="Library\Widgets\ListContainerBrowser.cs" />
     <Compile Include="Library\Widgets\ListView\IconListView.cs" />
     <Compile Include="Library\Widgets\ListView\IListContentView.cs" />
     <Compile Include="Library\Widgets\ListView\ListViewItemBase.cs" />

--- a/PartPreviewWindow/SaveAsWindow.cs
+++ b/PartPreviewWindow/SaveAsWindow.cs
@@ -115,7 +115,8 @@ namespace MatterHackers.MatterControl
 
 			librarySelectorWidget = new ListView(libraryNavContext)
 			{
-				BackgroundColor = ActiveTheme.Instance.TertiaryBackgroundColor
+				BackgroundColor = ActiveTheme.Instance.TertiaryBackgroundColor,
+				ShowItems = false
 			};
 
 			// put in the bread crumb widget


### PR DESCRIPTION
- Sidebar should focus on usable scene content
- Container browser should allow changing context of sidebar content
- Filter containers from library sidebar
- Replace breadcrumb bar with new container dropdown
- Add filtering to listview for containers/items
- Add container browser for container bar popup
- Filter library items from container browser
- Filter library items from SaveAs selector window

- Issue MatterHackers/MCCentral#1541
SaveAs window should only show writable locations and should not list container items
- Issue MatterHackers/MCCentral#1767
Content navigation and search