### PR TITLE
Restore the previous bedplate on load, revert to white icons

### DIFF
--- a/ApplicationView/ApplicationController.cs
+++ b/ApplicationView/ApplicationController.cs
@@ -278,14 +278,15 @@ namespace MatterHackers.MatterControl
 		{
 			string now = DateTime.Now.ToString("yyyyMMdd-HHmmss");
 
-			string platingDirectory = Path.Combine(ApplicationDataStorage.Instance.ApplicationTempDataPath, "Plating");
-			Directory.CreateDirectory(platingDirectory);
-
-			string mcxPath = Path.Combine(platingDirectory, now + ".mcx");
+			string mcxPath = Path.Combine(ApplicationDataStorage.Instance.PlatingDirectory, now + ".mcx");
 
 			ApplicationController.Instance.ActivePrintItem = new PrintItemWrapper(new PrintItem(now, mcxPath));
 
 			File.WriteAllText(mcxPath, new Object3D().ToJson());
+
+			ApplicationController.Instance.ActiveView3DWidget?.Scene.Load(mcxPath);
+			ApplicationController.Instance.ActiveView3DWidget?.PartHasBeenChanged();
+
 		}
 
 		public ThemeConfig Theme { get; set; } = new ThemeConfig();

--- a/ApplicationView/WidescreenPanel.cs
+++ b/ApplicationView/WidescreenPanel.cs
@@ -59,7 +59,10 @@ namespace MatterHackers.MatterControl
 				var firstFile = directoryInfo.GetFileSystemInfos("*.mcx").OrderByDescending(fl => fl.CreationTime).FirstOrDefault();
 
 				// Set as the current item - should be restored as the Active scene in the MeshViewer
-				ApplicationController.Instance.ActivePrintItem = new PrintItemWrapper(new PrintItem(firstFile.Name, firstFile.FullName));
+				if (firstFile != null)
+				{
+					ApplicationController.Instance.ActivePrintItem = new PrintItemWrapper(new PrintItem(firstFile.Name, firstFile.FullName));
+				}
 			}
 
 			var library3DViewSplitter = new Splitter()

--- a/ApplicationView/WidescreenPanel.cs
+++ b/ApplicationView/WidescreenPanel.cs
@@ -27,10 +27,14 @@ of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the FreeBSD Project.
 */
 
+using System.IO;
+using System.Linq;
 using MatterHackers.Agg;
 using MatterHackers.Agg.UI;
+using MatterHackers.MatterControl.DataStorage;
 using MatterHackers.MatterControl.PartPreviewWindow;
 using MatterHackers.MatterControl.PrintLibrary;
+using MatterHackers.MatterControl.PrintQueue;
 
 namespace MatterHackers.MatterControl
 {
@@ -50,7 +54,12 @@ namespace MatterHackers.MatterControl
 			// HACK: Long term we need a better solution which does not rely on ActivePrintItem/PrintItemWrapper
 			if (ApplicationController.Instance.ActivePrintItem == null)
 			{
-				ApplicationController.Instance.ClearPlate();
+				// Find the last used bed plate mcx
+				var directoryInfo = new DirectoryInfo(ApplicationDataStorage.Instance.PlatingDirectory);
+				var firstFile = directoryInfo.GetFileSystemInfos("*.mcx").OrderByDescending(fl => fl.CreationTime).FirstOrDefault();
+
+				// Set as the current item - should be restored as the Active scene in the MeshViewer
+				ApplicationController.Instance.ActivePrintItem = new PrintItemWrapper(new PrintItem(firstFile.Name, firstFile.FullName));
 			}
 
 			var library3DViewSplitter = new Splitter()

--- a/ApplicationView/WidescreenPanel.cs
+++ b/ApplicationView/WidescreenPanel.cs
@@ -65,6 +65,12 @@ namespace MatterHackers.MatterControl
 				}
 			}
 
+            // Clear if not assigned above
+            if (ApplicationController.Instance.ActivePrintItem == null)
+            {
+                ApplicationController.Instance.ClearPlate();
+            }
+
 			var library3DViewSplitter = new Splitter()
 			{
 				Padding = new BorderDouble(4),

--- a/DataStorage/Datastore.cs
+++ b/DataStorage/Datastore.cs
@@ -159,6 +159,17 @@ namespace MatterHackers.MatterControl.DataStorage
 			}
 		}
 
+		public string PlatingDirectory
+		{
+			get
+			{
+				string platingDirectory = Path.Combine(ApplicationTempDataPath, "Plating");
+				Directory.CreateDirectory(platingDirectory);
+
+				return platingDirectory;
+			}
+		}
+
 		public string DownloadsDirectory { get; } = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads");
 
 		public string CustomLibraryFoldersPath { get; } = Path.Combine(applicationUserDataPath, "LibraryFolders.conf");

--- a/Library/ContentProviders/MeshContentProvider.cs
+++ b/Library/ContentProviders/MeshContentProvider.cs
@@ -164,12 +164,12 @@ namespace MatterHackers.MatterControl
 					string cachePath = ApplicationController.Instance.CachePath(item);
 					ImageIO.SaveImageData(cachePath, thumbnail);
 
-					imageCallback(thumbnail.MultiplyWithPrimaryAccent());
+					imageCallback(thumbnail);
 				}
 				else
 				{
 					// If thumbnail generation was aborted or failed, return the default icon for this content type
-					imageCallback(DefaultImage.MultiplyWithPrimaryAccent());
+					imageCallback(DefaultImage);
 				}
 			}
 		}

--- a/Library/Widgets/ListView/ListView.cs
+++ b/Library/Widgets/ListView/ListView.cs
@@ -32,7 +32,6 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-using System.Threading.Tasks;
 using MatterHackers.Agg;
 using MatterHackers.Agg.Image;
 using MatterHackers.Agg.PlatformAbstract;
@@ -245,7 +244,7 @@ namespace MatterHackers.MatterControl.CustomWidgets
 				ImageIO.LoadImageData(cachePath, thumbnail);
 				thumbnail.SetRecieveBlender(new BlenderPreMultBGRA());
 				
-				return thumbnail.MultiplyWithPrimaryAccent();
+				return thumbnail;
 			}
 
 			return null;

--- a/Library/Widgets/ListView/ListViewItemBase.cs
+++ b/Library/Widgets/ListView/ListViewItemBase.cs
@@ -121,14 +121,14 @@ namespace MatterHackers.MatterControl.CustomWidgets
 					&& contentProvider is MeshContentProvider)
 				{
 					// Before we have a thumbnail set to the content specific thumbnail
-					thumbnail = contentProvider.DefaultImage.AlphaToPrimaryAccent();
+					thumbnail = contentProvider.DefaultImage;
 
 					ApplicationController.Instance.QueueForGeneration(async () =>
 					{
 						// When this widget is dequeued for generation, validate before processing. Off-screen widgets should be skipped and will requeue next time they become visible
 						if (ListViewItemBase.WidgetOnScreen(this, this.LocalBounds))
 						{
-							SetItemThumbnail(generatingThumbnailIcon.AlphaToPrimaryAccent());
+							SetItemThumbnail(generatingThumbnailIcon);
 
 							// Then try to load a content specific thumbnail
 							await contentProvider.GetThumbnail(

--- a/PartPreviewWindow/PlusTabPage.cs
+++ b/PartPreviewWindow/PlusTabPage.cs
@@ -31,7 +31,6 @@ using MatterHackers.Agg;
 using MatterHackers.Agg.UI;
 using MatterHackers.Localizations;
 using MatterHackers.MatterControl.ActionBar;
-using MatterHackers.MatterControl.CustomWidgets;
 using MatterHackers.MatterControl.PrinterCommunication;
 
 namespace MatterHackers.MatterControl.PartPreviewWindow
@@ -93,9 +92,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				{
 					UiThread.RunOnIdle(() =>
 					{
-						//WizardPage.WizardWindow.ChangeToSetupPrinterForm(true);
 						WizardWindow.ShowPrinterSetup(true);
-
 					});
 				}
 			};

--- a/PartPreviewWindow/View3D/MeshViewerWidget.cs
+++ b/PartPreviewWindow/View3D/MeshViewerWidget.cs
@@ -39,6 +39,7 @@ using MatterHackers.Agg.OpenGlGui;
 using MatterHackers.Agg.UI;
 using MatterHackers.Agg.VertexSource;
 using MatterHackers.DataConverters3D;
+using MatterHackers.MatterControl;
 using MatterHackers.MatterControl.PartPreviewWindow;
 using MatterHackers.PolygonMesh;
 using MatterHackers.RenderOpenGl;
@@ -83,6 +84,14 @@ namespace MatterHackers.MeshVisualizer
 		public MeshViewerWidget(Vector3 displayVolume, Vector2 bedCenter, BedShape bedShape, TrackballTumbleWidget trackballTumbleWidget, InteractionLayer interactionLayer, string startingTextMessage = "")
 		{
 			interactionLayer.Scene = Scene;
+
+			var activePrintItem = ApplicationController.Instance.ActivePrintItem;
+
+			if (activePrintItem != null 
+				&& File.Exists(activePrintItem.FileLocation))
+			{
+				Scene.Load(activePrintItem.FileLocation);
+			}
 
 			this.interactionLayer = interactionLayer;
 			this.World = interactionLayer.World;

--- a/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/PartPreviewWindow/View3D/View3DWidget.cs
@@ -332,6 +332,14 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 						});
 					};
 
+					Button clearPlateButton = smallMarginButtonFactory.Generate("Clear Plate".Localize());
+					clearPlateButton.Margin = new BorderDouble(right: 10);
+					clearPlateButton.Click += (sender, e) =>
+					{
+						UiThread.RunOnIdle(ApplicationController.Instance.ClearPlate);
+					};
+					doEdittingButtonsContainer.AddChild(clearPlateButton);
+
 					// put in the save button
 					AddSaveAndSaveAs(doEdittingButtonsContainer);
 

--- a/Tests/MatterControl.Tests/SceneTests.cs
+++ b/Tests/MatterControl.Tests/SceneTests.cs
@@ -34,6 +34,7 @@ using System.Threading.Tasks;
 using MatterHackers.Agg;
 using MatterHackers.Agg.PlatformAbstract;
 using MatterHackers.DataConverters3D;
+using MatterHackers.MatterControl;
 using MatterHackers.MatterControl.PartPreviewWindow;
 using MatterHackers.MatterControl.Tests.Automation;
 using MatterHackers.MeshVisualizer;
@@ -118,6 +119,8 @@ namespace MatterHackers.PolygonMesh.UnitTests
 
 			// because we are using it without adding it into a parent we need to initialize it
 			view3DWidget.Initialize();
+
+			ApplicationController.Instance.ClearPlate();
 
 			var scene = view3DWidget.Scene;
 			scene.Children.Add(new Object3D


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#1793
Restore non-colorized thumbnails per linked issue
- Related to MatterHackers/MCCentral#1775
UI for plating history