### PR TITLE
Specify type rather than instance for default container view widget

### DIFF
--- a/Library/Interfaces/ILibraryContainer.cs
+++ b/Library/Interfaces/ILibraryContainer.cs
@@ -43,7 +43,7 @@ namespace MatterHackers.MatterControl.Library
 		string KeywordFilter { get; set; }
 		bool IsProtected { get; }
 
-		GuiWidget DefaultView { get; }
+		Type DefaultView { get; }
 
 		event EventHandler Reloaded;
 

--- a/Library/Providers/LibraryContainer.cs
+++ b/Library/Providers/LibraryContainer.cs
@@ -78,7 +78,7 @@ namespace MatterHackers.MatterControl.Library
 		public string ID { get; set; }
 		public string Name { get; set; }
 
-		public GuiWidget DefaultView { get; protected set; }
+		public Type DefaultView { get; protected set; }
 
 		public List<ILibraryContainerLink> ChildContainers { get; set; }
 		public bool IsProtected => true;

--- a/Library/Providers/MatterControl/HistoryContainer.cs
+++ b/Library/Providers/MatterControl/HistoryContainer.cs
@@ -76,7 +76,7 @@ namespace MatterHackers.MatterControl.Library
 			this.ChildContainers = new List<ILibraryContainerLink>();
 			this.Items = new List<ILibraryItem>();
 			this.Name = "Print History".Localize();
-			this.DefaultView = new HistoryListView();
+			this.DefaultView = typeof(HistoryListView);
 
 			//PrintHistoryData.Instance.ItemAdded.RegisterEvent((sender, e) => OnDataReloaded(null), ref unregisterEvent);
 			

--- a/Library/Providers/RootLibraryContainer.cs
+++ b/Library/Providers/RootLibraryContainer.cs
@@ -48,7 +48,7 @@ namespace MatterHackers.MatterControl.Library
 
 		public ILibraryContainer Parent { get; set; } = null;
 
-		public GuiWidget DefaultView { get; } = null;
+		public Type DefaultView { get; } = null;
 
 		public string ID { get; } = "rootLibraryProvider";
 

--- a/Library/Widgets/ListView/ListView.cs
+++ b/Library/Widgets/ListView/ListView.cs
@@ -118,17 +118,22 @@ namespace MatterHackers.MatterControl.CustomWidgets
 		{
 			var activeContainer = e.ActiveContainer;
 
-			var containerDefaultView = activeContainer?.DefaultView;
-
-			if (containerDefaultView != null 
-				&& containerDefaultView != this.ListContentView)
+			Type targetType = activeContainer?.DefaultView;
+			if (targetType != null 
+				&& targetType != this.ListContentView.GetType())
 			{
 				stashedView = this.contentView;
-				// Critical that assign to the contentView backing field and not the ListContentView property that uses it
-				this.SetContentView(activeContainer.DefaultView);
+
+				// If the current view doesn't match the view requested by the container, construct and switch to the requested view
+				var targetView = Activator.CreateInstance(targetType) as GuiWidget;
+				if (targetView != null)
+				{
+					this.SetContentView(targetView);
+				}
 			}
 			else if (stashedView != null)
 			{
+				// Switch back to the original view
 				this.SetContentView(stashedView);
 				stashedView = null;
 			}


### PR DESCRIPTION
- Construct and switch to container requested view if not active
- MatterHackers/MCCentral#1814
'Already the child of another widget' exception when loading Print History