### PR TITLE
Verify ActiveSliceSettings for all export methods

### DIFF
--- a/Queue/OptionsMenu/QueueOptionsMenu.cs
+++ b/Queue/OptionsMenu/QueueOptionsMenu.cs
@@ -186,6 +186,10 @@ namespace MatterHackers.MatterControl.PrintQueue
 			{
 				UiThread.RunOnIdle(MustSelectPrinterMessage);
 			}
+			else if (!ActiveSliceSettings.Instance.IsValid())
+			{
+				return false;
+			}
 			else
 			{
 				UiThread.RunOnIdle(SelectLocationToExportGCode);
@@ -251,7 +255,19 @@ namespace MatterHackers.MatterControl.PrintQueue
 
 		private bool exportQueueToZipMenu_Click()
 		{
-			UiThread.RunOnIdle(ExportQueueToZipOnIdle);
+			if (!ActiveSliceSettings.Instance.PrinterSelected)
+			{
+				UiThread.RunOnIdle(MustSelectPrinterMessage);
+			}
+			else if (!ActiveSliceSettings.Instance.IsValid())
+			{
+				return false;
+			}
+			else
+			{
+				UiThread.RunOnIdle(ExportQueueToZipOnIdle);
+			}
+
 			return true;
 		}
 

--- a/Queue/QueueDataWidget.cs
+++ b/Queue/QueueDataWidget.cs
@@ -536,10 +536,27 @@ namespace MatterHackers.MatterControl.PrintQueue
 			SetEditButtonsStates();
 		}
 
+		private string pleaseSelectPrinterMessage = "Before you can export printable files, you must select a printer.";
+		private string pleaseSelectPrinterTitle = "Please select a printer";
+
+		private void MustSelectPrinterMessage()
+		{
+			StyledMessageBox.ShowMessageBox(null, pleaseSelectPrinterMessage, pleaseSelectPrinterTitle);
+		}
+
 		private void exportButton_Click(object sender, EventArgs mouseEvent)
 		{
 			//Open export options
-			if (QueueData.Instance.SelectedCount == 1)
+
+			if (!ActiveSliceSettings.Instance.PrinterSelected)
+			{
+				UiThread.RunOnIdle(MustSelectPrinterMessage);
+			}
+			else if (!ActiveSliceSettings.Instance.IsValid())
+			{
+				return;
+			}
+			else if (QueueData.Instance.SelectedCount == 1)
 			{
 				QueueRowItem libraryItem = queueDataView.GetQueueRowItem(QueueData.Instance.SelectedIndex);
 				if (libraryItem != null)


### PR DESCRIPTION
Fixes error where it is possible to export with invalid slice settings.

In "Layer View" clicking the "Generate" button will verify slice settings and complain if things are wrong. However, in the queue view if "Export", "Export to zip", or "Export to Folder or SD card" is selected, tool verification is not run and can cause the program to crash.

To recreate and crash MatterControl, set "Extruder Count" to 0 and click the "Export" button in the queue view.