### PR TITLE
Use TextObject.Spacing property

### DIFF
--- a/ApplicationView/ThemeConfig.cs
+++ b/ApplicationView/ThemeConfig.cs
@@ -439,20 +439,19 @@ namespace MatterHackers.MatterControl
 				scrollBarWidth = 20;
 			}
 
-			TextWidget spacingText = new TextWidget(header, textColor: ActiveTheme.Instance.PrimaryTextColor)
+			wordOptionContainer.AddChild(new TextWidget(header, textColor: ActiveTheme.Instance.PrimaryTextColor)
 			{
 				Margin = new BorderDouble(10, 3, 3, 5),
 				HAnchor = HAnchor.Left
-			};
-			wordOptionContainer.AddChild(spacingText);
+			});
 
-			SolidSlider namedSlider = new SolidSlider(new Vector2(), scrollBarWidth, 0, 1)
+			var namedSlider = new SolidSlider(new Vector2(), scrollBarWidth, 0, 1)
 			{
 				TotalWidthInPixels = DefaultScrollBarWidth,
 				Minimum = min,
 				Maximum = max,
-				Margin = new BorderDouble(3, 5, 3, 3),
-				HAnchor = HAnchor.Center,
+				Margin = new BorderDouble(12, 4),
+				HAnchor = HAnchor.Stretch,
 			};
 
 			wordOptionContainer.AddChild(namedSlider);

--- a/TextCreator/Text/TextEditor.cs
+++ b/TextCreator/Text/TextEditor.cs
@@ -44,7 +44,6 @@ namespace MatterHackers.MatterControl.Plugins.TextCreator
 	public class TextEditor : IObject3DEditor
 	{
 		private TextObject injectedItem = null;
-		private SolidSlider spacingScrollBar;
 		private TextGenerator textGenerator;
 		private MHTextEditWidget textToAddWidget;
 		private View3DWidget view3DWidget;
@@ -75,14 +74,17 @@ namespace MatterHackers.MatterControl.Plugins.TextCreator
 			textToAddWidget.ActualTextEditWidget.EnterPressed += (s, e) => RebuildText(textToAddWidget.Text);
 			container.AddChild(textToAddWidget);
 
-			spacingScrollBar = theme.CreateSolidSlider(container, "Spacing:".Localize(), .5, 1);
+			var spacingScrollBar = theme.CreateSolidSlider(container, "Spacing:".Localize(), .5, 1);
+			spacingScrollBar.Value = injectedItem.Spacing;
 			spacingScrollBar.ValueChanged += (sender, e) =>
-			 {
-				 if (injectedItem != null)
-				 {
-					 RebuildText(textToAddWidget.Text);
-				 }
-			 };
+			{
+				injectedItem.Spacing = spacingScrollBar.Value;
+
+				if (injectedItem != null)
+				{
+					RebuildText(textToAddWidget.Text);
+				}
+			};
 
 			Button updateButton = theme.ButtonFactory.Generate("Update".Localize());
 			updateButton.Margin = new BorderDouble(5);
@@ -141,7 +143,7 @@ namespace MatterHackers.MatterControl.Plugins.TextCreator
 			{
 				Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
 
-				return textGenerator.CreateText(text, spacingScrollBar.Value);
+				return textGenerator.CreateText(text, injectedItem.Spacing);
 			});
 
 			var scene = view3DWidget.InteractionLayer.Scene;


### PR DESCRIPTION
- Reduce accessibility of spacingScrollBar
- Ensure scrollbars resize with editor and start with correct bounds
- Issue MatterHackers/MCCentral#2110
TextBuilder Spacing settings do not round trip, are lost on close