### PR TITLE
Only verify ActiveSliceSettings when exporting/generating gcode

### DIFF
--- a/CustomWidgets/ExportPrintItemWindow.cs
+++ b/CustomWidgets/ExportPrintItemWindow.cs
@@ -288,6 +288,10 @@ namespace MatterHackers.MatterControl
 
 		private void ExportGCode_Click()
 		{
+			if (!ActiveSliceSettings.Instance.IsValid())
+			{
+				return;
+			}
 			SaveFileDialogParams saveParams = new SaveFileDialogParams("Export GCode|*.gcode", title: "Export GCode");
 			saveParams.Title = "MatterControl: Export File";
 			saveParams.ActionButtonLabel = "Export";

--- a/CustomWidgets/ExportPrintItemWindow.cs
+++ b/CustomWidgets/ExportPrintItemWindow.cs
@@ -290,6 +290,7 @@ namespace MatterHackers.MatterControl
 		{
 			if (!ActiveSliceSettings.Instance.IsValid())
 			{
+				Close();
 				return;
 			}
 			SaveFileDialogParams saveParams = new SaveFileDialogParams("Export GCode|*.gcode", title: "Export GCode");

--- a/PrinterCommunication/PrinterConnectionAndCommunication.cs
+++ b/PrinterCommunication/PrinterConnectionAndCommunication.cs
@@ -1359,7 +1359,7 @@ namespace MatterHackers.MatterControl.PrinterCommunication
 					{
 						StartSdCardPrint();
 					}
-					else if (ActiveSliceSettings.Instance.IsValid())
+					else
 					{
 						if (File.Exists(pathAndFile))
 						{
@@ -1390,7 +1390,7 @@ namespace MatterHackers.MatterControl.PrinterCommunication
 
 								UiThread.RunOnIdle(() => StyledMessageBox.ShowMessageBox(onConfirmPrint, gcodeWarningMessage, "Warning - GCode file".Localize(), new GuiWidget[] { new VerticalSpacer(), hideGCodeWarningCheckBox }, StyledMessageBox.MessageType.YES_NO));
 							}
-							else
+							else if (ActiveSliceSettings.Instance.IsValid())
 							{
 								CommunicationState = PrinterConnectionAndCommunication.CommunicationStates.PreparingToPrint;
 								PrintItemWrapper partToPrint = ActivePrintItem;

--- a/Queue/QueueDataWidget.cs
+++ b/Queue/QueueDataWidget.cs
@@ -552,10 +552,6 @@ namespace MatterHackers.MatterControl.PrintQueue
 			{
 				UiThread.RunOnIdle(MustSelectPrinterMessage);
 			}
-			else if (!ActiveSliceSettings.Instance.IsValid())
-			{
-				return;
-			}
 			else if (QueueData.Instance.SelectedCount == 1)
 			{
 				QueueRowItem libraryItem = queueDataView.GetQueueRowItem(QueueData.Instance.SelectedIndex);


### PR DESCRIPTION
This is a fix to my pull request, #2566. The fix issued before would complain about invalid slice settings if a gcode file was opened and printed. AMF's and STL's can also now be exported while invalid slice settings are selected. Slice settings are validated only when generating and/or exporting gcode.