### PR TITLE
Scene actions should be bound to their context, not to ActivePrinter

### DIFF
--- a/PartPreviewWindow/PartTabPage.cs
+++ b/PartPreviewWindow/PartTabPage.cs
@@ -55,7 +55,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			this.BackgroundColor = theme.TabBodyBackground;
 			this.Padding = 0;
 
-			viewControls3D = new ViewControls3D(theme, sceneContext.Scene.UndoBuffer)
+			viewControls3D = new ViewControls3D(sceneContext, theme, sceneContext.Scene.UndoBuffer)
 			{
 				//BackgroundColor = new Color(0, 0, 0, theme.OverlayAlpha),
 				PartSelectVisible = false,

--- a/PartPreviewWindow/ViewControls3D.cs
+++ b/PartPreviewWindow/ViewControls3D.cs
@@ -146,7 +146,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			}
 		}
 
-		public ViewControls3D(ThemeConfig theme, UndoBuffer undoBuffer)
+		public ViewControls3D(BedConfig sceneContext, ThemeConfig theme, UndoBuffer undoBuffer)
 		{
 			string iconPath;
 
@@ -323,7 +323,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				};
 				button.Click += (s, e) =>
 				{
-					namedAction.Action.Invoke(ApplicationController.Instance.ActivePrinter.Bed.Scene);
+					namedAction.Action.Invoke(sceneContext.Scene);
 				};
 				this.AddChild(button);
 			}


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#2211
Scene operations (subtract, intersect) do not work in Part view