### PR TITLE
Always hide GCode2D when switching to model view

### DIFF
--- a/PartPreviewWindow/PrinterTabPage.cs
+++ b/PartPreviewWindow/PrinterTabPage.cs
@@ -235,6 +235,10 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 							break;
 
 						case PartViewMode.Model:
+							if (gcode2DWidget != null)
+							{
+								gcode2DWidget.Visible = false;
+							}
 							this.ShowSliceLayers = false;
 							break;
 					}


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#2289
Can't switch from 2D Gcode view to 3D Model view