### PR TITLE
Compute opaque theme colors, save before slice, revise icon styling

### DIFF
--- a/ApplicationView/ApplicationController.cs
+++ b/ApplicationView/ApplicationController.cs
@@ -934,6 +934,28 @@ namespace MatterHackers.MatterControl
 			}
 		}
 
+		public string ComputeFileSha1(string filePath)
+		{
+			using (var stream = File.OpenRead(filePath))
+			{
+				return GenerateSha1(stream);
+			}
+		}
+
+		private string GenerateSha1(Stream stream)
+		{
+			// var timer = Stopwatch.StartNew();
+			using (var sha1 = System.Security.Cryptography.SHA1.Create())
+			{
+				byte[] hash = sha1.ComputeHash(stream);
+				string SHA1 = BitConverter.ToString(hash).Replace("-", String.Empty);
+
+				// Console.WriteLine("{0} {1} {2}", SHA1, timer.ElapsedMilliseconds, filePath);
+				return SHA1;
+			}
+		}
+
+
 		/// <summary>
 		/// Compute hash for string encoded as UTF8
 		/// </summary>

--- a/ApplicationView/ThemeConfig.cs
+++ b/ApplicationView/ThemeConfig.cs
@@ -95,13 +95,18 @@ namespace MatterHackers.MatterControl
 		public Color TabBodyBackground => new Color(ActiveTheme.Instance.TertiaryBackgroundColor, 175);
 
 		public TextImageButtonFactory ViewControlsButtonFactory { get; private set; }
+
 		public Color SplitterBackground { get; private set; } = new Color(0, 0, 0, 60);
+
 		public int SplitterWidth => (int)(6 * (GuiWidget.DeviceScale <= 1 ? GuiWidget.DeviceScale : GuiWidget.DeviceScale * 1.4));
 
 		public Color SlightShade { get; } = new Color(0, 0, 0, 40);
 		public Color MinimalShade { get; } = new Color(0, 0, 0, 15);
 		public Color Shade { get; } = new Color(0, 0, 0, 120);
 		public Color DarkShade { get; } = new Color(0, 0, 0, 190);
+
+		public Color ActiveTabColor { get; set; }
+		public Color InactiveTabColor { get; set; }
 
 		public TextImageButtonFactory DisableableControlBase { get; private set; }
 		public TextImageButtonFactory HomingButtons { get; private set; }
@@ -111,7 +116,6 @@ namespace MatterHackers.MatterControl
 		public BorderDouble ButtonSpacing { get; set; } = new BorderDouble(3, 0, 0, 0);
 		public TextImageButtonFactory NoMarginWhite { get; private set; }
 		public BorderDouble ToolbarPadding { get; set; } = 3;
-		public Color PrimaryTabFillColor { get; internal set; }
 		public double ButtonHeight { get; internal set; } = 32;
 
 		public int OverlayAlpha { get; set; } = 50;
@@ -157,6 +161,14 @@ namespace MatterHackers.MatterControl
 			commonOptions.ImageSpacing = 8;
 			commonOptions.BorderWidth = 0;
 			commonOptions.FixedHeight = 32;
+
+			this.ActiveTabColor = ResolveColor(theme.PrimaryBackgroundColor, new Color(Color.Black, this.SlightShade.alpha));
+
+			float alpha0to1 = (ActiveTheme.Instance.IsDarkTheme ? 20 : 60) / 255.0f;
+
+			this.InactiveTabColor = ResolveColor(theme.PrimaryBackgroundColor, new Color(Color.White, this.SlightShade.alpha));
+
+			this.SplitterBackground = this.ActiveTabColor;
 
 			this.ButtonFactory = new TextImageButtonFactory(commonOptions);
 
@@ -349,7 +361,12 @@ namespace MatterHackers.MatterControl
 				fontSize = FontSize10,
 				textColor = theme.SecondaryAccentColor
 			};
-			this.PrimaryTabFillColor = new Color(Color.White, ActiveTheme.Instance.IsDarkTheme ?  20 : 60);
+		}
+
+		// Compute a fixed color from a source and a target alpha
+		public Color ResolveColor(Color background, Color overlay)
+		{
+			return new BlenderRGBA().Blend(background, overlay);
 		}
 
 		public FlowLayoutWidget CreatePopupMenu(IEnumerable<NamedAction> menuActions)

--- a/CustomWidgets/DockingTabControl.cs
+++ b/CustomWidgets/DockingTabControl.cs
@@ -155,11 +155,11 @@ namespace MatterHackers.MatterControl.CustomWidgets
 				{
 					Width = PageWidth,
 					VAnchor = VAnchor.Stretch,
-					SpliterBarColor = ApplicationController.Instance.Theme.SplitterBackground,
-					SplitterWidth = ApplicationController.Instance.Theme.SplitterWidth,
+					SpliterBarColor = theme.SplitterBackground,
+					SplitterWidth = theme.SplitterWidth,
 				};
 
-				tabControl = ApplicationController.Instance.Theme.CreateTabControl();
+				tabControl = theme.CreateTabControl();
 				resizePage.AddChild(tabControl);
 
 				this.AddChild(resizePage);
@@ -222,11 +222,7 @@ namespace MatterHackers.MatterControl.CustomWidgets
 						MakeScrollable = false,
 					};
 
-					var spliterColor = ActiveTheme.Instance.PrimaryBackgroundColor;
-					var alpha = ApplicationController.Instance.Theme.SplitterBackground.Alpha0To1;
-					spliterColor.Red0To1 *= (1 - alpha);
-					spliterColor.Green0To1 *= (1 - alpha);
-					spliterColor.Blue0To1 *= (1 - alpha);
+					var spliterColor = theme.SplitterBackground;
 
 					var resizeContainer = new ResizeContainer(this)
 					{
@@ -297,6 +293,7 @@ namespace MatterHackers.MatterControl.CustomWidgets
 				}
 			}
 		}
+
 
 		private class DockingWindowContent : GuiWidget, IIgnoredPopupChild
 		{

--- a/CustomWidgets/SimpleButton.cs
+++ b/CustomWidgets/SimpleButton.cs
@@ -165,10 +165,7 @@ namespace MatterHackers.MatterControl.CustomWidgets
 		public RadioIconButton(ImageBuffer icon, ThemeConfig theme)
 			: base(icon, theme)
 		{
-			this.BorderColor = theme.ButtonFactory.Options.NormalTextColor;
 		}
-
-		public Color BorderColor { get; set; } = Color.White;
 
 		public override void OnClick(MouseEventArgs mouseEvent)
 		{
@@ -190,6 +187,8 @@ namespace MatterHackers.MatterControl.CustomWidgets
 						UncheckAllOtherRadioButtons();
 					}
 
+					this.BackgroundColor = (_checked) ? theme.MinimalShade : Color.Transparent;
+
 					OnCheckStateChanged();
 					Invalidate();
 				}
@@ -205,8 +204,7 @@ namespace MatterHackers.MatterControl.CustomWidgets
 		{
 			if (this.Checked)
 			{
-
-				graphics2D.Rectangle(LocalBounds, this.BorderColor);
+				graphics2D.Rectangle(0, 0, LocalBounds.Right, 2, ActiveTheme.Instance.PrimaryAccentColor);
 			}
 
 			base.OnDraw(graphics2D);

--- a/PartPreviewWindow/MainTab.cs
+++ b/PartPreviewWindow/MainTab.cs
@@ -43,12 +43,13 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 		private SimpleTabs parentTabControl;
 
-		public MainTab(string tabLabel, SimpleTabs parentTabControl, GuiWidget tabContent, string tabImageUrl = null)
+		public MainTab(string tabLabel, SimpleTabs parentTabControl, GuiWidget tabContent, ThemeConfig theme, string tabImageUrl = null)
 		{
 			this.HAnchor = HAnchor.Fit;
 			this.VAnchor = VAnchor.Fit | VAnchor.Bottom;
 			this.Padding = 0;
 			this.Margin = 0;
+			this.theme = theme;
 
 			this.TabContent = tabContent;
 			this.parentTabControl = parentTabControl;
@@ -76,11 +77,9 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			this.AddChild(closeButton);
 		}
 
+		private ThemeConfig theme;
+
 		public GuiWidget TabContent { get; }
-
-		public static Color ActiveTabColor =  ApplicationController.Instance.Theme.SlightShade;
-
-		public static Color InactiveTabColor = ApplicationController.Instance.Theme.PrimaryTabFillColor;
 
 		private static int tabInsetDistance = 14 / 2;
 
@@ -125,19 +124,19 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 			graphics2D.Render(
 				tabShape,
-				(this == activeTab) ? ActiveTabColor : InactiveTabColor);
+				(this == activeTab) ? theme.ActiveTabColor : theme.InactiveTabColor);
 
 			if (!isFirstTab)
 			{
 				DrawTabLowerLeft(
 					graphics2D, 
 					rect, 
-					(this.PreviousTab == activeTab || this == activeTab) ? ActiveTabColor : InactiveTabColor);
+					(this.PreviousTab == activeTab || this == activeTab) ? theme.ActiveTabColor : theme.InactiveTabColor);
 			}
 
 			if (rightSiblingSelected)
 			{
-				DrawTabLowerRight(graphics2D, rect, ActiveTabColor);
+				DrawTabLowerRight(graphics2D, rect, theme.ActiveTabColor);
 			}
 
 			base.OnDraw(graphics2D);

--- a/PartPreviewWindow/NewTabButton.cs
+++ b/PartPreviewWindow/NewTabButton.cs
@@ -38,13 +38,13 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 	public class NewTabButton : GuiWidget
 	{
 		private SimpleTabs parentTabControl;
-
-		public IconButton IconButton { get; }
+		private ThemeConfig theme;
 
 		public NewTabButton(ImageBuffer imageBuffer, SimpleTabs parentTabControl, ThemeConfig theme)
 		{
 			this.parentTabControl = parentTabControl;
 			this.HAnchor = HAnchor.Fit;
+			this.theme = theme;
 
 			IconButton = new IconButton(imageBuffer, theme)
 			{
@@ -60,12 +60,14 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 		public ITab LastTab { get; set; }
 
+		public IconButton IconButton { get; }
+
 		public override void OnDraw(Graphics2D graphics2D)
 		{
 			MainTab.DrawTabLowerLeft(
 				graphics2D, 
 				this.LocalBounds, 
-				(parentTabControl.ActiveTab == this.LastTab) ? MainTab.ActiveTabColor : MainTab.InactiveTabColor);
+				(parentTabControl.ActiveTab == this.LastTab) ? theme.ActiveTabColor : theme.InactiveTabColor);
 
 			base.OnDraw(graphics2D);
 		}

--- a/PartPreviewWindow/PartPreviewContent.cs
+++ b/PartPreviewWindow/PartPreviewContent.cs
@@ -44,8 +44,6 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 	{
 		private EventHandler unregisterEvents;
 		private MainTab printerTab = null;
-
-		private NewTabButton plusTabSelect;
 		private ChromeTabs tabControl;
 
 		public PartPreviewContent()
@@ -81,8 +79,8 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				}
 			};
 
+			tabControl.TabBar.BorderColor = theme.ActiveTabColor;
 			tabControl.TabBar.Padding = new BorderDouble(top: 4);
-			tabControl.TabBar.BorderColor = ApplicationController.Instance.Theme.SlightShade;
 			tabControl.TabBar.Border = new BorderDouble(bottom: 2);
 
 			Color selectedTabColor = ActiveTheme.Instance.TabLabelSelected;
@@ -98,14 +96,14 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			else
 			{
 				this.CreatePartTab(
-						"New Part",
-						new BedConfig(
-							new EditContext()
-							{
-								ContentStore = ApplicationController.Instance.Library.PlatingHistory,
-								SourceItem = BedConfig.NewPlatingItem()
-							}),
-						theme);
+					"New Part",
+					new BedConfig(
+						new EditContext()
+						{
+							ContentStore = ApplicationController.Instance.Library.PlatingHistory,
+							SourceItem = BedConfig.NewPlatingItem()
+						}),
+					theme);
 			}
 
 			// add in the update available button
@@ -178,6 +176,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				tabTitle,
 				tabControl,
 				new PrinterTabPage(printer, theme, tabTitle.ToUpper()),
+				theme,
 				"https://www.google.com/s2/favicons?domain=" + oemUrl ?? "www.matterhackers.com")
 			{
 				Name = "3D View Tab",
@@ -191,6 +190,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				tabTitle,
 				tabControl,
 				new PartTabPage(null, sceneContext, theme, "xxxxx"),
+				theme,
 				"https://i.imgur.com/nkeYgfU.png")
 			{
 				Name = "newPart" + tabControl.AllTabs.Count(),

--- a/PartPreviewWindow/Toolbar.cs
+++ b/PartPreviewWindow/Toolbar.cs
@@ -181,7 +181,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			leadingTabAdornment.AfterDraw += (s, e) =>
 			{
 				var firstItem = this.AllTabs.OfType<MainTab>().FirstOrDefault();
-				MainTab.DrawTabLowerRight(e.graphics2D, leadingTabAdornment.LocalBounds, (firstItem == this.ActiveTab) ? MainTab.ActiveTabColor : MainTab.InactiveTabColor);
+				MainTab.DrawTabLowerRight(e.graphics2D, leadingTabAdornment.LocalBounds, (firstItem == this.ActiveTab) ? theme.ActiveTabColor : theme.InactiveTabColor);
 			};
 			this.TabBar.ActionBar.AddChild(leadingTabAdornment);
 
@@ -198,7 +198,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			plusTabButton.IconButton.Click += (s, e) =>
 			{
 				this.AddTab(
-					new MainTab("New Tab".Localize(), this, this.NewTabPage())
+					new MainTab("New Tab".Localize(), this, this.NewTabPage(), theme)
 					{
 						MinimumSize = new Vector2(0, theme.shortButtonHeight)
 					});

--- a/PartPreviewWindow/View3D/SlicePopupMenu.cs
+++ b/PartPreviewWindow/View3D/SlicePopupMenu.cs
@@ -122,6 +122,8 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 					try
 					{
+						await printerTabPage.view3DWidget.SaveChanges();
+
 						await ApplicationController.Instance.SliceFileLoadOutput(
 							printer,
 							printer.Bed.EditContext.PartFilePath,

--- a/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/PartPreviewWindow/View3D/View3DWidget.cs
@@ -1998,7 +1998,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 		internal GuiWidget selectedObjectContainer;
 
-		private async Task SaveChanges()
+		internal async Task SaveChanges()
 		{
 			if (Scene.HasChildren())
 			{

--- a/PartPreviewWindow/ViewControls3D.cs
+++ b/PartPreviewWindow/ViewControls3D.cs
@@ -310,7 +310,9 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 			this.AddChild(new VerticalLine(50)
 			{
-				Margin = 3
+				Margin = 3,
+				Border = new BorderDouble(right: 5),
+				BorderColor = new Color(theme.ButtonFactory.Options.NormalTextColor, 100)
 			});
 
 			foreach (var namedAction in ApplicationController.Instance.RegisteredSceneOperations())


### PR DESCRIPTION
- Change slicing hash generation method/name
- Add ComputeFileSha1 to ApplicationController
- Issue MatterHackers/MCCentral#2307
Same color supplied for both tab and border
- Issue MatterHackers/MCCentral#2304
Have to Save file to make slicing go after change to scene