### PR TITLE
Make infill overlap take a 0

### DIFF
--- a/SlicerConfiguration/SlicerMapping/EngineMappingMatterSlice.cs
+++ b/SlicerConfiguration/SlicerMapping/EngineMappingMatterSlice.cs
@@ -79,7 +79,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				new MappedSetting("disable_fan_first_layers", "firstLayerToAllowFan"),
 				new MappedSetting("extrusion_multiplier", "extrusionMultiplier"),
 				new MappedSetting("fill_angle", "infillStartingAngle"),
-				new AsPercentOfReferenceOrDirect(SettingsKey.infill_overlap_perimeter, "infillExtendIntoPerimeter", SettingsKey.nozzle_diameter),
+				new AsPercentOfReferenceOrDirect(SettingsKey.infill_overlap_perimeter, "infillExtendIntoPerimeter", SettingsKey.nozzle_diameter, change0ToReference: false),
 				new OverrideSpeedOnSlaPrinters("infill_speed", "infillSpeed", "infill_speed"),
 				new MappedSetting("infill_type", "infillType"),
 				new MappedSetting("max_fan_speed", "fanSpeedMaxPercent"),

--- a/SlicerConfiguration/SlicerMapping/MappingClasses.cs
+++ b/SlicerConfiguration/SlicerMapping/MappingClasses.cs
@@ -553,12 +553,14 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 	public class AsPercentOfReferenceOrDirect : MappedSetting
 	{
+		bool change0ToReference;
 		string originalReference;
 		double scale;
 
-		public AsPercentOfReferenceOrDirect(string canonicalSettingsName, string exportedName, string originalReference, double scale = 1)
+		public AsPercentOfReferenceOrDirect(string canonicalSettingsName, string exportedName, string originalReference, double scale = 1, bool change0ToReference = true)
 			: base(canonicalSettingsName, exportedName)
 		{
+			this.change0ToReference = change0ToReference;
 			this.scale = scale;
 			this.originalReference = originalReference;
 		}
@@ -581,7 +583,8 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 					finalValue = ParseDouble(base.Value);
 				}
 
-				if (finalValue == 0)
+				if (change0ToReference
+					&& finalValue == 0)
 				{
 					finalValue = ParseDouble(ActiveSliceSettings.Instance.GetValue(originalReference));
 				}


### PR DESCRIPTION
issue: MatterHackers/MCCentral#2457
Infill overlap of 0 results in 100% nozzle diameter