### PR TITLE
Update the default name we use to save the workspace

### DIFF
--- a/ApplicationView/ApplicationController.cs
+++ b/ApplicationView/ApplicationController.cs
@@ -1285,7 +1285,7 @@ namespace MatterHackers.MatterControl
 							string platingDirectory = Path.Combine(ApplicationDataStorage.Instance.ApplicationLibraryDataPath, "PrintHistory");
 							Directory.CreateDirectory(platingDirectory);
 
-							string now = DateTime.Now.ToString("yyyyMMdd-HHmmss");
+							string now = "Workspace " + DateTime.Now.ToString("yyyy-MM-dd HH_mm_ss");
 							string archivePath = Path.Combine(platingDirectory, now + ".zip");
 
 							using (var file = File.OpenWrite(archivePath))

--- a/ApplicationView/PrinterModels.cs
+++ b/ApplicationView/PrinterModels.cs
@@ -126,7 +126,7 @@ namespace MatterHackers.MatterControl
 
 		internal static ILibraryItem NewPlatingItem()
 		{
-			string now = DateTime.Now.ToString("yyyyMMdd-HHmmss");
+			string now = "Workspace " + DateTime.Now.ToString("yyyy-MM-dd HH_mm_ss");
 			string mcxPath = Path.Combine(ApplicationDataStorage.Instance.PlatingDirectory, now + ".mcx");
 
 			File.WriteAllText(mcxPath, new Object3D().ToJson());

--- a/CustomWidgets/ExportPrintItemPage.cs
+++ b/CustomWidgets/ExportPrintItemPage.cs
@@ -198,12 +198,13 @@ namespace MatterHackers.MatterControl
 				UiThread.RunOnIdle(() =>
 				{
 					string title = ApplicationController.Instance.ProductName + " - " + "Export File".Localize();
+					string workspaceName = "Workspace " + DateTime.Now.ToString("yyyy-MM-dd HH_mm_ss");
 					AggContext.FileDialogs.SaveFileDialog(
 						new SaveFileDialogParams(fileTypeFilter)
 						{
 							Title = title,
 							ActionButtonLabel = "Export".Localize(),
-							FileName = Path.GetFileNameWithoutExtension(libraryItems.FirstOrDefault()?.Name ?? DateTime.Now.ToString("yyyyMMdd-HHmmss"))
+							FileName = Path.GetFileNameWithoutExtension(libraryItems.FirstOrDefault()?.Name ?? workspaceName)
 						},
 						(saveParams) =>
 						{


### PR DESCRIPTION
issue: MatterHackers/MCCentral#1933
2.0: Exporting does not maintain model name