### PR TITLE
Extruders beyond 0 only have temperature

### DIFF
--- a/ConfigurationPage/PrintLeveling/PrintLevelPages.cs
+++ b/ConfigurationPage/PrintLeveling/PrintLevelPages.cs
@@ -54,8 +54,7 @@ namespace MatterHackers.MatterControl.ConfigurationPage.PrintLeveling
 		public SelectMaterialPage(PrinterConfig printer, string pageDescription, string instructionsText)
 			: base(printer, pageDescription, instructionsText)
 		{
-			int extruderIndex = 0;
-			var materialSelector = new PresetSelectorWidget(printer, string.Format($"{"Material".Localize()} {extruderIndex + 1}"), Color.Transparent, NamedSettingsLayers.Material, extruderIndex);
+			var materialSelector = new PresetSelectorWidget(printer, "Material".Localize(), Color.Transparent, NamedSettingsLayers.Material);
 			materialSelector.BackgroundColor = Color.Transparent;
 			materialSelector.Margin = new BorderDouble(0, 0, 0, 15);
 			topToBottomControls.AddChild(materialSelector);

--- a/ConfigurationPage/RunningMacroPage.cs
+++ b/ConfigurationPage/RunningMacroPage.cs
@@ -59,8 +59,7 @@ namespace MatterHackers.MatterControl.PrinterControls
 
 			if (macroData.showMaterialSelector)
 			{
-				int extruderIndex = 0;
-				var materialSelector = new PresetSelectorWidget(printer, string.Format($"{"Material".Localize()} {extruderIndex + 1}"), Color.Transparent, NamedSettingsLayers.Material, extruderIndex);
+				var materialSelector = new PresetSelectorWidget(printer, "Material".Localize(), Color.Transparent, NamedSettingsLayers.Material);
 				materialSelector.BackgroundColor = Color.Transparent;
 				materialSelector.Margin = new BorderDouble(0, 0, 0, 15);
 				contentRow.AddChild(materialSelector);

--- a/PrinterEmulator/EmulatorPortFactory.cs
+++ b/PrinterEmulator/EmulatorPortFactory.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) 2015, Lars Brubaker
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+using MatterHackers.SerialPortCommunication.FrostedSerial;
+
+namespace MatterHackers.PrinterEmulator
+{
+	public class EmulatorPortFactory : FrostedSerialPortFactory
+	{
+		override protected string GetDriverType() => "Emulator";
+		public override IFrostedSerialPort Create(string serialPortName) => new Emulator();
+	}
+}

--- a/PrinterEmulator/Heater.cs
+++ b/PrinterEmulator/Heater.cs
@@ -1,0 +1,140 @@
+﻿// Copyright (c) 2015, Lars Brubaker
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//
+// 1. Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation
+// and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+// ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace MatterHackers.PrinterEmulator
+{
+	public partial class Emulator
+	{
+		public class Heater
+		{
+			public static int BounceAmount = (int)IncrementAmount / 2;
+			public static double IncrementAmount = 5.3;
+			private static int loopTimeInMs = 100;
+			private double _currentTemperature;
+			private bool _enabled;
+			private double _heatupTimeInSeconds = DefaultHeatUpTime;
+			private bool isDirty = true;
+			private bool shutdown = false;
+			private double targetTemp;
+
+			public Heater(string identifier)
+			{
+				this.ID = identifier;
+
+				// Maintain temperatures
+				Task.Run(() =>
+				{
+					Thread.CurrentThread.Name = $"EmulatorHeator{identifier}";
+
+					var random = new Random();
+
+					double requiredLoops = 0;
+					double incrementPerLoop = 0;
+
+					while (!shutdown)
+					{
+						if (this.Enabled
+							&& targetTemp > 0)
+						{
+							if (this.isDirty)
+							{
+								requiredLoops = this.HeatUpTimeInSeconds * 1000 / loopTimeInMs;
+								incrementPerLoop = TargetTemperature / requiredLoops;
+							}
+
+							if (CurrentTemperature < targetTemp)
+							{
+								CurrentTemperature += incrementPerLoop;
+							}
+							else if (CurrentTemperature != targetTemp)
+							{
+								CurrentTemperature = targetTemp;
+							}
+						}
+
+						Thread.Sleep(loopTimeInMs);
+					}
+				});
+			}
+
+			public double CurrentTemperature
+			{
+				get => _currentTemperature;
+				set
+				{
+					_currentTemperature = value;
+					isDirty = true;
+				}
+			}
+
+			public bool Enabled
+			{
+				get => _enabled;
+				set
+				{
+					if (_enabled != value)
+					{
+						_enabled = value;
+						CurrentTemperature = 0;
+					}
+				}
+			}
+
+			public double EPosition { get; set; }
+
+			public double HeatUpTimeInSeconds
+			{
+				get => _heatupTimeInSeconds;
+				set
+				{
+					_heatupTimeInSeconds = value;
+					isDirty = true;
+				}
+			}
+
+			public string ID { get; }
+
+			public double TargetTemperature
+			{
+				get => targetTemp;
+				set
+				{
+					if (targetTemp != value)
+					{
+						targetTemp = value;
+						this.Enabled = this.targetTemp > 0;
+					}
+				}
+			}
+
+			public void Stop()
+			{
+				shutdown = true;
+			}
+		}
+	}
+}

--- a/PrinterEmulator/PrinterEmulator.csproj
+++ b/PrinterEmulator/PrinterEmulator.csproj
@@ -60,6 +60,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Emulator.cs" />
+    <Compile Include="EmulatorPortFactory.cs" />
+    <Compile Include="Heater.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/SlicerConfiguration/PresetSelectorWidget.cs
+++ b/SlicerConfiguration/PresetSelectorWidget.cs
@@ -45,7 +45,6 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		public DropDownList DropDownList;
 		private string defaultMenuItemText = "- none -".Localize();
 		private Button editButton;
-		private int extruderIndex;
 		private NamedSettingsLayers layerType;
 		private PrinterConfig printer;
 		private GuiWidget pullDownContainer;
@@ -53,7 +52,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		private bool whiteBackground;
 		//For multiple materials
 
-		public PresetSelectorWidget(PrinterConfig printer, string label, Color accentColor, NamedSettingsLayers layerType, int extruderIndex, bool whiteBackground = false)
+		public PresetSelectorWidget(PrinterConfig printer, string label, Color accentColor, NamedSettingsLayers layerType, bool whiteBackground = false)
 			: base(FlowDirection.TopToBottom)
 		{
 			this.printer = printer;
@@ -72,7 +71,6 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				}
 			}, ref unregisterEvents);
 
-			this.extruderIndex = extruderIndex;
 			this.layerType = layerType;
 
 			this.HAnchor = HAnchor.Stretch;
@@ -126,7 +124,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				{
 					if (ApplicationController.Instance.EditMaterialPresetsWindow == null)
 					{
-						string presetsID = printer.Settings.GetMaterialPresetKey(extruderIndex);
+						string presetsID = printer.Settings.ActiveMaterialKey;
 						if (string.IsNullOrEmpty(presetsID))
 						{
 							return;
@@ -139,7 +137,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 							LayerType = NamedSettingsLayers.Material,
 							SetAsActive = (materialKey) =>
 							{
-								printer.Settings.SetMaterialPreset(this.extruderIndex, materialKey);
+								printer.Settings.ActiveMaterialKey = materialKey;
 							},
 							DeleteLayer = () =>
 							{
@@ -152,7 +150,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 									}
 								}
 
-								printer.Settings.SetMaterialPreset(extruderIndex, "");
+								printer.Settings.ActiveMaterialKey = "";
 								printer.Settings.MaterialLayers.Remove(layerToEdit);
 								printer.Settings.Save();
 							}
@@ -268,7 +266,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				{
 					newLayer.Name = "Material" + printer.Settings.MaterialLayers.Count;
 					printer.Settings.MaterialLayers.Add(newLayer);
-					printer.Settings.SetMaterialPreset(this.extruderIndex, newLayer.LayerID);
+					printer.Settings.ActiveMaterialKey = newLayer.LayerID;
 				}
 
 				RebuildDropDownList();
@@ -282,7 +280,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 				if (layerType == NamedSettingsLayers.Material)
 				{
-					settingsKey = printer.Settings.GetMaterialPresetKey(extruderIndex);
+					settingsKey = printer.Settings.ActiveMaterialKey;
 
 					printer.Settings.MaterialLayers.CollectionChanged += SettingsLayers_CollectionChanged;
 					dropDownList.Closed += (s1, e1) =>
@@ -328,12 +326,12 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 			if (layerType == NamedSettingsLayers.Material)
 			{
-				if (activeSettings.GetMaterialPresetKey(extruderIndex) != item.Value)
+				if (activeSettings.ActiveMaterialKey != item.Value)
 				{
 					// Restore deactivated user overrides by iterating the Material preset we're coming off of
 					activeSettings.RestoreConflictingUserOverrides(activeSettings.MaterialLayer);
 
-					activeSettings.SetMaterialPreset(extruderIndex, item.Value);
+					activeSettings.ActiveMaterialKey = item.Value;
 
 					// Deactivate conflicting user overrides by iterating the Material preset we've just switched to
 					activeSettings.DeactivateConflictingUserOverrides(activeSettings.MaterialLayer);

--- a/SlicerConfiguration/PresetsToolbar.cs
+++ b/SlicerConfiguration/PresetsToolbar.cs
@@ -42,28 +42,9 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 			int numberOfHeatedExtruders = printer.Settings.Helpers.NumberOfHotEnds();
 
-			this.AddChild(new PresetSelectorWidget(printer, "Quality".Localize(), Color.Yellow, NamedSettingsLayers.Quality, 0));
+			this.AddChild(new PresetSelectorWidget(printer, "Quality".Localize(), Color.Yellow, NamedSettingsLayers.Quality));
 			this.AddChild(new GuiWidget(8, 0));
-
-			if (numberOfHeatedExtruders > 1)
-			{
-				List<Color> colorList = new List<Color>() { Color.Orange, Color.Violet, Color.YellowGreen };
-
-				for (int i = 0; i < numberOfHeatedExtruders; i++)
-				{
-					if (i > 0)
-					{
-						this.AddChild(new GuiWidget(8, 0));
-					}
-					int colorIndex = i % colorList.Count;
-					Color color = colorList[colorIndex];
-					this.AddChild(new PresetSelectorWidget(printer, string.Format("{0} {1}", "Material".Localize(), i + 1), color, NamedSettingsLayers.Material, i));
-				}
-			}
-			else
-			{
-				this.AddChild(new PresetSelectorWidget(printer, "Material".Localize(), Color.Orange, NamedSettingsLayers.Material, 0));
-			}
+			this.AddChild(new PresetSelectorWidget(printer, "Material".Localize(), Color.Orange, NamedSettingsLayers.Material));
 
 			this.Height = 60 * GuiWidget.DeviceScale;
 		}

--- a/SlicerConfiguration/Settings/PrinterSettings.cs
+++ b/SlicerConfiguration/Settings/PrinterSettings.cs
@@ -291,7 +291,19 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			}
 		}
 
-		public string GetMaterialPresetKey(int extruderIndex)
+		public string ActiveMaterialKey
+		{
+			get
+			{
+				return GetMaterialPresetKey(0);
+			}
+			internal set
+			{
+				SetMaterialPreset(0, value);
+			}
+		}
+
+		private string GetMaterialPresetKey(int extruderIndex)
 		{
 			if (extruderIndex >= MaterialSettingsKeys.Count)
 			{
@@ -301,7 +313,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			return MaterialSettingsKeys[extruderIndex];
 		}
 
-		public void SetMaterialPreset(int extruderIndex, string materialKey)
+		private void SetMaterialPreset(int extruderIndex, string materialKey)
 		{
 			if (extruderIndex >= PrinterCommunication.PrinterConnection.MAX_EXTRUDERS)
 			{

--- a/SlicerConfiguration/Settings/SettingsHelpers.cs
+++ b/SlicerConfiguration/Settings/SettingsHelpers.cs
@@ -130,6 +130,9 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 		public const string write_regex = nameof(write_regex);
 		public const string read_regex = nameof(read_regex);
 		public const string temperature = nameof(temperature);
+		public const string temperature1 = nameof(temperature1);
+		public const string temperature2 = nameof(temperature2);
+		public const string temperature3 = nameof(temperature3);
 		public const string enable_retractions = nameof(enable_retractions);
 		public const string use_z_probe = nameof(use_z_probe);
 		public const string z_probe_samples = nameof(z_probe_samples);
@@ -196,21 +199,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				// Otherwise, use the SettingsLayers that is bound to this extruder
 				if (extruderIndex < printerSettings.MaterialSettingsKeys.Count)
 				{
-					string materialKey = printerSettings.MaterialSettingsKeys[extruderIndex];
-					PrinterSettingsLayer layer = printerSettings.GetMaterialLayer(materialKey);
-
-					if (layer != null)
-					{
-						string result = "0";
-						if (layer.TryGetValue(SettingsKey.temperature, out result))
-						{
-							double value = 0;
-							if (double.TryParse(result, out value))
-							{
-								return value;
-							}
-						}
-					}
+					return printerSettings.GetValue<double>($"{SettingsKey.temperature}{extruderIndex}");
 				}
 
 				// else return the normal settings cascade

--- a/StaticData/SliceSettings/Properties.json
+++ b/StaticData/SliceSettings/Properties.json
@@ -1607,6 +1607,33 @@
 		"DefaultValue": "200"
 	},
 	{
+		"SlicerConfigName": "temperature1",
+		"PresentationName": "Extruder 2 Temperature",
+		"HelpText": "The target temperature the extruder will attempt to reach during the print.",
+		"DataEditType": "POSITIVE_DOUBLE",
+		"ExtraSettings": "°C",
+		"ShowIfSet": "!sla_printer",
+		"DefaultValue": "200"
+	},
+	{
+		"SlicerConfigName": "temperature2",
+		"PresentationName": "Extruder 3 Temperature",
+		"HelpText": "The target temperature the extruder will attempt to reach during the print.",
+		"DataEditType": "POSITIVE_DOUBLE",
+		"ExtraSettings": "°C",
+		"ShowIfSet": "!sla_printer",
+		"DefaultValue": "200"
+	},
+	{
+		"SlicerConfigName": "temperature3",
+		"PresentationName": "Extruder 4 Temperature",
+		"HelpText": "The target temperature the extruder will attempt to reach during the print.",
+		"DataEditType": "POSITIVE_DOUBLE",
+		"ExtraSettings": "°C",
+		"ShowIfSet": "!sla_printer",
+		"DefaultValue": "200"
+	},
+	{
 		"SlicerConfigName": "extruder_wipe_temperature",
 		"PresentationName": "Extruder Wipe Temperature",
 		"HelpText": "The temperature at which the extruder will wipe the nozzle, as specified by Custom G-Code.",

--- a/Tests/MatterControl.AutomationTests/PrintingTests.cs
+++ b/Tests/MatterControl.AutomationTests/PrintingTests.cs
@@ -606,7 +606,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					testRunner.WaitFor(() => fanChangedCount > 0, 15, 500);
 
 					// Assert expected temp targets and fan transitions
-					Assert.AreEqual(0, (int) emulator.Hotend.TargetTemperature, "Unexpected target temperature - MC close should call Connection.Disable->TurnOffBedAndExtruders to shutdown heaters");
+					Assert.AreEqual(0, (int) emulator.CurrentExtruder.TargetTemperature, "Unexpected target temperature - MC close should call Connection.Disable->TurnOffBedAndExtruders to shutdown heaters");
 					Assert.AreEqual(0, (int) emulator.HeatedBed.TargetTemperature, "Unexpected target temperature - MC close should call Connection.Disable->TurnOffBedAndExtruders to shutdown heaters");
 					Assert.AreEqual(1, fanChangedCount, "Unexpected fan speed change count - MC close should call Connection.Disable which shuts down fans via M106");
 				}

--- a/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
+++ b/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
@@ -195,21 +195,21 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					// assert the temp changed to a new temp
 					Assert.AreEqual(hipsGoalTemp,(int) tempWidget.Value, "The goal temp should match the material temp");
 					// and the printer heat is off
-					Assert.AreEqual(0, (int) emulator.ExtruderGoalTemperature, "The printer should report the heaters are off");
+					Assert.AreEqual(0, (int) emulator.CurrentExtruder.TargetTemperature, "The printer should report the heaters are off");
 
 					// turn on the heater
 					testRunner.ClickByName("Toggle Heater");
 					testRunner.Delay(2);
 
 					// assert the printer is heating
-					Assert.AreEqual(hipsGoalTemp, (int)emulator.ExtruderGoalTemperature, "The printer should report the expected goal temp");
+					Assert.AreEqual(hipsGoalTemp, (int)emulator.CurrentExtruder.TargetTemperature, "The printer should report the expected goal temp");
 
 					// turn off the heater
 					testRunner.ClickByName("Toggle Heater");
 					testRunner.Delay(2);
 
 					// assert the printer is off
-					Assert.AreEqual(0, (int)emulator.ExtruderGoalTemperature, "The printer should report the heaters are off");
+					Assert.AreEqual(0, (int)emulator.CurrentExtruder.TargetTemperature, "The printer should report the heaters are off");
 
 					// type in a temp when the heating is off
 					testRunner.ClickByName("Temperature Input");
@@ -218,7 +218,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					testRunner.Delay();
 
 					// assert the printer is off
-					Assert.AreEqual(0, (int)emulator.ExtruderGoalTemperature);
+					Assert.AreEqual(0, (int)emulator.CurrentExtruder.TargetTemperature);
 
 					// and the heat toggle is showing on
 					CheckBox heatToggle = testRunner.GetWidgetByName("Toggle Heater", out _) as CheckBox;
@@ -226,14 +226,14 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 					// turn it on
 					testRunner.ClickByName("Toggle Heater");
-					Assert.AreEqual(110, (int)emulator.ExtruderGoalTemperature);
+					Assert.AreEqual(110, (int)emulator.CurrentExtruder.TargetTemperature);
 
 					// adjust when on
 					testRunner.ClickByName("Temperature Input");
 					testRunner.Type("104");
 					testRunner.Type("{Enter}");
 					testRunner.Delay();
-					Assert.AreEqual(104, (int)emulator.ExtruderGoalTemperature);
+					Assert.AreEqual(104, (int)emulator.CurrentExtruder.TargetTemperature);
 
 					// type in 0 and have the heater turn off
 					testRunner.ClickByName("Temperature Input");
@@ -243,7 +243,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					testRunner.Delay();
 
 					// assert the printer is not heating
-					Assert.AreEqual(0, (int)emulator.ExtruderGoalTemperature);
+					Assert.AreEqual(0, (int)emulator.CurrentExtruder.TargetTemperature);
 					// and the on toggle is showing off
 					Assert.IsFalse(heatToggle.Checked);
 

--- a/Tests/MatterControl.Tests/MatterControl/OemProfileTests.cs
+++ b/Tests/MatterControl.Tests/MatterControl/OemProfileTests.cs
@@ -465,7 +465,7 @@ namespace MatterControl.Tests.MatterControl
 				printerSettings.AutoSave = false;
 
 				// Disable active material/quality overrides
-				printerSettings.SetMaterialPreset(0, "");
+				printerSettings.ActiveMaterialKey = "";
 				printerSettings.ActiveQualityKey = "";
 
 				// Validate just the OemLayer
@@ -481,7 +481,7 @@ namespace MatterControl.Tests.MatterControl
 				{
 					printer.RuleViolated = false;
 
-					printerSettings.SetMaterialPreset(0, layer.LayerID);
+					printerSettings.ActiveMaterialKey = layer.LayerID;
 
 					// Validate the settings with this material layer active
 					action(printer, printerSettings);
@@ -492,7 +492,7 @@ namespace MatterControl.Tests.MatterControl
 					}
 				}
 
-				printerSettings.SetMaterialPreset(0, "");
+				printerSettings.ActiveMaterialKey = "";
 
 				// Validate quality layers
 				foreach (var layer in printer.PrinterSettings.QualityLayers)


### PR DESCRIPTION
Removed ability to set material for extruders other than the first
added settings for extruder 1-4 temp
Refactored emulator (move classes to new files)
Made the emulator support multiple extruders

More on: MatterHackers/MCCentral#2593
Temperature control widget doesn't pull changed values from settings