### PR TITLE
Hold bottom height on scale

### DIFF
--- a/PartPreviewWindow/View3D/Gui3D/MoveInZControl.cs
+++ b/PartPreviewWindow/View3D/Gui3D/MoveInZControl.cs
@@ -90,7 +90,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 					return false;
 				}
 ,
-				GetDisplayString = (value) => "{0:0.0}mm".FormatWith(value)
+				GetDisplayString = (value) => "{0:0.0#}mm".FormatWith(value)
 			};
 
 			zHeightDisplayInfo.VisibleChanged += (s, e) =>

--- a/PartPreviewWindow/View3D/SideBar/ScaleControl.cs
+++ b/PartPreviewWindow/View3D/SideBar/ScaleControl.cs
@@ -234,7 +234,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 			// keep the bottom where it was
 			AxisAlignedBoundingBox scaledBounds = selectedItem.GetAxisAlignedBoundingBox(Matrix4X4.Identity);
-			PlatingHelper.PlaceMeshAtHeight(selectedItem, scaledBounds.minXYZ.Z);
+			PlatingHelper.PlaceMeshAtHeight(selectedItem, originalMeshBounds.minXYZ.Z);
 
 			Invalidate();
 		}


### PR DESCRIPTION
Better display of z height info (show extra decimal when required)

issue: MatterHackers/MCCentral#2592
Scale control not keeping part on bed