### PR TITLE
Fixed bug when opening subfolders in custom library.

### DIFF
--- a/Library/Provider/LibraryProviderFileSystem.cs
+++ b/Library/Provider/LibraryProviderFileSystem.cs
@@ -240,7 +240,8 @@ namespace MatterHackers.MatterControl.PrintLibrary.Provider
 
 		public override LibraryProvider GetProviderForCollection(PrintItemCollection collection)
 		{
-			return new LibraryProviderFileSystem(Path.Combine(rootPath, collection.Key), collection.Name, this, SetCurrentLibraryProvider);
+			string folder = collection.Key.TrimStart('\\');
+			return new LibraryProviderFileSystem(Path.Combine(rootPath, folder), collection.Name, this, SetCurrentLibraryProvider);
 		}
 
 		public override void RenameCollection(int collectionIndexToRename, string newName)


### PR DESCRIPTION
When opening a subfolder in a custom library, the folder name had
a leading slash. Path.combine treats this as a root folder and the first
argument is discarded. This leads to an exception further down the line.
Removing the leading slash fixes that.