### PR TITLE
Put in a hack to make the size get recalculated.

### DIFF
--- a/PartPreviewWindow/SectionWidget.cs
+++ b/PartPreviewWindow/SectionWidget.cs
@@ -37,6 +37,8 @@ namespace MatterHackers.MatterControl.CustomWidgets
 					checkbox.CheckedStateChanged += (s, e) =>
 					{
 						ContentPanel.Visible = checkbox.Checked;
+						// TODO: Remove this Height = 10 and figure out why the layout engine is not sizing these corretly without this.
+						ContentPanel.Height = 10;
 						this.BorderColor = (checkbox.Checked) ? Color.Transparent : SeperatorColor;
 					};
 


### PR DESCRIPTION
issue: MatterHackers/MCCentral#2635
Initial opening of closed settings groups has wrong height