### PR TITLE
Disable align buttons if less than 2 items selected.

### DIFF
--- a/PartPreviewWindow/AlignControls.cs
+++ b/PartPreviewWindow/AlignControls.cs
@@ -86,6 +86,15 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			this.AddChild(dualExtrusionAlignButton);
 
 			AddAlignDelegates(0, AxisAlignment.SourceCoordinateSystem, dualExtrusionAlignButton);
+
+			scene.SelectionChanged += (s, e) =>
+			{
+				bool haveSelectionGroup = scene.SelectedItem is SelectionGroup;
+				foreach(var button in this.Descendants<Button>())
+				{
+					button.Enabled = haveSelectionGroup;
+				}
+			};
 		}
 
 		private GuiWidget CreateAlignButton(int axisIndex, AxisAlignment alignment, string label)


### PR DESCRIPTION
issue: MatterHackers/MCCentral#2631
Align should be disabled unless more than one object selected