### PR TITLE
Made load and unload intrinsic to all printers and extruders

### DIFF
--- a/MatterControl.csproj
+++ b/MatterControl.csproj
@@ -511,6 +511,8 @@
     </Content>
     <Content Include="StaticData\OEMSettings\AboutPage.html" />
     <Content Include="StaticData\SliceSettings\Layouts.txt" />
+    <Content Include="StaticData\SliceSettings\load_filament.txt" />
+    <Content Include="StaticData\SliceSettings\unload_filament.txt" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="config.json">

--- a/PrinterControls/ControlWidgets/MacroControls.cs
+++ b/PrinterControls/ControlWidgets/MacroControls.cs
@@ -45,13 +45,13 @@ namespace MatterHackers.MatterControl.PrinterControls
 			var noMacrosFound = new TextWidget("No macros are currently set up for this printer.".Localize(), pointSize: 10, textColor: theme.Colors.PrimaryTextColor);
 			this.AddChild(noMacrosFound);
 
-			if (printer.Settings?.GetMacros(MacroUiLocation.Controls).Any() != true)
+			if (printer.Settings?.GetMacros().Any() != true)
 			{
 				noMacrosFound.Visible = true;
 				return;
 			}
 
-			foreach (GCodeMacro macro in printer.Settings.GetMacros(MacroUiLocation.Controls))
+			foreach (GCodeMacro macro in printer.Settings.GetMacros())
 			{
 				var macroButton = new TextButton(GCodeMacro.FixMacroName(macro.Name), theme)
 				{

--- a/PrinterControls/ControlWidgets/MacroControls.cs
+++ b/PrinterControls/ControlWidgets/MacroControls.cs
@@ -45,13 +45,13 @@ namespace MatterHackers.MatterControl.PrinterControls
 			var noMacrosFound = new TextWidget("No macros are currently set up for this printer.".Localize(), pointSize: 10, textColor: theme.Colors.PrimaryTextColor);
 			this.AddChild(noMacrosFound);
 
-			if (printer.Settings?.GetMacros().Any() != true)
+			if (printer.Settings?.Macros.Any() != true)
 			{
 				noMacrosFound.Visible = true;
 				return;
 			}
 
-			foreach (GCodeMacro macro in printer.Settings.GetMacros())
+			foreach (GCodeMacro macro in printer.Settings.Macros)
 			{
 				var macroButton = new TextButton(GCodeMacro.FixMacroName(macro.Name), theme)
 				{

--- a/PrinterControls/MacroDetailPage.cs
+++ b/PrinterControls/MacroDetailPage.cs
@@ -37,8 +37,6 @@ using MatterHackers.MatterControl.SlicerConfiguration;
 
 namespace MatterHackers.MatterControl
 {
-	public enum MacroUiLocation { Controls, Extruder_1, Extruder_2, Extruder_3, Extruder_4 }
-
 	public class MacroDetailPage : DialogPage
 	{
 		private List<FormField> formFields;
@@ -109,27 +107,6 @@ namespace MatterHackers.MatterControl
 				HAnchor = HAnchor.Stretch
 			};
 
-			container.AddChild(new TextWidget("Where to show this macro:")
-			{
-				TextColor = theme.Colors.PrimaryTextColor,
-				VAnchor = VAnchor.Center
-			});
-
-			var macroUiLocation = new DropDownList("Default", theme.Colors.PrimaryTextColor, Direction.Up, pointSize: theme.DefaultFontSize)
-			{
-				TextColor = theme.Colors.PrimaryTextColor,
-				Margin = new BorderDouble(5, 0),
-				VAnchor = VAnchor.Center
-			};
-			foreach (var location in Enum.GetValues(typeof(MacroUiLocation)))
-			{
-				macroUiLocation.AddItem(location.ToString().Replace("_", " ").Localize(), location.ToString());
-			}
-
-			macroUiLocation.SelectedValue = gcodeMacro.MacroUiLocation.ToString();
-
-			container.AddChild(macroUiLocation);
-
 			contentRow.AddChild(container);
 
 			Button addMacroButton = textImageButtonFactory.Generate("Save".Localize());
@@ -142,13 +119,6 @@ namespace MatterHackers.MatterControl
 						// SaveActiveMacro
 						gcodeMacro.Name = macroNameInput.Text;
 						gcodeMacro.GCode = macroCommandInput.Text;
-
-						MacroUiLocation result;
-						if (!Enum.TryParse(macroUiLocation.SelectedValue, out result))
-						{
-							result = MacroUiLocation.Controls;
-						}
-						gcodeMacro.MacroUiLocation = result;
 
 						if (!printerSettings.Macros.Contains(gcodeMacro))
 						{

--- a/SlicerConfiguration/Settings/GCodeMacro.cs
+++ b/SlicerConfiguration/Settings/GCodeMacro.cs
@@ -38,7 +38,6 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 	{
 		public string Name { get; set; }
 		public string GCode { get; set; }
-		public MacroUiLocation MacroUiLocation { get; set; }
 		public DateTime LastModified { get; set; }
 
 		public static string FixMacroName(string input)

--- a/SlicerConfiguration/Settings/PrinterSettings.cs
+++ b/SlicerConfiguration/Settings/PrinterSettings.cs
@@ -90,7 +90,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 		public List<GCodeMacro> Macros { get; set; } = new List<GCodeMacro>();
 
-		public IEnumerable<GCodeMacro> GetMacros(MacroUiLocation macroLocation) => Macros.Where(m => m.MacroUiLocation == macroLocation).OrderBy(p => p.Name);
+		public IEnumerable<GCodeMacro> GetMacros() => Macros;
 
 		/// <summary>
 		/// Restore deactivated user overrides by iterating the active preset and removing/restoring matching items

--- a/SlicerConfiguration/Settings/PrinterSettings.cs
+++ b/SlicerConfiguration/Settings/PrinterSettings.cs
@@ -90,8 +90,6 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 		public List<GCodeMacro> Macros { get; set; } = new List<GCodeMacro>();
 
-		public IEnumerable<GCodeMacro> GetMacros() => Macros;
-
 		/// <summary>
 		/// Restore deactivated user overrides by iterating the active preset and removing/restoring matching items
 		/// </summary>

--- a/SlicerConfiguration/SlicerMapping/MappingClasses.cs
+++ b/SlicerConfiguration/SlicerMapping/MappingClasses.cs
@@ -65,6 +65,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			new ScaledSingleNumber("travel_speed", "travel_speed", 60),
 			new AsPercentOfReferenceOrDirect("load_filament_length_over_six", "", "load_filament_length", 1.0/6.0, false),
 			new AsPercentOfReferenceOrDirect("unload_filament_length_over_six", "", "unload_filament_length", 1.0/6.0, false),
+			new ScaledSingleNumber("load_filament_speed", "load_filament_speed", 60),
 			new MappedSetting("trim_image", "trim_image"),
 			new MappedSetting("insert_image", "insert_image"),
 			new MappedSetting("running_clean_image", "running_clean_image"),

--- a/SlicerConfiguration/SlicerMapping/MappingClasses.cs
+++ b/SlicerConfiguration/SlicerMapping/MappingClasses.cs
@@ -39,7 +39,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 	public static class GCodeProcessing
 	{
 		private static MappedSetting[] replaceWithSettingsStrings = new MappedSetting[]
-        {
+		{
 			// Have a mapping so that MatterSlice while always use a setting that can be set. (the user cannot set first_layer_bedTemperature in MatterSlice)
 			new AsPercentOfReferenceOrDirect(SettingsKey.first_layer_speed, "first_layer_speed", "infill_speed", 60),
 			new AsPercentOfReferenceOrDirect("external_perimeter_speed","external_perimeter_speed", "perimeter_speed", 60),
@@ -63,6 +63,11 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			new ScaledSingleNumber("retract_speed","retract_speed", 60),
 			new ScaledSingleNumber("support_material_speed","support_material_speed", 60),
 			new ScaledSingleNumber("travel_speed", "travel_speed", 60),
+			new AsPercentOfReferenceOrDirect("load_filament_length_over_six", "", "load_filament_length", 1.0/6.0, false),
+			new AsPercentOfReferenceOrDirect("unload_filament_length_over_six", "", "unload_filament_length", 1.0/6.0, false),
+			new MappedSetting("trim_image", "trim_image"),
+			new MappedSetting("insert_image", "insert_image"),
+			new MappedSetting("running_clean_image", "running_clean_image"),
 		};
 
 		public static string ReplaceMacroValues(string gcodeWithMacros)

--- a/SlicerConfiguration/SlicerMapping/SliceEngineMapping.cs
+++ b/SlicerConfiguration/SlicerMapping/SliceEngineMapping.cs
@@ -104,7 +104,11 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			SettingsKey.max_acceleration,
 			SettingsKey.ip_address,
 			SettingsKey.ip_port,
-
+			"load_filament_length",
+			"trim_image",
+			"insert_image",
+			"running_clean_image",
+			"unload_filament_length",
 		};
 
 		public SliceEngineMapping(string engineName)

--- a/SlicerConfiguration/SlicerMapping/SliceEngineMapping.cs
+++ b/SlicerConfiguration/SlicerMapping/SliceEngineMapping.cs
@@ -109,6 +109,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			"insert_image",
 			"running_clean_image",
 			"unload_filament_length",
+			"load_filament_speed",
 		};
 
 		public SliceEngineMapping(string engineName)

--- a/StaticData/SliceSettings/Layouts.txt
+++ b/StaticData/SliceSettings/Layouts.txt
@@ -194,6 +194,7 @@ Printer
     Loading
       Loading
         load_filament_length
+        load_filament_speed
         trim_image
         insert_image
         running_clean_image

--- a/StaticData/SliceSettings/Layouts.txt
+++ b/StaticData/SliceSettings/Layouts.txt
@@ -191,6 +191,13 @@ Printer
         max_acceleration
         max_velocity
         jerk_velocity
+    Loading
+      Loading
+        load_filament_length
+        trim_image
+        insert_image
+        running_clean_image
+        unload_filament_length
     Slicing
       Slicing Options
         output_only_first_layer

--- a/StaticData/SliceSettings/Properties.json
+++ b/StaticData/SliceSettings/Properties.json
@@ -43,6 +43,15 @@
     "DefaultValue": "20"
   },
   {
+    "SlicerConfigName": "load_filament_speed",
+    "PresentationName": "Load Filament Speed",
+    "HelpText": "The speed to run filament into the printer when loading.",
+    "DataEditType": "POSITIVE_DOUBLE",
+    "Units": "mm/s",
+    "ShowIfSet": "!sla_printer",
+    "DefaultValue": "80"
+  },
+  {
     "SlicerConfigName": "load_filament_length_over_six",
     "PresentationName": "Load Filament Length",
     "HelpText": "Should be 100%. Not shown to user.",

--- a/StaticData/SliceSettings/Properties.json
+++ b/StaticData/SliceSettings/Properties.json
@@ -34,6 +34,66 @@
     "DefaultValue": "70"
   },
   {
+    "SlicerConfigName": "load_filament_length",
+    "PresentationName": "Load Filament Length",
+    "HelpText": "The amount of filament to insert into the printer when loading.",
+    "DataEditType": "POSITIVE_DOUBLE",
+    "Units": "mm",
+    "ShowIfSet": "!sla_printer",
+    "DefaultValue": "20"
+  },
+  {
+    "SlicerConfigName": "load_filament_length_over_six",
+    "PresentationName": "Load Filament Length",
+    "HelpText": "Should be 100%. Not shown to user.",
+    "DataEditType": "DOUBLE_OR_PERCENT",
+    "Units": "%",
+    "ShowIfSet": "!sla_printer",
+    "DefaultValue": "100%"
+  },
+  {
+    "SlicerConfigName": "unload_filament_length",
+    "PresentationName": "Unload Filament Length",
+    "HelpText": "The amount of filament to remove from the printer while unloading.",
+    "DataEditType": "POSITIVE_DOUBLE",
+    "Units": "mm",
+    "ShowIfSet": "!sla_printer",
+    "DefaultValue": "70"
+  },
+  {
+    "SlicerConfigName": "unload_filament_length_over_six",
+    "PresentationName": "Unload Filament Length",
+    "HelpText": "Should be 100%. Not shown to user.",
+    "DataEditType": "DOUBLE_OR_PERCENT",
+    "Units": "%",
+    "ShowIfSet": "!sla_printer",
+    "DefaultValue": "100%"
+  },
+  {
+    "SlicerConfigName": "trim_image",
+    "PresentationName": "Trim Image",
+    "HelpText": "The image to show when explaining trimming.",
+    "DataEditType": "STRING",
+    "ShowIfSet": "!sla_printer",
+    "DefaultValue": "https://lh3.googleusercontent.com/7vFs0ih2mGseQBKo-0gHnzaT2SsuAPgeRuqFlVKG23c4brFnIaA2nlYIg8BUcdI-mVaDAadgu5bdBv_jZ69VOi3mYw"
+  },
+  {
+    "SlicerConfigName": "insert_image",
+    "PresentationName": "Insert Image",
+    "HelpText": "The image to show when explaining inserting.",
+    "DataEditType": "STRING",
+    "ShowIfSet": "!sla_printer",
+    "DefaultValue": "https://lh3.googleusercontent.com/S4eW9-uZ0lgpg_ws9Ss4LmUc_MiXCfHnfJmGVQ0XtOdpvr_XZQLuP5zWGv7eCSM65EbsWIdHVMC40EYL7u8k7LvMP4Y"
+  },
+  {
+    "SlicerConfigName": "running_clean_image",
+    "PresentationName": "Running Clean Image",
+    "HelpText": "The image to show when explaining filament running clean.",
+    "DataEditType": "STRING",
+    "ShowIfSet": "!sla_printer",
+    "DefaultValue": ""
+  },
+  {
     "SlicerConfigName": "bottom_solid_layers",
     "PresentationName": "Bottom Solid Layers",
     "HelpText": "The number of layers or the distance in millimeters to solid fill on the bottom surface(s) of the object. Add mm to the end of the number to specify distance in millimeters.",

--- a/StaticData/SliceSettings/load_filament.txt
+++ b/StaticData/SliceSettings/load_filament.txt
@@ -11,12 +11,12 @@ G90                 ; Absolute positioning
 ; host.show_message(title:"Loading filament...", count_down:"28")
 G92 E0              ; reset the extruder position to 0
 G91                 ; Relative positioning
-G1 E[load_filament_length_over_six] F5000       ; extrude the filament (pulse was 598)
-G1 E[load_filament_length_over_six] F5000       ; extrude the filament 
-G1 E[load_filament_length_over_six] F5000       ; extrude the filament 
-G1 E[load_filament_length_over_six] F5000       ; extrude the filament 
-G1 E[load_filament_length_over_six] F5000       ; extrude the filament
-G1 E[load_filament_length_over_six] F5000       ; extrude the filament 
+G1 E[load_filament_length_over_six] F[load_filament_speed]       ; extrude the filament (pulse was 598)
+G1 E[load_filament_length_over_six] F[load_filament_speed]       ; extrude the filament 
+G1 E[load_filament_length_over_six] F[load_filament_speed]       ; extrude the filament 
+G1 E[load_filament_length_over_six] F[load_filament_speed]       ; extrude the filament 
+G1 E[load_filament_length_over_six] F[load_filament_speed]       ; extrude the filament
+G1 E[load_filament_length_over_six] F[load_filament_speed]       ; extrude the filament 
 G4 S1               ; wait for move to finish
 
 M302 S150  ; Set cold extrude temp back to reasonable

--- a/StaticData/SliceSettings/load_filament.txt
+++ b/StaticData/SliceSettings/load_filament.txt
@@ -1,0 +1,34 @@
+; host.choose_material(title:"Choose the material that you are loading.")
+
+M104 S[temperature] ; start heating up the extruder
+
+; host.show_message(title:"Trim the end of the filament to ensure a good load.", image:"[trim_image]", wait_ok:"true")
+
+M302 S0  ; Allow extrusion at any temperature
+G91                 ; Relative positioning
+; host.show_message(title:"Put filament into extruder until you feel it start to feed and then click Continue.", repeat_gcode:"G1 E.1 F150|G4 P10", expire:"90", image:"[insert_image]")
+G90                 ; Absolute positioning
+; host.show_message(title:"Loading filament...", count_down:"28")
+G92 E0              ; reset the extruder position to 0
+G91                 ; Relative positioning
+G1 E[load_filament_length_over_six] F5000       ; extrude the filament (pulse was 598)
+G1 E[load_filament_length_over_six] F5000       ; extrude the filament 
+G1 E[load_filament_length_over_six] F5000       ; extrude the filament 
+G1 E[load_filament_length_over_six] F5000       ; extrude the filament 
+G1 E[load_filament_length_over_six] F5000       ; extrude the filament
+G1 E[load_filament_length_over_six] F5000       ; extrude the filament 
+G4 S1               ; wait for move to finish
+
+M302 S150  ; Set cold extrude temp back to reasonable
+; host.show_message(title:"Waiting for extruder to heat to [temperature].")
+G4 S1               ; wait message to display
+M109 S[temperature] ; heat up the extruder
+
+; extrude slowly so that we can prime the extruder
+; host.show_message(title:"Click 'Continue' when filament is running cleanly through the nozzle.", repeat_gcode:"G1 E1 F300|G4 P10", expire:"90", image:"[running_clean_image]")
+
+G4 S1               ; wait for move to finish
+G90                 ; Absolute positioning
+G92 E0              ; reset the extruder position to 0
+
+M104 S0             ; turn the extruder temperature off

--- a/StaticData/SliceSettings/unload_filament.txt
+++ b/StaticData/SliceSettings/unload_filament.txt
@@ -9,13 +9,12 @@ M302 S0  ; Allow extrusion at any temperature
 G92 E0              ; reset the extruder position to 0
 G91                 ; Relative positioning
 G1 E15 F600         ; push some out first
-G1 E-[unload_filament_length_over_six] F5000      ; unload the filament 
-G1 E-[unload_filament_length_over_six] F5000      ; unload the filament 
-G1 E-[unload_filament_length_over_six] F5000      ; unload the filament 
-G1 E-[unload_filament_length_over_six] F5000      ; unload the filament 
-G1 E-[unload_filament_length_over_six] F5000      ; unload the filament 
-G1 E-[unload_filament_length_over_six] F5000
-G1 E-[unload_filament_length_over_six] F5000      ; unload the filament 
+G1 E-[unload_filament_length_over_six] F[load_filament_speed]      ; unload the filament 
+G1 E-[unload_filament_length_over_six] F[load_filament_speed]      ; unload the filament 
+G1 E-[unload_filament_length_over_six] F[load_filament_speed]      ; unload the filament 
+G1 E-[unload_filament_length_over_six] F[load_filament_speed]      ; unload the filament 
+G1 E-[unload_filament_length_over_six] F[load_filament_speed]      ; unload the filament 
+G1 E-[unload_filament_length_over_six] F[load_filament_speed]      ; unload the filament 
 G4 S1               ; wait for move to finish
 G90                 ; Absolute positioning
 G92 E0              ; reset the extruder position to 0

--- a/StaticData/SliceSettings/unload_filament.txt
+++ b/StaticData/SliceSettings/unload_filament.txt
@@ -1,0 +1,25 @@
+; host.choose_material(title:"Confirm the material you are unloading.")
+
+; host.show_message(title:"Waiting for extruder to heat to [temperature], before unloading.")
+G4 S1               ; wait message to display
+M109 S[temperature] ; heat up the extruder
+
+M302 S0  ; Allow extrusion at any temperature
+; host.show_message(title:"Unloading filament..." count_down:28)
+G92 E0              ; reset the extruder position to 0
+G91                 ; Relative positioning
+G1 E15 F600         ; push some out first
+G1 E-[unload_filament_length_over_six] F5000      ; unload the filament 
+G1 E-[unload_filament_length_over_six] F5000      ; unload the filament 
+G1 E-[unload_filament_length_over_six] F5000      ; unload the filament 
+G1 E-[unload_filament_length_over_six] F5000      ; unload the filament 
+G1 E-[unload_filament_length_over_six] F5000      ; unload the filament 
+G1 E-[unload_filament_length_over_six] F5000
+G1 E-[unload_filament_length_over_six] F5000      ; unload the filament 
+G4 S1               ; wait for move to finish
+G90                 ; Absolute positioning
+G92 E0              ; reset the extruder position to 0
+
+M302 S150  ; Set cold extrude temp back to reasonable
+
+M104 S0             ; turn the extruder temperature off


### PR DESCRIPTION
Took out macro location option
Added load and unload macros to StaticData

issue: MatterHackers/MCCentral#2690
Make load and unload filament available on every extruder and create settings to allow printer specific config

MatterHackers/MCCentral#2679
Macros marked for Action menu have no home in design_tools