### PR TITLE
Turn off heat when on last page of leveling

### DIFF
--- a/ConfigurationPage/PrintLeveling/LevelingStrings.cs
+++ b/ConfigurationPage/PrintLeveling/LevelingStrings.cs
@@ -78,11 +78,11 @@ namespace MatterHackers.MatterControl.ConfigurationPage.PrintLeveling
 			{
 				if (printerSettings.Helpers.UseZProbe())
 				{
-					return "{0}{1}\n\n{2}{3}".FormatWith(doneLine1, doneLine1b, doneLine3, doneLine3b);
+					return $"{doneLine1} {doneLine1b}\n\n{doneLine3} {doneLine3b}";
 				}
 				else
 				{
-					return "{0}{1}\n\n\t• {2}\n\n{3}{4}".FormatWith(doneLine1, doneLine1b, doneLine2, doneLine3, doneLine3b);
+					return $"{doneLine1} {doneLine1b}\n\n\t• {doneLine2}\n\n{doneLine3} {doneLine3b}";
 				}
 			}
 		}

--- a/ConfigurationPage/PrintLeveling/PrintLevelPages.cs
+++ b/ConfigurationPage/PrintLeveling/PrintLevelPages.cs
@@ -115,7 +115,7 @@ namespace MatterHackers.MatterControl.ConfigurationPage.PrintLeveling
 			Parent.Closed += (s, e) =>
 			{
 				// Make sure when the wizard closes we turn off the bed heating
-				printer.Connection.TargetBedTemperature = 0;
+				printer.Connection.TurnOffBedAndExtruders(false);
 			};
 
 			if (printer.Settings.Helpers.UseZProbe())
@@ -207,6 +207,9 @@ namespace MatterHackers.MatterControl.ConfigurationPage.PrintLeveling
 			}
 
 			container.backButton.Enabled = false;
+
+			// Make sure when the wizard is done we turn off the bed heating
+			printer.Connection.TurnOffBedAndExtruders(false);
 
 			base.PageIsBecomingActive();
 		}


### PR DESCRIPTION
issue: MatterHackers/MCCentral#2720
Heaters stay on until user interaction at the conclusion of automated probing