### PR TITLE
Improved the math around gcode time and jerk setting

### DIFF
--- a/MatterControl.Printing/GCode/GCodeFile.cs
+++ b/MatterControl.Printing/GCode/GCodeFile.cs
@@ -224,11 +224,17 @@ namespace MatterControl.Printing
 			Vector4 velocitySameAsStopMmPerS,
 			Vector4 speedMultiplierV4)
 		{
-			double startingVelocityMmPerS = velocitySameAsStopMmPerS.X;
-			double endingVelocityMmPerS = velocitySameAsStopMmPerS.X;
-			double maxVelocityMmPerSx = Math.Min(feedRateMmPerMin / 60, maxVelocityMmPerS.X);
-			double acceleration = maxAccelerationMmPerS2.X;
 			double lengthOfThisMoveMm = Math.Max(deltaPositionThisLine.Length, deltaEPositionThisLine);
+
+			if (lengthOfThisMoveMm == 0)
+			{
+				return 0;
+			}
+
+			double maxVelocityMmPerSx = Math.Min(feedRateMmPerMin / 60, maxVelocityMmPerS.X);
+			double startingVelocityMmPerS = Math.Min(velocitySameAsStopMmPerS.X, maxVelocityMmPerSx);
+			double endingVelocityMmPerS = startingVelocityMmPerS;
+			double acceleration = maxAccelerationMmPerS2.X;
 			double speedMultiplier = speedMultiplierV4.X;
 
 			double distanceToMaxVelocity = GetDistanceToReachEndingVelocity(startingVelocityMmPerS, maxVelocityMmPerSx, acceleration);


### PR DESCRIPTION
issue: MatterHackers/MCCentral#2774
Increasing Jerk Velocity above 100 mm/s causes print time estimate to increase