### PR TITLE
Made subtract and replace ensure contrast with the inserted part

### DIFF
--- a/PartPreviewWindow/View3D/Actions/MeshWrapperObject3D.cs
+++ b/PartPreviewWindow/View3D/Actions/MeshWrapperObject3D.cs
@@ -138,6 +138,8 @@ namespace MatterHackers.MatterControl.PartPreviewWindow.View3D
 				item.Visible = true;
 				// set the mesh back to the child mesh
 				item.Mesh = item.Children.First().Mesh;
+				// and set the color back
+				item.Color = item.Children.First().Color;
 			}
 		}
 	}

--- a/PartPreviewWindow/View3D/Actions/SubtractAndReplace.cs
+++ b/PartPreviewWindow/View3D/Actions/SubtractAndReplace.cs
@@ -252,6 +252,8 @@ namespace MatterHackers.MatterControl.PartPreviewWindow.View3D
 
 						paint.Mesh = paintMesh;
 
+						paint.Color = paint.WorldColor().AdjustContrast(keepObjects.First().WorldColor(), 2).ToColor();
+
 						// now set it to the new solid color
 						paint.OutputType = PrintOutputTypes.Solid;
 					}


### PR DESCRIPTION
issue: MatterHackers/MCCentral#2921
If Object3D selection shares the same color, Paint Material appears to fail