### PR TITLE
Remove ReleaseVersion line from .csproj files

### DIFF
--- a/Community.CsharpSqlite/Community.CsharpSqlite.csproj
+++ b/Community.CsharpSqlite/Community.CsharpSqlite.csproj
@@ -30,7 +30,6 @@
     <IsWebBootstrapper>false</IsWebBootstrapper>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
-    <ReleaseVersion>1.1.4</ReleaseVersion>
     <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/Launcher/Launcher.csproj
+++ b/Launcher/Launcher.csproj
@@ -16,7 +16,6 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <OldToolsVersion>2.0</OldToolsVersion>
-    <ReleaseVersion>0.8.2</ReleaseVersion>
     <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/PluginSystem/MatterControlPluginSystem.csproj
+++ b/PluginSystem/MatterControlPluginSystem.csproj
@@ -15,7 +15,6 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <OldToolsVersion>2.0</OldToolsVersion>
-    <ReleaseVersion>1.1.4</ReleaseVersion>
     <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/PrinterDriverInstaller/InfInstaller.csproj
+++ b/PrinterDriverInstaller/InfInstaller.csproj
@@ -16,7 +16,6 @@
     <UpgradeBackupLocation>
     </UpgradeBackupLocation>
     <OldToolsVersion>2.0</OldToolsVersion>
-    <ReleaseVersion>1.1.4</ReleaseVersion>
     <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <TargetFrameworkProfile />
   </PropertyGroup>


### PR DESCRIPTION
Whenever I open MatterControl in MonoDevelop, it edits all the .csproj files by removing the ReleaseVersion line. Is there any reason not to just let this happen? If you guys are ok with this then I will update the other repos as well.