### PR TITLE
Swap colon for dash in progress messages

### DIFF
--- a/PrinterCommunication/Io/SendProgressStream.cs
+++ b/PrinterCommunication/Io/SendProgressStream.cs
@@ -58,7 +58,7 @@ namespace MatterHackers.MatterControl.PrinterCommunication.Io
 				}
 				else
 				{
-					return String.Format("M117 Printing: {0:0}%", printer.Connection.activePrintTask.PercentDone);
+					return String.Format("M117 Printing - {0:0}%", printer.Connection.activePrintTask.PercentDone);
 				}
 			}
 


### PR DESCRIPTION
The Taz does not like the colon for some reason. It causes the line checksum to fail.