### PR TITLE
Fix fast moves on resume

### DIFF
--- a/DesignTools/Operations/Object3DExtensions.cs
+++ b/DesignTools/Operations/Object3DExtensions.cs
@@ -58,6 +58,18 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 			return objectToTranslate;
 		}
 
+
+		public static IObject3D Scale(this IObject3D objectToTranslate, double x = 0, double y = 0, double z = 0, string name = "")
+		{
+			return objectToTranslate.Scale(new Vector3(x, y, z), name);
+		}
+
+		public static IObject3D Scale(this IObject3D objectToTranslate, Vector3 translation, string name = "")
+		{
+			objectToTranslate.Matrix *= Matrix4X4.CreateScale(translation);
+			return objectToTranslate;
+		}
+
 		public static IObject3D Minus(this IObject3D a, IObject3D b)
 		{
 			var resultsA = a.Clone();

--- a/Tests/MatterControl.Tests/MatterControl/GCodeStreamTests.cs
+++ b/Tests/MatterControl.Tests/MatterControl/GCodeStreamTests.cs
@@ -362,8 +362,6 @@ namespace MatterControl.Tests.MatterControl
 
 				// move some more
 				"G1 X13 Y10 Z10 E40",
-				"G1 X14 Y10 Z10 E50",
-				"G1 X15 Y10 Z10 E60",
 				null,
 			};
 
@@ -392,9 +390,16 @@ namespace MatterControl.Tests.MatterControl
 				"G1 Z0 E30.8 F12000",
 				"G90",
 				"M114",
+				"",
+				"G1 X12.1 F1800",
+				"G1 X12.2",
+				"G90",
+				"G1 X12.33 Z1.667 E32.333",
+				"G1 X12.47 Z3.333 E33.867",
+				"G1 X12.6 Z5 E35.4",
+				"G1 X12.73 Z6.667 E36.933",
+				"G1 X12.87 Z8.333 E38.467",
 				"G1 X13 Z10 E40",
-				"G1 X14 E50",
-				"G1 X15 E60",
 				null,
 			};
 


### PR DESCRIPTION
Make sure we don't release the printers motors while paused

also issue: MatterHackers/MCCentral#625
Print does not resume in an acceptable way after a Pause has been issued