### PR TITLE
Clear ActivePrinters list before Add, remove 16 minute delay

### DIFF
--- a/ApplicationView/ApplicationController.cs
+++ b/ApplicationView/ApplicationController.cs
@@ -155,9 +155,15 @@ namespace MatterHackers.MatterControl
 					initialPrinter?.Connection?.Disable();
 				}
 
-				// ActivePrinters is IEnumerable to force us to use SetActivePrinter until it's ingrained in our pattern - cast to list since it is and we need to add
-				(this.ActivePrinters as List<PrinterConfig>).Add(printer);
-				this.ActivePrinter = printer;
+				// ActivePrinters is IEnumerable to force us to use SetActivePrinter until it's ingrained in our pattern
+				// Cast to list since it is one and we need to clear and add
+				if (this.ActivePrinters is List<PrinterConfig> activePrinterList)
+				{
+					activePrinterList.Clear();
+					activePrinterList.Add(printer);
+
+					this.ActivePrinter = printer;
+				}
 
 				// TODO: Decide if non-printer contexts should prompt for a printer, if we should have a default printer, or get "ActiveTab printer" working
 				// HACK: short term solution to resolve printer reference for non-printer related contexts

--- a/SlicerConfiguration/Settings/SettingsHelpers.cs
+++ b/SlicerConfiguration/Settings/SettingsHelpers.cs
@@ -468,6 +468,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 				// Ensure the local file with the old ID moves with the new ID change
 				string existingProfilePath = ProfilePath;
+
 				if (File.Exists(existingProfilePath))
 				{
 					// Profile ID change must come after existingProfilePath calculation and before ProfilePath getter

--- a/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
+++ b/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
@@ -144,7 +144,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 				testRunner.AddAndSelectPrinter("Airwolf 3D", "HD");
 
-				// Navigate to Local Library 
+				// Navigate to Local Library
 				testRunner.SwitchToPrinterSettings();
 
 				testRunner.ClickByName("Features Tab");
@@ -319,7 +319,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 				testRunner.AddAndSelectPrinter("Airwolf 3D", "HD");
 
-				// Navigate to Local Library 
+				// Navigate to Local Library
 				testRunner.SwitchToSliceSettings();
 
 				// Navigate to General Tab -> Layers / Surface Tab
@@ -374,7 +374,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			//testRunner.ScrollIntoView(checkBoxName);
 			//testRunner.ClickByName(checkBoxName);
 			testRunner.SelectSliceSettingsField(printer ? "Printer" : "Advanced", settingToChange);
-			
+
 			// give some time for the ui to update if necessary
 			testRunner.Delay(2);
 
@@ -412,7 +412,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 				testRunner.AddAndSelectPrinter("Airwolf 3D", "HD");
 
-				// Navigate to Settings Tab and make sure Bed Temp Text box is visible 
+				// Navigate to Settings Tab and make sure Bed Temp Text box is visible
 				testRunner.SwitchToSliceSettings();
 
 				testRunner.SelectSliceSettingsField("Advanced", SettingsKey.bed_temperature);
@@ -467,13 +467,13 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 				testRunner.AddAndSelectPrinter("BCN", "Sigma");
 
-				// Check Guest printer count 
+				// Check Guest printer count
 				Assert.AreEqual(2, ProfileManager.Instance.ActiveProfiles.Count(), "ProfileManager has 2 Profiles");
 
 				// Check if Guest printer names exists in dropdown
 				testRunner.OpenPrintersDropdown();
 				testRunner.ClickByName("Airwolf 3D HD Menu Item");
-				testRunner.Delay(1000);
+				testRunner.Delay(0.2);
 				testRunner.ClickByName("Open Empty Plate Button");
 
 				printer = ApplicationController.Instance.ActivePrinter;


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#3197
QualitySettingsStayAsOverrides test failing due to failure to switch
to selected printer