### PR TITLE
Getting leveling triangle lookup to have a cache

### DIFF
--- a/ConfigurationPage/PrintLeveling/LevelingFunctions.cs
+++ b/ConfigurationPage/PrintLeveling/LevelingFunctions.cs
@@ -142,7 +142,6 @@ namespace MatterHackers.MatterControl.ConfigurationPage.PrintLeveling
 
 		Dictionary<(int, int), int> positonToRegion = new Dictionary<(int, int), int>();
 
-		int hits = 0;
 		private LevelingTriangle GetCorrectRegion(Vector3 currentDestination)
 		{
 			int xIndex = (int)Math.Round(currentDestination.X * 100 / bedSize.X);
@@ -166,12 +165,6 @@ namespace MatterHackers.MatterControl.ConfigurationPage.PrintLeveling
 				}
 
 				positonToRegion.Add((xIndex, yIndex), bestIndex);
-				hits = 0;
-			}
-			else
-			{
-				hits++;
-				int a = 0;
 			}
 
 			return Regions[bestIndex];

--- a/PartPreviewWindow/SelectedObjectPanel.cs
+++ b/PartPreviewWindow/SelectedObjectPanel.cs
@@ -51,6 +51,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 	{
 	}
 
+	[HideUpdateButtonAttribute]
 	public class SelectedObjectPanel : FlowLayoutWidget, IContentStore
 	{
 		private IObject3D item = new Object3D();

--- a/PrinterCommunication/Io/PrintLevelingStream.cs
+++ b/PrinterCommunication/Io/PrintLevelingStream.cs
@@ -122,11 +122,6 @@ namespace MatterHackers.MatterControl.PrinterCommunication.Io
 					|| currentProbeOffset != printerSettings.GetValue<double>(SettingsKey.z_probe_z_offset)
 					|| !levelingData.SamplesAreSame(currentLevelingFunctions.SampledPositions))
 				{
-					if (currentLevelingFunctions != null)
-					{
-						currentLevelingFunctions.Dispose();
-					}
-
 					currentProbeOffset = printerSettings.GetValue<double>(SettingsKey.z_probe_z_offset);
 					currentLevelingFunctions = new LevelingFunctions(printerSettings, levelingData);
 				}


### PR DESCRIPTION
issue: MatterHackers/MatterControl#3258
Make bed grid have a cache to improve performance of position lookups