### PR TITLE
Change make permanent to apply (consistent with solidworks)

### DIFF
--- a/DesignTools/Operations/Align3D.cs
+++ b/DesignTools/Operations/Align3D.cs
@@ -267,7 +267,7 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 		[DisplayName("Offset Z")]
 		public double ZOffset { get; set; } = 0;
 
-		public override bool CanMakePermanent => true;
+		public override bool CanApply => true;
 
 		public override bool CanRemove => true;
 
@@ -404,7 +404,7 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 			});
 		}
 
-		public override void Remove()
+		public override void Remove(UndoBuffer undoBuffer)
 		{
 			// put everything back to where it was before the arrange started
 			if (OriginalChildrenBounds.Count == Children.Count)
@@ -418,7 +418,7 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 				}
 			}
 
-			base.Remove();
+			base.Remove(undoBuffer);
 		}
 
 		public void UpdateControls(PPEContext context)

--- a/DesignTools/Operations/ArrayAdvanced3D.cs
+++ b/DesignTools/Operations/ArrayAdvanced3D.cs
@@ -42,7 +42,7 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 			Name = "Advanced Array".Localize();
 		}
 
-		public override bool CanMakePermanent => true;
+		public override bool CanApply => true;
 		public override bool CanRemove => true;
 
 		public int Count { get; set; } = 3;
@@ -89,7 +89,7 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 			});
 		}
 
-		public override void Remove()
+		public override void Remove(UndoBuffer undoBuffer)
 		{
 			this.Children.Modify(list =>
 			{
@@ -98,7 +98,7 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 				list.Add(firstChild);
 			});
 
-			base.Remove();
+			base.Remove(undoBuffer);
 		}
 	}
 

--- a/DesignTools/Operations/ArrayLinear3D.cs
+++ b/DesignTools/Operations/ArrayLinear3D.cs
@@ -42,7 +42,7 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 			Name = "Linear Array".Localize();
 		}
 		
-		public override bool CanMakePermanent => true;
+		public override bool CanApply => true;
 		public override bool CanRemove => true;
 		public int Count { get; set; } = 3;
 		public DirectionVector Direction { get; set; } = new DirectionVector { Normal = new Vector3(1, 0, 0) };
@@ -66,7 +66,7 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 			});
 		}
 
-		public override void Remove()
+		public override void Remove(UndoBuffer undoBuffer)
 		{
 			this.Children.Modify(list =>
 			{
@@ -75,7 +75,7 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 				list.Add(firstChild);
 			});
 
-			base.Remove();
+			base.Remove(undoBuffer);
 		}
 	}
 }

--- a/DesignTools/Operations/ArrayRadial3D.cs
+++ b/DesignTools/Operations/ArrayRadial3D.cs
@@ -43,7 +43,7 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 			Name = "Radial Array".Localize();
 		}
 
-		public override bool CanMakePermanent => true;
+		public override bool CanApply => true;
 		public override bool CanRemove => true;
 
 		public int Count { get; set; } = 3;
@@ -97,7 +97,7 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 			this.Invalidate();
 		}
 
-		public override void Remove()
+		public override void Remove(UndoBuffer undoBuffer)
 		{
 			this.Children.Modify(list =>
 			{
@@ -106,7 +106,7 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 				list.Add(firstChild);
 			});
 
-			base.Remove();
+			base.Remove(undoBuffer);
 		}
 	}
 }

--- a/DesignTools/Operations/FitToBounds3D.cs
+++ b/DesignTools/Operations/FitToBounds3D.cs
@@ -68,7 +68,7 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 		{
 		}
 
-		public override void MakePermanent()
+		public override void Apply(UndoBuffer undoBuffer)
 		{
 			// push our matrix into our children
 			foreach (var child in this.Children)
@@ -87,7 +87,7 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 			});
 		}
 
-		public override void Remove()
+		public override void Remove(UndoBuffer undoBuffer)
 		{
 			// push our matrix into inner children
 			foreach (var child in ScaleItem.Children)

--- a/DesignTools/Primitives/TextObject3D.cs
+++ b/DesignTools/Primitives/TextObject3D.cs
@@ -27,6 +27,7 @@ of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the FreeBSD Project.
 */
 
+using System.Collections.Generic;
 using System.ComponentModel;
 using MatterHackers.Agg;
 using MatterHackers.Agg.Font;
@@ -34,6 +35,7 @@ using MatterHackers.Agg.Transform;
 using MatterHackers.Agg.UI;
 using MatterHackers.Agg.VertexSource;
 using MatterHackers.DataConverters3D;
+using MatterHackers.DataConverters3D.UndoCommands;
 using MatterHackers.Localizations;
 using MatterHackers.VectorMath;
 using Newtonsoft.Json;
@@ -97,6 +99,22 @@ namespace MatterHackers.MatterControl.DesignTools
 		[Sortable]
 		[JsonConverter(typeof(StringEnumConverter))]
 		public NamedTypeFace Font { get; set; } = new NamedTypeFace();
+
+		public override bool CanRemove => false;
+
+		public override void Apply(UndoBuffer undoBuffer)
+		{
+			// change this from a text object to a group
+			var newContainer = new Object3D()
+			{
+				Matrix = this.Matrix
+			};
+			foreach (var child in this.Children)
+			{
+				newContainer.Children.Add(child.Clone());
+			}
+			undoBuffer.AddAndDo(new ReplaceCommand(new List<IObject3D> { this }, new List<IObject3D> { newContainer }));
+		}
 
 		public void Rebuild(UndoBuffer undoBuffer)
 		{

--- a/Library/Widgets/InsertionGroup.cs
+++ b/Library/Widgets/InsertionGroup.cs
@@ -60,6 +60,11 @@ namespace MatterHackers.MatterControl.Library
 		// TODO: Figure out how best to collapse the InsertionGroup after the load task completes
 		public InsertionGroup(IEnumerable<ILibraryItem> items, View3DWidget view3DWidget, InteractiveScene scene, Vector2 bedCenter, Func<bool> dragOperationActive, bool trackSourceFiles = false)
 		{
+			if(items == null)
+			{
+				return;
+			}
+
 			// Add a temporary placeholder to give us some bounds
 			this.scene = scene;
 			this.view3DWidget = view3DWidget;
@@ -67,7 +72,8 @@ namespace MatterHackers.MatterControl.Library
 			this.LoadingItemsTask = Task.Run((Func<Task>)(async () =>
 			{
 				var newItemOffset = Vector2.Zero;
-				if (!dragOperationActive())
+				if (dragOperationActive != null
+					&& !dragOperationActive())
 				{
 					newItemOffset = bedCenter;
 				}
@@ -149,7 +155,8 @@ namespace MatterHackers.MatterControl.Library
 
 				ContentLoaded?.Invoke(this, null);
 
-				if (!dragOperationActive())
+				if (dragOperationActive != null
+					&& !dragOperationActive())
 				{
 					this.Collapse();
 				}

--- a/PartPreviewWindow/MaterialControls.cs
+++ b/PartPreviewWindow/MaterialControls.cs
@@ -53,7 +53,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 			materialButtons.Clear();
 			int extruderCount = 4;
-			for (int extruderIndex = 0; extruderIndex < extruderCount; extruderIndex++)
+			for (int extruderIndex = -1; extruderIndex < extruderCount; extruderIndex++)
 			{
 				var row = new FlowLayoutWidget()
 				{
@@ -62,7 +62,12 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				};
 				this.AddChild(row);
 
-				var radioButton = new RadioButton(string.Format("{0} {1}", "Material".Localize(), extruderIndex + 1), textColor: theme.Colors.PrimaryTextColor, fontSize: theme.DefaultFontSize);
+				var name = $"{"Material".Localize()} {extruderIndex +1}";
+				if(extruderIndex == -1)
+				{
+					name = "Default".Localize();
+				}
+				var radioButton = new RadioButton(name, textColor: theme.Colors.PrimaryTextColor, fontSize: theme.DefaultFontSize);
 				materialButtons.Add(radioButton);
 				radioButton.SiblingRadioButtonList = materialButtons;
 				row.AddChild(radioButton);
@@ -79,7 +84,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 				var scaledButtonSize = 16 * GuiWidget.DeviceScale;
 
-				row.AddChild(new ColorButton(MaterialRendering.Color(extruderIndex))
+				row.AddChild(new ColorButton(extruderIndex == -1 ? Color.Black : MaterialRendering.Color(extruderIndex))
 				{
 					Margin = new BorderDouble(5, 0, 0, 0),
 					Width = scaledButtonSize,

--- a/PartPreviewWindow/SelectedObjectPanel.cs
+++ b/PartPreviewWindow/SelectedObjectPanel.cs
@@ -163,19 +163,19 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			toolbar.AddChild(editButton);
 
 			// put in a make permanent button
-			var icon = AggContext.StaticData.LoadIcon("permanent.png", 16, 16, theme.InvertIcons).SetPreMultiply();
-			var bakeButton = new IconButton(icon, theme)
+			var icon = AggContext.StaticData.LoadIcon("fa-check_16.png", 16, 16, theme.InvertIcons).SetPreMultiply();
+			var applyButton = new IconButton(icon, theme)
 			{
 				Margin = theme.ButtonSpacing,
-				ToolTipText = "Make operation permanent".Localize()
+				ToolTipText = "Apply operation and make permanent".Localize()
 			};
-			bakeButton.Click += (s, e) =>
+			applyButton.Click += (s, e) =>
 			{
 				scene.SelectedItem = null;
-				this.item.MakePermanent();
+				this.item.Apply(view3DWidget.Scene.UndoBuffer);
 			};
-			scene.SelectionChanged += (s, e) => bakeButton.Enabled = scene.SelectedItem?.CanMakePermanent == true;
-			toolbar.AddChild(bakeButton);
+			scene.SelectionChanged += (s, e) => applyButton.Enabled = scene.SelectedItem?.CanApply == true;
+			toolbar.AddChild(applyButton);
 
 			// put in a remove button
 			var removeButton = new IconButton(ThemeConfig.RestoreNormal, theme)
@@ -186,7 +186,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			removeButton.Click += (s, e) =>
 			{
 				scene.SelectedItem = null;
-				this.item.Remove();
+				this.item.Remove(view3DWidget.Scene.UndoBuffer);
 			};
 			scene.SelectionChanged += (s, e) => removeButton.Enabled = scene.SelectedItem?.CanRemove == true;
 			toolbar.AddChild(removeButton);

--- a/PartPreviewWindow/View3D/Actions/MeshWrapperObject3D.cs
+++ b/PartPreviewWindow/View3D/Actions/MeshWrapperObject3D.cs
@@ -29,6 +29,7 @@ either expressed or implied, of the FreeBSD Project.
 
 using System.Collections.Generic;
 using System.Linq;
+using MatterHackers.Agg.UI;
 using MatterHackers.DataConverters3D;
 using MatterHackers.DataConverters3D.UndoCommands;
 using MatterHackers.PolygonMesh;
@@ -41,26 +42,26 @@ namespace MatterHackers.MatterControl.PartPreviewWindow.View3D
 		{
 		}
 
-		public override bool CanMakePermanent => true;
+		public override bool CanApply => true;
 		public override bool CanRemove => true;
 
-		public override void Remove()
+		public override void Remove(UndoBuffer undoBuffer)
 		{
 			// remove all the mesh wrappers that we own
 			var meshWrappers = this.Descendants().Where(o => o.OwnerID == this.ID).ToList();
 			foreach(var meshWrapper in meshWrappers)
 			{
-				meshWrapper.Remove();
+				meshWrapper.Remove(undoBuffer);
 			}
 			foreach(var child in Children)
 			{
 				child.OutputType = PrintOutputTypes.Default;
 			}
 			// collapes our children into our parent
-			base.Remove();
+			base.Remove(undoBuffer);
 		}
 
-		public override void MakePermanent()
+		public override void Apply(UndoBuffer undoBuffer)
 		{
 			var meshWrappers = this.Descendants().Where(o => o.OwnerID == this.ID).ToList();
 
@@ -83,7 +84,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow.View3D
 				}
 			}
 
-			base.MakePermanent();
+			base.Apply(undoBuffer);
 		}
 
 		public static void WrapSelection(MeshWrapperObject3D meshWrapper, InteractiveScene scene)


### PR DESCRIPTION
issues:
MatterHackers/MCCentral#3273
Selection object should not have delete and make permanent
MatterHackers/MCCentral#3277
check on text makes group of meshes
MatterHackers/MCCentral#3276
disable delete on text
MatterHackers/MCCentral#3263
Need a material none button (unset)