### PR TITLE
Fixing folder move sending to library provider

### DIFF
--- a/Library/Widgets/PrintLibraryWidget.cs
+++ b/Library/Widgets/PrintLibraryWidget.cs
@@ -668,7 +668,8 @@ namespace MatterHackers.MatterControl.PrintLibrary
 				Title = "Move".Localize(),
 				Action = (selectedLibraryItems, listView) =>
 				{
-					var partItems = selectedLibraryItems.Where(item => item is ILibraryAssetStream);
+					var partItems = selectedLibraryItems.Where(item => item is ILibraryAssetStream
+					|| item is ILibraryContainerLink);
 					if (partItems.Any()
 						&& libraryView.ActiveContainer is ILibraryWritableContainer sourceContainer)
 					{


### PR DESCRIPTION
Part of issue: MatterHackers/MatterControl#3238
can't move a folder in cloud library