### PR TITLE
Made linear extrude do an apply correctly

### DIFF
--- a/PartPreviewWindow/SelectedObjectPanel.cs
+++ b/PartPreviewWindow/SelectedObjectPanel.cs
@@ -199,6 +199,15 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 			selectedObjectEditorColumn.AddChild(scrollableEditor);
 
+			// Put the bottom resize container in a guiwidgt that is H:stretch V:fit so that the container can be hiden and shown and the resize container can keep it's size.
+			var selectedObjectEditorColumnContainer = new GuiWidget()
+			{
+				HAnchor = HAnchor.Stretch,
+				VAnchor = VAnchor.Fit
+			};
+
+			selectedObjectEditorColumnContainer.AddChild(selectedObjectEditorColumn);
+
 			inlineTitleEdit = new InlineTitleEdit("", theme, "Object Name");
 			inlineTitleEdit.TitleChanged += (s, e) =>
 			{
@@ -208,7 +217,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				}
 			};
 
-			selectedObjectEditorSection = new SectionWidget("Editor", selectedObjectEditorColumn, theme, serializationKey: UserSettingsKey.EditorPanelExpanded, defaultExpansion: true, setContentVAnchor: false)
+			selectedObjectEditorSection = new SectionWidget("Editor", selectedObjectEditorColumnContainer, theme, serializationKey: UserSettingsKey.EditorPanelExpanded, defaultExpansion: true)
 			{
 				VAnchor = VAnchor.Fit,
 			};

--- a/PartPreviewWindow/View3D/Actions/CombineObject3D.cs
+++ b/PartPreviewWindow/View3D/Actions/CombineObject3D.cs
@@ -114,10 +114,10 @@ namespace MatterHackers.MatterControl.PartPreviewWindow.View3D
 			{
 				if (remove != first)
 				{
-					var transformedRemove = Mesh.Copy(remove.Mesh, CancellationToken.None);
+					var transformedRemove = remove.Mesh.Copy(CancellationToken.None);
 					transformedRemove.Transform(remove.WorldMatrix());
 
-					var transformedKeep = Mesh.Copy(first.Mesh, CancellationToken.None);
+					var transformedKeep = first.Mesh.Copy(CancellationToken.None);
 					transformedKeep.Transform(first.WorldMatrix());
 
 					transformedKeep = PolygonMesh.Csg.CsgOperations.Union(transformedKeep, transformedRemove, (status, progress0To1) =>

--- a/PartPreviewWindow/View3D/Actions/IntersectionObject3D.cs
+++ b/PartPreviewWindow/View3D/Actions/IntersectionObject3D.cs
@@ -87,10 +87,10 @@ namespace MatterHackers.MatterControl.PartPreviewWindow.View3D
 					{
 						if (remove != first)
 						{
-							var transformedRemove = Mesh.Copy(remove.Mesh, CancellationToken.None);
+							var transformedRemove = remove.Mesh.Copy(CancellationToken.None);
 							transformedRemove.Transform(remove.WorldMatrix());
 
-							var transformedKeep = Mesh.Copy(first.Mesh, CancellationToken.None);
+							var transformedKeep = first.Mesh.Copy(CancellationToken.None);
 							transformedKeep.Transform(first.WorldMatrix());
 
 							transformedKeep = PolygonMesh.Csg.CsgOperations.Intersect(transformedKeep, transformedRemove, (status, progress0To1) =>

--- a/PartPreviewWindow/View3D/Actions/MeshWrapperObject3D.cs
+++ b/PartPreviewWindow/View3D/Actions/MeshWrapperObject3D.cs
@@ -135,7 +135,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow.View3D
 				var firstChild = item.Children.First();
 				item.SuspendRebuild();
 				// set the mesh back to a copy of the child mesh
-				item.Mesh = Mesh.Copy(firstChild.Mesh, cancellationToken);
+				item.Mesh = firstChild.Mesh.Copy(cancellationToken);
 				// and reset the properties
 				item.CopyProperties(firstChild, flags & (~Object3DPropertyFlags.Matrix));
 				item.ResumeRebuild();

--- a/PartPreviewWindow/View3D/Actions/SubtractAndReplaceObject3D.cs
+++ b/PartPreviewWindow/View3D/Actions/SubtractAndReplaceObject3D.cs
@@ -96,14 +96,14 @@ namespace MatterHackers.MatterControl.PartPreviewWindow.View3D
 
 					foreach (var paint in paintObjects.Select((r) => (obj3D: r, matrix: r.WorldMatrix())).ToList())
 					{
-						var transformedPaint = Mesh.Copy(paint.obj3D.Mesh, cancellationToken);
+						var transformedPaint = paint.obj3D.Mesh.Copy(cancellationToken);
 						transformedPaint.Transform(paint.matrix);
 						var inverseRemove = paint.matrix.Inverted;
 						Mesh paintMesh = null;
 
 						foreach (var keep in keepObjects.Select((r) => (obj3D: r, matrix: r.WorldMatrix())).ToList())
 						{
-							var transformedKeep = Mesh.Copy(keep.obj3D.Mesh, cancellationToken);
+							var transformedKeep = keep.obj3D.Mesh.Copy(cancellationToken);
 							transformedKeep.Transform(keep.matrix);
 
 							// remove the paint from the original

--- a/PartPreviewWindow/View3D/Actions/SubtractObject3D.cs
+++ b/PartPreviewWindow/View3D/Actions/SubtractObject3D.cs
@@ -72,12 +72,12 @@ namespace MatterHackers.MatterControl.PartPreviewWindow.View3D
 					{
 						progressStatus.Status = "Copy Remove";
 						reporter?.Report(progressStatus);
-						var transformedRemove = Mesh.Copy(remove.obj3D.Mesh, cancellationToken);
+						var transformedRemove = remove.obj3D.Mesh.Copy(cancellationToken);
 						transformedRemove.Transform(remove.matrix);
 
 						progressStatus.Status = "Copy Keep";
 						reporter?.Report(progressStatus);
-						var transformedKeep = Mesh.Copy(keep.obj3D.Mesh, cancellationToken);
+						var transformedKeep = keep.obj3D.Mesh.Copy(cancellationToken);
 						transformedKeep.Transform(keep.matrix);
 
 						progressStatus.Status = "Do CSG";


### PR DESCRIPTION
Fixed object properties panel collapse regression

Making copy mesh an extension method

issue: MatterHackers/MCCentral#3561
Editor panel fails to maintain size when collapsed via SectionWidget controls