### PR TITLE
Design tools

### DIFF
--- a/DesignTools/Operations/FitToBounds3D.cs
+++ b/DesignTools/Operations/FitToBounds3D.cs
@@ -129,7 +129,6 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 			}
 			else
 			{
-				// If the child bounds changed than adjust the scale control
 				base.OnInvalidate(invalidateType);
 			}
 		}

--- a/DesignTools/Primitives/BaseObject3D.cs
+++ b/DesignTools/Primitives/BaseObject3D.cs
@@ -37,7 +37,6 @@ using MatterHackers.Agg.VertexSource;
 using MatterHackers.DataConverters2D;
 using MatterHackers.DataConverters3D;
 using MatterHackers.Localizations;
-using MatterHackers.MatterControl.DesignTools.Operations;
 using MatterHackers.VectorMath;
 using Newtonsoft.Json;
 
@@ -66,15 +65,24 @@ namespace MatterHackers.MatterControl.DesignTools
 
 		public override void Apply(UndoBuffer undoBuffer)
 		{
-			OperationSource.Apply(this);
+			var visibleMeshes = this.VisibleMeshes().ToList();
+			this.Children.Modify((list) =>
+			{
+				list.Clear();
+				foreach(var child in visibleMeshes)
+				{
+					list.Add(new Object3D()
+					{
+						Mesh = child.Mesh
+					});
+				}
+			});
 
 			base.Apply(undoBuffer);
 		}
 
 		public override void Remove(UndoBuffer undoBuffer)
 		{
-			OperationSource.Remove(this);
-
 			base.Remove(undoBuffer);
 		}
 
@@ -130,7 +138,12 @@ namespace MatterHackers.MatterControl.DesignTools
 
 			Children.Modify((list) =>
 			{
-				list.RemoveAll((i) => !(i is OperationSource));
+				if (list.Count > 0)
+				{
+					var first = list[0];
+					list.Clear();
+					list.Add(first);
+				}
 			});
 
 			// Fall back to sibling content if VertexSource is unset

--- a/DesignTools/Primitives/TextObject3D.cs
+++ b/DesignTools/Primitives/TextObject3D.cs
@@ -126,7 +126,7 @@ namespace MatterHackers.MatterControl.DesignTools
 
 			ResumeRebuild();
 
-			Invalidate(new InvalidateArgs(this, InvalidateType.Content | InvalidateType.Mesh));
+			Invalidate(new InvalidateArgs(this, InvalidateType.Content));
 		}
 	}
 }

--- a/PartPreviewWindow/View3D/Actions/MeshWrapperObject3D.cs
+++ b/PartPreviewWindow/View3D/Actions/MeshWrapperObject3D.cs
@@ -54,20 +54,20 @@ namespace MatterHackers.MatterControl.PartPreviewWindow.View3D
 			// remove all the meshWrappers (collapse the children)
 			foreach (var meshWrapper in meshWrappers)
 			{
+				var parent = meshWrapper.Parent;
 				if (meshWrapper.Visible)
 				{
-					// clear the children
-					meshWrapper.Children.Modify(list =>
+					var newMesh = new Object3D()
 					{
-						list.Clear();
-					});
-					meshWrapper.OwnerID = null;
+						Mesh = meshWrapper.Mesh
+					};
+					newMesh.CopyProperties(meshWrapper, Object3DPropertyFlags.All);
+					newMesh.Name = this.Name;
+					parent.Children.Add(newMesh);
 				}
-				else
-				{
-					// remove it
-					meshWrapper.Parent.Children.Remove(meshWrapper);
-				}
+
+				// remove it
+				parent.Children.Remove(meshWrapper);
 			}
 
 			base.Apply(undoBuffer);


### PR DESCRIPTION
issue: MatterHackers/MCCentral#3579
Subtract -> Apply fails to remove subtract

issue: MatterHackers/MCCentral#3584
text -> fit -> align not rebuilding correctly

issue: MatterHackers/MCCentral#3585
Put image converter construction (object tree) into primitives container