### PR TITLE
Changing default sides to 40 from 30 so that aabb matches diameter

### DIFF
--- a/DesignTools/Primitives/ConeObject3D.cs
+++ b/DesignTools/Primitives/ConeObject3D.cs
@@ -58,7 +58,7 @@ namespace MatterHackers.MatterControl.DesignTools
 		//[DisplayName("Top")]
 		//public double TopDiameter { get; set; } = 0;
 		public double Height { get; set; } = 20;
-		public int Sides { get; set; } = 30;
+		public int Sides { get; set; } = 40;
 
 		public override void Rebuild(UndoBuffer undoBuffer)
 		{

--- a/DesignTools/Primitives/CylinderObject3D.cs
+++ b/DesignTools/Primitives/CylinderObject3D.cs
@@ -110,7 +110,7 @@ namespace MatterHackers.MatterControl.DesignTools
 
 		public double Diameter { get; set; } = 20;
 		public double Height { get; set; } = 20;
-		public int Sides { get; set; } = 30;
+		public int Sides { get; set; } = 40;
 
 		public bool Advanced { get; set; } = false;
 		public double StartingAngle { get; set; } = 0;

--- a/DesignTools/Primitives/HalfCylinderObject3D.cs
+++ b/DesignTools/Primitives/HalfCylinderObject3D.cs
@@ -56,7 +56,7 @@ namespace MatterHackers.MatterControl.DesignTools
 
 		public double Width { get; set; } = 20;
 		public double Depth { get; set; } = 20;
-		public int Sides { get; set; } = 15;
+		public int Sides { get; set; } = 20;
 
 		public override void Rebuild(UndoBuffer undoBuffer)
 		{

--- a/DesignTools/Primitives/HalfSphereObject3D.cs
+++ b/DesignTools/Primitives/HalfSphereObject3D.cs
@@ -63,7 +63,7 @@ namespace MatterHackers.MatterControl.DesignTools
 		}
 
 		public double Diameter { get; set; } = 20;
-		public int LongitudeSides { get; set; } = 30;
+		public int LongitudeSides { get; set; } = 40;
 		public int LatitudeSides { get; set; } = 10;
 
 		public override void Rebuild(UndoBuffer undoBuffer)

--- a/DesignTools/Primitives/RingObject3D.cs
+++ b/DesignTools/Primitives/RingObject3D.cs
@@ -70,7 +70,7 @@ namespace MatterHackers.MatterControl.DesignTools
 		public double OuterDiameter { get; set; } = 20;
 		public double InnerDiameter { get; set; } = 15;
 		public double Height { get; set; } = 5;
-		public int Sides { get; set; } = 30;
+		public int Sides { get; set; } = 40;
 
 		public bool Advanced { get; set; } = false;
 		public double StartingAngle { get; set; } = 0;

--- a/DesignTools/Primitives/SphereObject3D.cs
+++ b/DesignTools/Primitives/SphereObject3D.cs
@@ -64,7 +64,7 @@ namespace MatterHackers.MatterControl.DesignTools
 		}
 
 		public double Diameter { get; set; } = 20;
-		public int Sides { get; set; } = 30;
+		public int Sides { get; set; } = 40;
 
 		public bool Advanced { get; set; } = false;
 		public double StartingAngle { get; set; } = 0;

--- a/DesignTools/Primitives/TorusObject3D.cs
+++ b/DesignTools/Primitives/TorusObject3D.cs
@@ -53,7 +53,7 @@ namespace MatterHackers.MatterControl.DesignTools
 
 		public double OuterDiameter { get; set; } = 20;
 		public double InnerDiameter { get; set; } = 10;
-		public int Sides { get; set; } = 30;
+		public int Sides { get; set; } = 40;
 
 		public bool Advanced { get; set; } = false;
 		public double StartingAngle { get; set; } = 0;


### PR DESCRIPTION
issue: MatterHackers/MCCentral#3618
Change primitive sides to 40 by default. This makes size same as radius.