### PR TITLE
Make SubtractAndReplace rebuild on color and material child change

### DIFF
--- a/PartPreviewWindow/View3D/Actions/SubtractAndReplaceObject3D.cs
+++ b/PartPreviewWindow/View3D/Actions/SubtractAndReplaceObject3D.cs
@@ -56,6 +56,8 @@ namespace MatterHackers.MatterControl.PartPreviewWindow.View3D
 		{
 			if ((invalidateType.InvalidateType == InvalidateType.Content
 				|| invalidateType.InvalidateType == InvalidateType.Matrix
+				|| invalidateType.InvalidateType == InvalidateType.Color
+				|| invalidateType.InvalidateType == InvalidateType.Material
 				|| invalidateType.InvalidateType == InvalidateType.Mesh)
 				&& invalidateType.Source != this
 				&& !RebuildSuspended)


### PR DESCRIPTION
issue: MatterHackers/MCCentral#3603
Changing the inner objects material does not cause subtract and replace to update