### PR TITLE
Fix ToolTips on library IconListView items

### DIFF
--- a/Library/Widgets/ListView/IconListView.cs
+++ b/Library/Widgets/ListView/IconListView.cs
@@ -230,7 +230,10 @@ namespace MatterHackers.MatterControl.CustomWidgets
 			}
 			else
 			{
-				var container = new FlowLayoutWidget(FlowDirection.TopToBottom);
+				var container = new FlowLayoutWidget(FlowDirection.TopToBottom)
+				{
+					Selectable = false
+				};
 				this.AddChild(container);
 
 				imageWidget = new ImageWidget(scaledWidth, scaledHeight)


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#3630
Tooltips no longer appear on truncated item labels