### PR TITLE
Fixing boolean operations to not recurs as they set meshes

### DIFF
--- a/PartPreviewWindow/View3D/Actions/CombineObject3D.cs
+++ b/PartPreviewWindow/View3D/Actions/CombineObject3D.cs
@@ -135,7 +135,10 @@ namespace MatterHackers.MatterControl.PartPreviewWindow.View3D
 					var inverse = first.WorldMatrix();
 					inverse.Invert();
 					transformedKeep.Transform(inverse);
-					first.Mesh = transformedKeep;
+					using (first.RebuildLock())
+					{
+						first.Mesh = transformedKeep;
+					}
 					remove.Visible = false;
 
 					percentCompleted += amountPerOperation;

--- a/PartPreviewWindow/View3D/Actions/IntersectionObject3D.cs
+++ b/PartPreviewWindow/View3D/Actions/IntersectionObject3D.cs
@@ -110,7 +110,10 @@ namespace MatterHackers.MatterControl.PartPreviewWindow.View3D
 							var inverse = first.WorldMatrix();
 							inverse.Invert();
 							transformedKeep.Transform(inverse);
-							first.Mesh = transformedKeep;
+							using (first.RebuildLock())
+							{
+								first.Mesh = transformedKeep;
+							}
 							remove.Visible = false;
 
 							percentCompleted += amountPerOperation;

--- a/PartPreviewWindow/View3D/Actions/SubtractAndReplaceObject3D.cs
+++ b/PartPreviewWindow/View3D/Actions/SubtractAndReplaceObject3D.cs
@@ -124,7 +124,10 @@ namespace MatterHackers.MatterControl.PartPreviewWindow.View3D
 							}, cancellationToken);
 							var inverseKeep = keep.matrix.Inverted;
 							intersectAndSubtract.subtract.Transform(inverseKeep);
-							keep.obj3D.Mesh = intersectAndSubtract.subtract;
+							using (keep.obj3D.RebuildLock())
+							{
+								keep.obj3D.Mesh = intersectAndSubtract.subtract;
+							}
 
 							// keep all the intersections together
 							if (paintMesh == null)
@@ -145,7 +148,10 @@ namespace MatterHackers.MatterControl.PartPreviewWindow.View3D
 						// move the paint mesh back to its original coordinates
 						paintMesh.Transform(inverseRemove);
 
-						paint.obj3D.Mesh = paintMesh;
+						using (paint.obj3D.RebuildLock())
+						{
+							paint.obj3D.Mesh = paintMesh;
+						}
 
 						paint.obj3D.Color = paint.obj3D.WorldColor().AdjustContrast(keepObjects.First().WorldColor(), 2).ToColor();
 					}

--- a/Tests/MatterControl.AutomationTests/PrintingTests.cs
+++ b/Tests/MatterControl.AutomationTests/PrintingTests.cs
@@ -82,7 +82,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					Assert.IsTrue(ProfileManager.Instance.ActiveProfile != null);
 
 					// Cancel in this case is on the Leveling Wizard, results in ReloadAll and for consistency across devices, requires we wait till it completes
-					testRunner.WaitForReloadAll(() => testRunner.ClickByName("Cancel Button"));
+					testRunner.WaitForReloadAll(() => testRunner.ClickByName("Cancel Wizard Button"));
 
 					testRunner.ClickByName("Finish Setup Button");
 					int numNextButtons = 5;


### PR DESCRIPTION
issue: MatterHackers/MCCentral#3763
Subtracting and replacing a sphere causes a "loop" in some scenarios