### PR TITLE
Fixed screenshot in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ MatterControl
 
 [MatterControl](http://www.mattercontrol.com/) is an open-source program designed to control and enhance the desktop 3D printing experience. It's designed to help you get the most out of your 3D printer - making it easy to track, preview, and print your 3D parts. Development of MatterControl is sponsored by [MatterHackers](http://www.matterhackers.com/) and it's partners.
 
-![Screenshot](http://www.mattercontrol.com/static/mattercontrol/screenshot_slice.png)
+![Screenshot](https://user-images.githubusercontent.com/3131268/43025866-3af2d478-8c28-11e8-88c8-5a8768dbd64f.png)
 
 Features
 --------


### PR DESCRIPTION
The old link was dead since mattercontrol.com was taken down. I took a new screenshot for MatterControl 2.0.