### PR TITLE
set good starting undo point for slice settings

### DIFF
--- a/SlicerConfiguration/SliceSettingsWidget.cs
+++ b/SlicerConfiguration/SliceSettingsWidget.cs
@@ -854,6 +854,16 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 				uiField.SetValue(sliceSettingValue, userInitiated: false);
 
+				// make sure the undo data goes back to the intial value after a change
+				if(uiField.Content is MHTextEditWidget textWidget)
+				{
+					textWidget.ActualTextEditWidget.InternalTextEditWidget.ClearUndoHistory();
+				}
+				else if (uiField.Content is MHNumberEdit numberWidget)
+				{
+					numberWidget.ActuallNumberEdit.InternalTextEditWidget.ClearUndoHistory();
+				}
+
 				uiField.ValueChanged += (s, e) =>
 				{
 					if (useDefaultSavePattern


### PR DESCRIPTION
issue: MatterHackers/MCCentral#3916
Slice settings text fields should get undo data set to cleared after initial setting