### PR TITLE
Alt popups, new context menus

### DIFF
--- a/ApplicationView/ThemeConfig.cs
+++ b/ApplicationView/ThemeConfig.cs
@@ -323,10 +323,16 @@ namespace MatterHackers.MatterControl
 			return new BlenderBGRA().Blend(background, overlay);
 		}
 
-		public FlowLayoutWidget CreateMenuItems(PopupMenu popupMenu, IEnumerable<NamedAction> menuActions)
+		public FlowLayoutWidget CreateMenuItems(PopupMenu popupMenu, IEnumerable<NamedAction> menuActions, bool emptyMenu = true)
 		{
+			// Retain past behavior, where menu is cleared each call. More recent callers many pass in a newly populated menu and
+			// not require the clear
+			if (emptyMenu)
+			{
+				popupMenu.CloseAllChildren();
+			}
+
 			// Create menu items in the DropList for each element in this.menuActions
-			popupMenu.CloseAllChildren();
 			foreach (var menuAction in menuActions)
 			{
 				if (menuAction is ActionSeparator)

--- a/ApplicationView/ThemeConfig.cs
+++ b/ApplicationView/ThemeConfig.cs
@@ -329,7 +329,7 @@ namespace MatterHackers.MatterControl
 			popupMenu.CloseAllChildren();
 			foreach (var menuAction in menuActions)
 			{
-				if (menuAction.Title == "----")
+				if (menuAction is ActionSeparator)
 				{
 					popupMenu.CreateHorizontalLine();
 				}

--- a/CustomWidgets/NamedAction.cs
+++ b/CustomWidgets/NamedAction.cs
@@ -42,6 +42,9 @@ namespace MatterHackers.Agg.UI
 		public Action Action { get; set; }
 		public ImageBuffer Icon { get; set; }
 		public Func<bool> IsEnabled { get; set; }
+
+	public class ActionSeparator : NamedAction
+	{
 	}
 
 	public class NamedBoolAction : NamedAction

--- a/CustomWidgets/NamedAction.cs
+++ b/CustomWidgets/NamedAction.cs
@@ -42,6 +42,8 @@ namespace MatterHackers.Agg.UI
 		public Action Action { get; set; }
 		public ImageBuffer Icon { get; set; }
 		public Func<bool> IsEnabled { get; set; }
+		public string ID { get; internal set; }
+	}
 
 	public class ActionSeparator : NamedAction
 	{

--- a/CustomWidgets/TreeView/TreeNode.cs
+++ b/CustomWidgets/TreeView/TreeNode.cs
@@ -64,7 +64,7 @@ namespace MatterHackers.MatterControl.CustomWidgets
 					TreeView.SelectedNode = this;
 				}
 
-				this.TreeView.NotifyItemClicked(this, e);
+				this.TreeView.NotifyItemClicked(this.TitleBar, e);
 			};
 			this.AddChild(this.TitleBar);
 

--- a/CustomWidgets/TreeView/TreeNode.cs
+++ b/CustomWidgets/TreeView/TreeNode.cs
@@ -63,6 +63,8 @@ namespace MatterHackers.MatterControl.CustomWidgets
 				{
 					TreeView.SelectedNode = this;
 				}
+
+				this.TreeView.NotifyItemClicked(this, e);
 			};
 			this.AddChild(this.TitleBar);
 

--- a/CustomWidgets/TreeView/TreeView.cs
+++ b/CustomWidgets/TreeView/TreeView.cs
@@ -75,9 +75,9 @@ namespace MatterHackers.MatterControl.CustomWidgets
 
 		public event EventHandler BeforeCheck;
 
-		internal void NotifyItemClicked(TreeNode treeNode, MouseEventArgs e)
+		internal void NotifyItemClicked(GuiWidget sourceWidget, MouseEventArgs e)
 		{
-			this.NodeMouseClick?.Invoke(treeNode, e);
+			this.NodeMouseClick?.Invoke(sourceWidget, e);
 		}
 
 		public event EventHandler BeforeCollapse;

--- a/CustomWidgets/TreeView/TreeView.cs
+++ b/CustomWidgets/TreeView/TreeView.cs
@@ -75,6 +75,11 @@ namespace MatterHackers.MatterControl.CustomWidgets
 
 		public event EventHandler BeforeCheck;
 
+		internal void NotifyItemClicked(TreeNode treeNode, MouseEventArgs e)
+		{
+			this.NodeMouseClick?.Invoke(treeNode, e);
+		}
+
 		public event EventHandler BeforeCollapse;
 
 		public event EventHandler BeforeExpand;

--- a/Library/Widgets/ListView/ListView.cs
+++ b/Library/Widgets/ListView/ListView.cs
@@ -38,6 +38,7 @@ using MatterHackers.Agg.Image;
 using MatterHackers.Agg.Platform;
 using MatterHackers.Agg.UI;
 using MatterHackers.MatterControl.Library;
+using MatterHackers.MatterControl.PrintQueue;
 using MatterHackers.VectorMath;
 
 namespace MatterHackers.MatterControl.CustomWidgets
@@ -59,6 +60,8 @@ namespace MatterHackers.MatterControl.CustomWidgets
 		private GuiWidget contentView;
 		private Color loadingBackgroundColor;
 		private ImageSequenceWidget loadingIndicator;
+
+		public List<PrintItemAction> MenuActions { get; set; }
 
 		// Default constructor uses IconListView
 		public ListView(ILibraryContext context, ThemeConfig theme)
@@ -224,6 +227,7 @@ namespace MatterHackers.MatterControl.CustomWidgets
 				items.Add(listViewItem);
 
 				listViewItem.ViewWidget = itemsContentView.AddItem(listViewItem);
+				listViewItem.ViewWidget.HasMenu = true;
 				listViewItem.ViewWidget.Name = childContainer.Name + " Row Item Collection";
 			}
 
@@ -243,6 +247,7 @@ namespace MatterHackers.MatterControl.CustomWidgets
 					items.Add(listViewItem);
 
 					listViewItem.ViewWidget = itemsContentView.AddItem(listViewItem);
+					listViewItem.ViewWidget.HasMenu = true;
 					listViewItem.ViewWidget.Name = "Row Item " + item.Name;
 				}
 

--- a/Library/Widgets/ListView/ListViewItemBase.cs
+++ b/Library/Widgets/ListView/ListViewItemBase.cs
@@ -410,7 +410,7 @@ namespace MatterHackers.MatterControl.CustomWidgets
 				RectangleDouble popupBounds;
 				if (mouseEvent.Button == MouseButtons.Right)
 				{
-					popupBounds = new RectangleDouble(mouseEvent.X, mouseEvent.Y, mouseEvent.X, mouseEvent.Y);
+					popupBounds = new RectangleDouble(mouseEvent.X + 1, mouseEvent.Y + 1, mouseEvent.X + 1, mouseEvent.Y + 1);
 				}
 				else
 				{
@@ -421,7 +421,7 @@ namespace MatterHackers.MatterControl.CustomWidgets
 				systemWindow.ShowPopup(
 					new MatePoint(this)
 					{
-						Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+						Mate = new MateOptions(MateEdge.Left, MateEdge.Bottom),
 						AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
 					},
 					new MatePoint(menu)

--- a/Library/Widgets/ListView/ListViewItemBase.cs
+++ b/Library/Widgets/ListView/ListViewItemBase.cs
@@ -54,6 +54,8 @@ namespace MatterHackers.MatterControl.CustomWidgets
 		private bool mouseDownInBounds = false;
 		private Vector2 mouseDownAt;
 
+		private ImageBuffer overflowIcon;
+
 		public ImageWidget imageWidget;
 		protected int thumbWidth;
 		protected int thumbHeight;
@@ -64,6 +66,8 @@ namespace MatterHackers.MatterControl.CustomWidgets
 			this.listViewItem = listViewItem;
 			this.thumbWidth = width;
 			this.thumbHeight = height;
+
+			overflowIcon = AggContext.StaticData.LoadIcon(Path.Combine("ViewTransformControls", "overflow.png"), 32, 32, theme.InvertIcons);
 		}
 
 		public bool HasMenu { get; set; } = false;
@@ -388,7 +392,7 @@ namespace MatterHackers.MatterControl.CustomWidgets
 				&& (hitRegion.Contains(mouseEvent.Position)
 					|| mouseEvent.Button == MouseButtons.Right))
 			{
-				var menu = new PopupMenu(theme);
+				var menu = new PopupMenu(ApplicationController.Instance.MenuTheme);
 
 				foreach (var menuAction in this.listViewItem.ListView.MenuActions)
 				{
@@ -434,8 +438,6 @@ namespace MatterHackers.MatterControl.CustomWidgets
 
 			base.OnClick(mouseEvent);
 		}
-
-		private ImageBuffer overflowIcon = AggContext.StaticData.LoadIcon(Path.Combine("ViewTransformControls", "overflow.png"), 32, 32);
 
 		protected virtual void UpdateColors()
 		{

--- a/Library/Widgets/ListView/ListViewItemBase.cs
+++ b/Library/Widgets/ListView/ListViewItemBase.cs
@@ -29,6 +29,7 @@ either expressed or implied, of the FreeBSD Project.
 
 using System;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using MatterHackers.Agg;
 using MatterHackers.Agg.Image;
@@ -36,6 +37,7 @@ using MatterHackers.Agg.Platform;
 using MatterHackers.Agg.UI;
 using MatterHackers.MatterControl.Library;
 using MatterHackers.MatterControl.PartPreviewWindow;
+using MatterHackers.MatterControl.PrintQueue;
 using MatterHackers.VectorMath;
 
 namespace MatterHackers.MatterControl.CustomWidgets
@@ -63,6 +65,8 @@ namespace MatterHackers.MatterControl.CustomWidgets
 			this.thumbWidth = width;
 			this.thumbHeight = height;
 		}
+
+		public bool HasMenu { get; set; } = false;
 
 		public async Task LoadItemThumbnail()
 		{
@@ -286,6 +290,11 @@ namespace MatterHackers.MatterControl.CustomWidgets
 
 		public override void OnLoad(EventArgs args)
 		{
+			foreach (var child in Children)
+			{
+				child.Selectable = false;
+			}
+
 			// On first draw, lookup and set best thumbnail
 			this.LoadItemThumbnail().ConfigureAwait(false);
 
@@ -302,6 +311,13 @@ namespace MatterHackers.MatterControl.CustomWidgets
 
 				// Requeue thumbnail generation
 				this.ScheduleRaytraceOperation();
+			}
+
+			if (this.mouseInBounds
+				&& this.HasMenu)
+			{
+				var bounds = this.LocalBounds;
+				graphics2D.Render(overflowIcon, new Point2D(bounds.Right - 32, bounds.Top - 32 - 3));
 			}
 
 			base.OnDraw(graphics2D);
@@ -360,6 +376,66 @@ namespace MatterHackers.MatterControl.CustomWidgets
 			UpdateHoverState();
 			Invalidate();
 		}
+
+		public override void OnClick(MouseEventArgs mouseEvent)
+		{
+			var bounds = this.LocalBounds;
+			var hitRegion = new RectangleDouble(
+				new Vector2(bounds.Right - 32, bounds.Top),
+				new Vector2(bounds.Right, bounds.Top - 32));
+
+			if (this.HasMenu
+				&& (hitRegion.Contains(mouseEvent.Position)
+					|| mouseEvent.Button == MouseButtons.Right))
+			{
+				var menu = new PopupMenu(theme);
+
+				foreach (var menuAction in this.listViewItem.ListView.MenuActions)
+				{
+					if (menuAction is MenuSeparator)
+					{
+						menu.CreateHorizontalLine();
+					}
+					else if (menuAction.IsEnabled(this.listViewItem.ListView.SelectedItems, this.listViewItem.ListView))
+					{
+						var item = menu.CreateMenuItem(menuAction.Title);
+						item.Click += (s, e) => UiThread.RunOnIdle(() =>
+						{
+							menu.Close();
+							menuAction.Action.Invoke(this.listViewItem.ListView.SelectedItems.Select(o => o.Model), this.listViewItem.ListView);
+						});
+					}
+				}
+
+				RectangleDouble popupBounds;
+				if (mouseEvent.Button == MouseButtons.Right)
+				{
+					popupBounds = new RectangleDouble(mouseEvent.X, mouseEvent.Y, mouseEvent.X, mouseEvent.Y);
+				}
+				else
+				{
+					popupBounds = new RectangleDouble(this.Width - 32, this.Height - 32, this.Width, this.Height);
+				}
+
+				var systemWindow = this.Parents<SystemWindow>().FirstOrDefault();
+				systemWindow.ShowPopup(
+					new MatePoint(this)
+					{
+						Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+						AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
+					},
+					new MatePoint(menu)
+					{
+						Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+						AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
+					},
+					altBounds: popupBounds);
+			}
+
+			base.OnClick(mouseEvent);
+		}
+
+		private ImageBuffer overflowIcon = AggContext.StaticData.LoadIcon(Path.Combine("ViewTransformControls", "overflow.png"), 32, 32);
 
 		protected virtual void UpdateColors()
 		{

--- a/Library/Widgets/PrintLibraryWidget.cs
+++ b/Library/Widgets/PrintLibraryWidget.cs
@@ -852,6 +852,8 @@ namespace MatterHackers.MatterControl.PrintLibrary
 					&& libraryAsset.ContentType == "mcx";
 				}
 			});
+
+			libraryView.MenuActions = menuActions;
 		}
 
 		public override void OnClosed(ClosedEventArgs e)

--- a/MatterControl.csproj
+++ b/MatterControl.csproj
@@ -213,6 +213,7 @@
     <Compile Include="PartPreviewWindow\MoveItemPage.cs" />
     <Compile Include="PartPreviewWindow\StartPage\ExplorerBar.cs" />
     <Compile Include="PartPreviewWindow\RoundedToggleSwitch.cs" />
+    <Compile Include="PartPreviewWindow\SystemWindowExtension.cs" />
     <Compile Include="PartPreviewWindow\View3D\Actions\ImageEditor.cs" />
     <Compile Include="PartPreviewWindow\View3D\Actions\MeshWrapperObject3D.cs" />
     <Compile Include="PartPreviewWindow\View3D\PrinterBar\OverflowBar.cs" />

--- a/PartPreviewWindow/PartTabPage.cs
+++ b/PartPreviewWindow/PartTabPage.cs
@@ -28,6 +28,7 @@ either expressed or implied, of the FreeBSD Project.
 */
 
 using System;
+using System.Linq;
 using MatterHackers.Agg.UI;
 using MatterHackers.MeshVisualizer;
 using MatterHackers.VectorMath;
@@ -87,6 +88,9 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				editorType: (isPrinterType) ? MeshViewerWidget.EditorType.Printer : MeshViewerWidget.EditorType.Part);
 
 			viewControls3D.SetView3DWidget(view3DWidget);
+
+			// Construct and store dictionary of menu actions accessible at workspace level
+			view3DWidget.WorkspaceActions = viewControls3D.MenuActions.Where(o => !string.IsNullOrEmpty(o.ID)).ToDictionary(o => o.ID, o => o);
 
 			this.AddChild(topToBottom = new FlowLayoutWidget(FlowDirection.TopToBottom)
 			{

--- a/PartPreviewWindow/SelectedObjectPanel.cs
+++ b/PartPreviewWindow/SelectedObjectPanel.cs
@@ -134,65 +134,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			overflowButton.PopupBorderColor = ApplicationController.Instance.MenuTheme.GetBorderColor(120);
 			overflowButton.DynamicPopupContent = () =>
 			{
-				var popupMenu = new PopupMenu(ApplicationController.Instance.MenuTheme);
-
-				var menuItem = popupMenu.CreateMenuItem("Rename");
-				menuItem.Click += (s, e) =>
-				{
-					DialogWindow.Show(
-						new InputBoxPage(
-							"Rename Item".Localize(),
-							"Name".Localize(),
-							item.Name,
-							"Enter New Name Here".Localize(),
-							"Rename".Localize(),
-							(newName) =>
-							{
-								item.Name = newName;
-								editorSectionWidget.Text = newName;
-							}));
-				};
-
-				popupMenu.CreateHorizontalLine();
-
-				if (true) //allowOperations)
-				{
-					var selectedItemType = item.GetType();
-					var selectedItem = item;
-
-					var menuTheme = ApplicationController.Instance.MenuTheme;
-
-					foreach (var nodeOperation in ApplicationController.Instance.Graph.Operations)
-					{
-						foreach (var type in nodeOperation.MappedTypes)
-						{
-							if (type.IsAssignableFrom(selectedItemType)
-								&& (nodeOperation.IsVisible?.Invoke(selectedItem) != false)
-								&& nodeOperation.IsEnabled?.Invoke(selectedItem) != false)
-							{
-								var button = popupMenu.CreateMenuItem(nodeOperation.Title, nodeOperation.IconCollector?.Invoke(menuTheme));
-								button.Click += (s, e) =>
-								{
-									nodeOperation.Operation(selectedItem, sceneContext.Scene).ConfigureAwait(false);
-								};
-							}
-						}
-					}
-
-					if (selectedItem.Ancestors().OfType<ComponentObject3D>().FirstOrDefault() is ComponentObject3D componentAncestor
-						&& !componentAncestor.Finalized)
-					{
-						var button = popupMenu.CreateMenuItem("Copy Path".Localize());
-						button.Click += (s, e) =>
-						{
-							var selector = "$." + string.Join(".", selectedItem.AncestorsAndSelf().TakeWhile(o => !(o is ComponentObject3D)).Select(o => $"Children<{o.GetType().Name.ToString()}>").Reverse().ToArray());
-
-							Clipboard.Instance.SetText(selector);
-						};
-					}
-				}
-
-				return popupMenu;
+				return ApplicationController.Instance.GetActionMenuForSceneItem(item, sceneContext.Scene);
 			};
 			toolbar.AddChild(overflowButton);
 

--- a/PartPreviewWindow/SystemWindowExtension.cs
+++ b/PartPreviewWindow/SystemWindowExtension.cs
@@ -206,6 +206,8 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			};
 
 			popup.Widget.Focus();
+
+			popup.Widget.Invalidate();
 		}
 
 		private static Vector2 GetYAnchor(MateOptions anchor, MateOptions popup, GuiWidget popupWidget, RectangleDouble bounds)

--- a/PartPreviewWindow/SystemWindowExtension.cs
+++ b/PartPreviewWindow/SystemWindowExtension.cs
@@ -1,0 +1,247 @@
+﻿/*
+Copyright (c) 2017, Lars Brubaker, John Lewin
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the FreeBSD Project.
+*/
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MatterHackers.Agg;
+using MatterHackers.Agg.UI;
+using MatterHackers.DataConverters3D;
+using MatterHackers.VectorMath;
+
+namespace MatterHackers.MatterControl.PartPreviewWindow
+{
+	[Flags]
+	public enum MateEdge
+	{
+		Top = 1,
+		Bottom = 2,
+		Left = 4,
+		Right = 8
+	}
+
+	public class MateOptions
+	{
+		public MateOptions(MateEdge horizontalEdge = MateEdge.Left, MateEdge verticalEdge = MateEdge.Bottom)
+		{
+			this.HorizontalEdge = horizontalEdge;
+			this.VerticalEdge = verticalEdge;
+		}
+
+		public MateEdge HorizontalEdge { get; set; }
+		public MateEdge VerticalEdge { get; set; }
+
+		public bool Top => this.VerticalEdge.HasFlag(MateEdge.Top);
+		public bool Bottom => this.VerticalEdge.HasFlag(MateEdge.Bottom);
+		public bool Left => this.HorizontalEdge.HasFlag(MateEdge.Left);
+		public bool Right => this.HorizontalEdge.HasFlag(MateEdge.Right);
+	}
+
+	public class MatePoint
+	{
+		public MateOptions Mate { get; set; } = new MateOptions();
+		public MateOptions AltMate { get; set; } = new MateOptions();
+
+		public GuiWidget Widget { get; set; }
+
+		public MatePoint()
+		{
+		}
+
+		public MatePoint(GuiWidget widget)
+		{
+			this.Widget = widget;
+		}
+
+		public RectangleDouble Offset { get; set; }
+	}
+
+	public static class SystemWindowExtension
+	{
+		public static void ShowPopup(this SystemWindow systemWindow, MatePoint anchor, MatePoint popup, RectangleDouble altBounds = default(RectangleDouble))
+		{
+			var hookedParents = new HashSet<GuiWidget>();
+
+			var ignoredWidgets = popup.Widget.Children.Where(c => c is IIgnoredPopupChild).ToList();
+
+			bool checkIfNeedScrollBar = true;
+
+			void widgetRelativeTo_PositionChanged(object sender, EventArgs e)
+			{
+				if (anchor.Widget?.Parent != null)
+				{
+					// Calculate left aligned screen space position (using widgetRelativeTo.parent)
+					Vector2 anchorLeft = anchor.Widget.Parent.TransformToScreenSpace(anchor.Widget.Position);
+					anchorLeft += new Vector2(altBounds.Left, altBounds.Bottom);
+
+					Vector2 popupPosition = anchorLeft;
+
+					var bounds = altBounds == default(RectangleDouble) ? anchor.Widget.LocalBounds : altBounds;
+
+					Vector2 xPosition = GetXAnchor(anchor.Mate, popup.Mate, popup.Widget, bounds);
+
+					Vector2 screenPosition;
+
+					screenPosition = anchorLeft + xPosition;
+
+					// Constrain
+					if (screenPosition.X + popup.Widget.Width > systemWindow.Width
+						|| screenPosition.X < 0)
+					{
+						xPosition = GetXAnchor(anchor.AltMate, popup.AltMate, popup.Widget, bounds);
+					}
+
+					popupPosition += xPosition;
+
+					Vector2 yPosition = GetYAnchor(anchor.Mate, popup.Mate, popup.Widget, bounds);
+
+					screenPosition = anchorLeft + yPosition;
+
+					// Constrain
+					if (anchor.AltMate != null
+						&& (screenPosition.Y + popup.Widget.Height > systemWindow.Height
+							|| screenPosition.Y < 0))
+					{
+						yPosition = GetYAnchor(anchor.AltMate, popup.AltMate, popup.Widget, bounds);
+					}
+
+					popupPosition += yPosition;
+
+					popup.Widget.Position = popupPosition;
+				}
+			}
+
+			void CloseMenu()
+			{
+				popup.Widget.Close();
+
+				// Unbind callbacks on parents for position_changed if we're closing
+				foreach (GuiWidget widget in hookedParents)
+				{
+					widget.PositionChanged -= widgetRelativeTo_PositionChanged;
+					widget.BoundsChanged -= widgetRelativeTo_PositionChanged;
+				}
+
+				// Long lived originating item must be unregistered
+				anchor.Widget.Closed -= anchor_Closed;
+
+				// Restore focus to originating widget on close
+				if (anchor.Widget?.HasBeenClosed == false)
+				{
+					anchor.Widget.Focus();
+				}
+			}
+
+			void FocusChanged(object sender, EventArgs e)
+			{
+				UiThread.RunOnIdle(() =>
+				{
+					// Fired any time focus changes. Traditionally we closed the menu if the we weren't focused.
+					// To accommodate children (or external widgets) having focus we also query for and consider special cases
+					bool specialChildHasFocus = ignoredWidgets.Any(w => w.ContainsFocus || w.Focused)
+						|| popup.Widget.DescendantsAndSelf<DropDownList>().Any(w => w.IsOpen);
+
+					// If the focused changed and we've lost focus and no special cases permit, close the menu
+					if (!popup.Widget.ContainsFocus
+						&& !specialChildHasFocus)
+					{
+						CloseMenu();
+					}
+				});
+
+			}
+
+			void anchor_Closed(object sender, ClosedEventArgs e)
+			{
+				// If the owning widget closed, so should we
+				CloseMenu();
+			}
+
+			foreach (var ancestor in anchor.Widget.Parents<GuiWidget>().Where(p => p != systemWindow))
+			{
+				if (hookedParents.Add(ancestor))
+				{
+					ancestor.PositionChanged += widgetRelativeTo_PositionChanged;
+					ancestor.BoundsChanged += widgetRelativeTo_PositionChanged;
+				}
+			}
+
+			popup.Widget.ContainsFocusChanged += FocusChanged;
+
+			widgetRelativeTo_PositionChanged(anchor.Widget, null);
+			anchor.Widget.Closed += anchor_Closed;
+
+			// When the widgets position changes, sync the popup position
+			systemWindow?.AddChild(popup.Widget);
+
+			popup.Widget.Closed += (s, e) =>
+			{
+				Console.WriteLine();
+			};
+
+			popup.Widget.Focus();
+		}
+
+		private static Vector2 GetYAnchor(MateOptions anchor, MateOptions popup, GuiWidget popupWidget, RectangleDouble bounds)
+		{
+			if (anchor.Top && popup.Bottom)
+			{
+				return new Vector2(0, bounds.Height);
+			}
+			else if (anchor.Top && popup.Top)
+			{
+				return new Vector2(0, popupWidget.Height - bounds.Height) * -1;
+			}
+			else if (anchor.Bottom && popup.Top)
+			{
+				return new Vector2(0, -popupWidget.Height);
+			}
+
+			return Vector2.Zero;
+		}
+
+		private static Vector2 GetXAnchor(MateOptions anchor, MateOptions popup, GuiWidget popupWidget, RectangleDouble bounds)
+		{
+			if (anchor.Right && popup.Left)
+			{
+				return new Vector2(bounds.Width, 0);
+			}
+			else if (anchor.Left && popup.Right)
+			{
+				return new Vector2(-popupWidget.Width, 0);
+			}
+			else if (anchor.Right && popup.Right)
+			{
+				return new Vector2(popupWidget.Width - bounds.Width, 0) * -1;
+			}
+
+			return Vector2.Zero;
+		}
+	}
+}

--- a/PartPreviewWindow/View3D/Actions/ImageEditor.cs
+++ b/PartPreviewWindow/View3D/Actions/ImageEditor.cs
@@ -144,8 +144,6 @@ namespace MatterHackers.MatterControl.DesignTools
 							AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
 						},
 						altBounds: popupBounds);
-
-					systemWindow.Invalidate();
 				}
 			};
 

--- a/PartPreviewWindow/View3D/Actions/ImageEditor.cs
+++ b/PartPreviewWindow/View3D/Actions/ImageEditor.cs
@@ -38,9 +38,11 @@ using MatterHackers.MatterControl.PartPreviewWindow;
 
 namespace MatterHackers.MatterControl.DesignTools
 {
+	using System.Linq;
 	using CustomWidgets;
 	using DataConverters3D;
 	using MatterHackers.Agg.Platform;
+	using MatterHackers.MatterControl.DataStorage;
 	using MatterHackers.MatterControl.Library;
 
 	public class ImageEditor : IObject3DEditor
@@ -87,6 +89,65 @@ namespace MatterHackers.MatterControl.DesignTools
 				Margin = new BorderDouble(bottom: 5),
 				HAnchor = HAnchor.Center
 			});
+
+			thumbnailWidget.Click += (s, e) =>
+			{
+				if (e.Button == MouseButtons.Right)
+				{
+					var popupMenu = new PopupMenu(theme);
+
+					var pasteMenu = popupMenu.CreateMenuItem("Paste".Localize());
+					pasteMenu.Click += (s2, e2) =>
+					{
+						activeImage = Clipboard.Instance.GetImage();
+
+						thumbnailWidget.Image = activeImage;
+
+						// Persist
+						string filePath = ApplicationDataStorage.Instance.GetNewLibraryFilePath(".png");
+						AggContext.ImageIO.SaveImageData(
+							filePath,
+							activeImage);
+
+						imageObject.AssetPath = filePath;
+						imageObject.Mesh = null;
+
+						thumbnailWidget.Image = SetImage(theme, imageObject);
+
+						column.Invalidate();
+						imageObject.Invalidate(new InvalidateArgs(imageObject, InvalidateType.Image));
+
+						popupMenu.Unfocus();
+					};
+
+					pasteMenu.Enabled = Clipboard.Instance.ContainsImage;
+
+					var copyMenu = popupMenu.CreateMenuItem("Copy".Localize());
+					copyMenu.Click += (s2, e2) =>
+					{
+						Clipboard.Instance.SetImage(thumbnailWidget.Image);
+						popupMenu.Unfocus();
+					};
+
+					var popupBounds = new RectangleDouble(e.X + 1, e.Y + 1, e.X + 1, e.Y + 1);
+
+					var systemWindow = column.Parents<SystemWindow>().FirstOrDefault();
+					systemWindow.ShowPopup(
+						new MatePoint(thumbnailWidget)
+						{
+							Mate = new MateOptions(MateEdge.Left, MateEdge.Bottom),
+							AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
+						},
+						new MatePoint(popupMenu)
+						{
+							Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+							AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
+						},
+						altBounds: popupBounds);
+
+					systemWindow.Invalidate();
+				}
+			};
 
 			// add in the invert checkbox and change image button
 			var changeButton = new TextButton("Change".Localize(), theme)

--- a/PartPreviewWindow/View3D/PrinterBar/PrinterActionsBar.cs
+++ b/PartPreviewWindow/View3D/PrinterBar/PrinterActionsBar.cs
@@ -292,7 +292,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 					GetIsActive = () => printer.ViewState.ConfigurePrinterVisible,
 					SetIsActive = (value) => printer.ViewState.ConfigurePrinterVisible = value
 				},
-				new NamedAction() { Title = "----" },
+				new ActionSeparator(),
 				new NamedAction()
 				{
 					Title = "Delete Printer".Localize(),

--- a/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/PartPreviewWindow/View3D/View3DWidget.cs
@@ -270,6 +270,8 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			this.sceneContext.SceneLoaded += SceneContext_SceneLoaded;
 		}
 
+		public Dictionary<string, NamedAction> WorkspaceActions { get; set; }
+
 		private void ModelViewSidePanel_Resized(object sender, EventArgs e)
 		{
 			if (this.Printer !=null)

--- a/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/PartPreviewWindow/View3D/View3DWidget.cs
@@ -196,8 +196,9 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			};
 			treeView.NodeMouseClick += (s, e) =>
 			{
-				if (e is MouseEventArgs mouseEvent
-					&& mouseEvent.Button == MouseButtons.Right)
+				if (e is MouseEventArgs sourceEvent
+					&& s is GuiWidget clickedWidget
+					&& sourceEvent.Button == MouseButtons.Right)
 				{
 					UiThread.RunOnIdle(() =>
 					{
@@ -205,17 +206,17 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 						var systemWindow = this.Parents<SystemWindow>().FirstOrDefault();
 						systemWindow.ShowPopup(
-						new MatePoint(treeView.SelectedNode)
-						{
-							Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
-							AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
-						},
-						new MatePoint(menu)
-						{
-							Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
-							AltMate = new MateOptions(MateEdge.Right, MateEdge.Top)
-						},
-						altBounds: new RectangleDouble(mouseEvent.X + 1, mouseEvent.Y + 1, mouseEvent.X + 1, mouseEvent.Y + 1));
+							new MatePoint(clickedWidget)
+							{
+								Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+								AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
+							},
+							new MatePoint(menu)
+							{
+								Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+								AltMate = new MateOptions(MateEdge.Right, MateEdge.Top)
+							},
+							altBounds: new RectangleDouble(sourceEvent.X + 1, sourceEvent.Y + 1, sourceEvent.X + 1, sourceEvent.Y + 1));
 					});
 				}
 			};

--- a/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/PartPreviewWindow/View3D/View3DWidget.cs
@@ -1218,17 +1218,17 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 						var systemWindow = this.Parents<SystemWindow>().FirstOrDefault();
 						systemWindow.ShowPopup(
-						new MatePoint(this)
-						{
-							Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
-							AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
-						},
-						new MatePoint(menu)
-						{
-							Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
-							AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
-						},
-						altBounds: new RectangleDouble(mouseEvent.X + 1, mouseEvent.Y + 1, mouseEvent.X + 1, mouseEvent.Y + 1));
+							new MatePoint(this)
+							{
+								Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+								AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
+							},
+							new MatePoint(menu)
+							{
+								Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+								AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
+							},
+							altBounds: new RectangleDouble(mouseEvent.X + 1, mouseEvent.Y + 1, mouseEvent.X + 1, mouseEvent.Y + 1));
 					});
 				}
 				else // open up the menu for the bed (copy past image)

--- a/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/PartPreviewWindow/View3D/View3DWidget.cs
@@ -891,6 +891,32 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 					}
 				}
 			}
+
+
+			if (mouseEvent.Button == MouseButtons.Right)
+			{
+				var info2 = new IntersectInfo();
+				if (Scene.SelectedItem is IObject3D selectedItem
+					&& FindHitObject3D(mouseEvent.Position, ref info2) is IObject3D hitObject2
+					&& hitObject2 == selectedItem)
+				{
+					var menu = ApplicationController.Instance.GetActionMenuForSceneItem(Scene.SelectedItem, Scene);
+
+					var systemWindow = this.Parents<SystemWindow>().FirstOrDefault();
+					systemWindow.ShowPopup(
+						new MatePoint(this)
+						{
+							Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+							AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
+						},
+						new MatePoint(menu)
+						{
+							Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+							AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
+						},
+						altBounds: new RectangleDouble(mouseEvent.X, mouseEvent.Y, mouseEvent.X, mouseEvent.Y));
+				}
+			}
 		}
 
 		public override void OnMouseMove(MouseEventArgs mouseEvent)

--- a/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/PartPreviewWindow/View3D/View3DWidget.cs
@@ -892,31 +892,33 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				}
 			}
 
-
-			if (mouseEvent.Button == MouseButtons.Right)
+			UiThread.RunOnIdle(() =>
 			{
-				var info2 = new IntersectInfo();
-				if (Scene.SelectedItem is IObject3D selectedItem
-					&& FindHitObject3D(mouseEvent.Position, ref info2) is IObject3D hitObject2
-					&& hitObject2 == selectedItem)
+				if (mouseEvent.Button == MouseButtons.Right)
 				{
-					var menu = ApplicationController.Instance.GetActionMenuForSceneItem(Scene.SelectedItem, Scene);
+					var info2 = new IntersectInfo();
+					if (Scene.SelectedItem is IObject3D selectedItem
+						&& FindHitObject3D(mouseEvent.Position, ref info2) is IObject3D hitObject2
+						&& hitObject2 == selectedItem)
+					{
+						var menu = ApplicationController.Instance.GetActionMenuForSceneItem(Scene.SelectedItem, Scene);
 
-					var systemWindow = this.Parents<SystemWindow>().FirstOrDefault();
-					systemWindow.ShowPopup(
-						new MatePoint(this)
-						{
-							Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
-							AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
-						},
-						new MatePoint(menu)
-						{
-							Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
-							AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
-						},
-						altBounds: new RectangleDouble(mouseEvent.X, mouseEvent.Y, mouseEvent.X, mouseEvent.Y));
+						var systemWindow = this.Parents<SystemWindow>().FirstOrDefault();
+						systemWindow.ShowPopup(
+							new MatePoint(this)
+							{
+								Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+								AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
+							},
+							new MatePoint(menu)
+							{
+								Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+								AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
+							},
+							altBounds: new RectangleDouble(mouseEvent.X + 1, mouseEvent.Y + 1, mouseEvent.X + 1, mouseEvent.Y + 1));
+					}
 				}
-			}
+			});
 		}
 
 		public override void OnMouseMove(MouseEventArgs mouseEvent)

--- a/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/PartPreviewWindow/View3D/View3DWidget.cs
@@ -194,6 +194,31 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				}
 				selectedObjectPanel.SetActiveItem((IObject3D)treeView.SelectedNode.Tag);
 			};
+			treeView.NodeMouseClick += (s, e) =>
+			{
+				if (e is MouseEventArgs mouseEvent
+					&& mouseEvent.Button == MouseButtons.Right)
+				{
+					UiThread.RunOnIdle(() =>
+					{
+						var menu = ApplicationController.Instance.GetActionMenuForSceneItem((IObject3D)treeView.SelectedNode.Tag, Scene);
+
+						var systemWindow = this.Parents<SystemWindow>().FirstOrDefault();
+						systemWindow.ShowPopup(
+						new MatePoint(treeView.SelectedNode)
+						{
+							Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+							AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
+						},
+						new MatePoint(menu)
+						{
+							Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+							AltMate = new MateOptions(MateEdge.Right, MateEdge.Top)
+						},
+						altBounds: new RectangleDouble(mouseEvent.X + 1, mouseEvent.Y + 1, mouseEvent.X + 1, mouseEvent.Y + 1));
+					});
+				}
+			};
 			treeView.ScrollArea.ChildAdded += (s, e) =>
 			{
 				if (e is GuiWidgetEventArgs childEventArgs

--- a/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/PartPreviewWindow/View3D/View3DWidget.cs
@@ -1202,9 +1202,9 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				&& mouseDownPositon == mouseEvent.Position
 				&& this.TrackballTumbleWidget.FirstWidgetUnderMouse)
 			{
-				IntersectInfo info = new IntersectInfo();
-				var hitObject = FindHitObject3D(mouseEvent.Position, ref info);
-				if (hitObject != null)
+				var info = new IntersectInfo();
+
+				if (FindHitObject3D(mouseEvent.Position, ref info) is IObject3D hitObject)
 				{
 					if (hitObject != Scene.SelectedItem)
 					{

--- a/PartPreviewWindow/ViewControls3D.cs
+++ b/PartPreviewWindow/ViewControls3D.cs
@@ -455,6 +455,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			{
 				new NamedAction()
 				{
+					ID = "Insert",
 					Title = "Insert".Localize(),
 					Icon = AggContext.StaticData.LoadIcon("cube.png", 16, 16, theme.InvertIcons),
 					Action = () =>
@@ -487,6 +488,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				new ActionSeparator(),
 				new NamedAction()
 				{
+					ID = "Cut",
 					Title = "Cut".Localize(),
 					Shortcut = "Ctrl+X",
 					Action = () =>
@@ -497,6 +499,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				},
 				new NamedAction()
 				{
+					ID = "Copy",
 					Title = "Copy".Localize(),
 					Shortcut = "Ctrl+C",
 					Action = () =>
@@ -507,6 +510,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				},
 				new NamedAction()
 				{
+					ID = "Paste",
 					Title = "Paste".Localize(),
 					Shortcut = "Ctrl+V",
 					Action = () =>
@@ -518,6 +522,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				new ActionSeparator(),
 				new NamedAction()
 				{
+					ID = "Save",
 					Title = "Save".Localize(),
 					Shortcut = "Ctrl+S",
 					Action = async () =>
@@ -528,6 +533,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				},
 				new NamedAction()
 				{
+					ID = "SaveAs",
 					Title = "Save As".Localize(),
 					Action = () => UiThread.RunOnIdle(() =>
 					{
@@ -555,6 +561,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				},
 				new NamedAction()
 				{
+					ID = "Export",
 					Title = "Export".Localize(),
 					Action = () =>
 					{
@@ -573,6 +580,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				},
 				new NamedAction()
 				{
+					ID = "ArrangeAll",
 					Title = "Arrange All Parts".Localize(),
 					Action = () =>
 					{
@@ -583,6 +591,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				new ActionSeparator(),
 				new NamedAction()
 				{
+					ID = "ClearBed",
 					Title = "Clear Bed".Localize(),
 					Action = () =>
 					{
@@ -608,6 +617,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				new ActionSeparator(),
 				new NamedAction()
 				{
+					ID = "Help",
 					Title = "Help".Localize() + "...",
 					Action = () =>
 					{

--- a/PartPreviewWindow/ViewControls3D.cs
+++ b/PartPreviewWindow/ViewControls3D.cs
@@ -87,6 +87,8 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 		private ViewControls3DButtons activeTransformState = ViewControls3DButtons.PartSelect;
 		private List<(GuiWidget button, SceneSelectionOperation operation)> operationButtons;
 
+		public NamedAction[] MenuActions { get; private set; }
+
 		public bool IsPrinterMode { get; }
 
 		public ViewControls3DButtons ActiveButton
@@ -345,12 +347,15 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				VAnchor = VAnchor.Fit,
 			};
 
+			// Construct and store menu actions
+			this.MenuActions = this.BedMenuActions(sceneContext, ApplicationController.Instance.MenuTheme);
+
 			return new PopupMenuButton(buttonView, theme)
 			{
 				Name = "Bed Options Menu",
 				DynamicPopupContent = () =>
 				{
-					var menuContent = theme.CreateMenuItems(popupMenu, this.BedMenuActions(sceneContext, ApplicationController.Instance.MenuTheme));
+					var menuContent = theme.CreateMenuItems(popupMenu, this.MenuActions);
 					menuContent.MinimumSize = new Vector2(200, 0);
 
 					return menuContent;

--- a/PartPreviewWindow/ViewControls3D.cs
+++ b/PartPreviewWindow/ViewControls3D.cs
@@ -484,7 +484,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 						});
 					}
 				},
-				new NamedAction() { Title = "----" },
+				new ActionSeparator(),
 				new NamedAction()
 				{
 					Title = "Cut".Localize(),
@@ -515,7 +515,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 					},
 					IsEnabled = () => sceneContext.EditableScene
 				},
-				new NamedAction() { Title = "----" },
+				new ActionSeparator(),
 				new NamedAction()
 				{
 					Title = "Save".Localize(),
@@ -580,7 +580,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 					},
 					IsEnabled = () => sceneContext.EditableScene
 				},
-				new NamedAction() { Title = "----" },
+				new ActionSeparator(),
 				new NamedAction()
 				{
 					Title = "Clear Bed".Localize(),
@@ -605,7 +605,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 					}
 				},
 #endif
-				new NamedAction() { Title = "----" },
+				new ActionSeparator(),
 				new NamedAction()
 				{
 					Title = "Help".Localize() + "...",

--- a/Tests/MatterControl.Tests/MatterControl.Tests.csproj
+++ b/Tests/MatterControl.Tests/MatterControl.Tests.csproj
@@ -55,6 +55,7 @@
   <ItemGroup>
     <Compile Include="MatterControl\ApplicationControllerTests.cs" />
     <Compile Include="MatterControl\BrailleGrade2Tests.cs" />
+    <Compile Include="MatterControl\PopupAnchorTests.cs" />
     <Compile Include="MatterControl\InteractiveSceneTests.cs" />
     <Compile Include="MatterControl\ImportSettingsTests.cs" />
     <Compile Include="MatterControl\AssetManagerTests.cs" />

--- a/Tests/MatterControl.Tests/MatterControl/PopupAnchorTests.cs
+++ b/Tests/MatterControl.Tests/MatterControl/PopupAnchorTests.cs
@@ -1,0 +1,933 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using MatterHackers.Agg;
+using MatterHackers.Agg.UI;
+using MatterHackers.GuiAutomation;
+using MatterHackers.MatterControl;
+using MatterHackers.MatterControl.CustomWidgets;
+using MatterHackers.MatterControl.PartPreviewWindow;
+using MatterHackers.VectorMath;
+using NUnit.Framework;
+
+namespace MatterControl.Tests.MatterControl
+{
+	[TestFixture, Category("PopupAnchorTests"), RunInApplicationDomain, Apartment(ApartmentState.STA)]
+	public class PopupAnchorTests
+	{
+		[Test]
+		public async Task WindowTest()
+		{
+			var systemWindow = new PopupsTestWindow(700, 300)
+			{
+				Details = new Dictionary<string, string>()
+				{
+					["Task"] = "General Popup",
+					["Expected"] = "Popup should appear on click"
+				}
+			};
+
+			await systemWindow.RunTest(testRunner =>
+			{
+				systemWindow.Padding = systemWindow.Padding.Clone(bottom: 180);
+
+				var button = new TextButton("Popup", systemWindow.Theme)
+				{
+					Name = "targetA",
+					VAnchor = VAnchor.Bottom,
+					HAnchor= HAnchor.Left,
+				};
+				systemWindow.AddChild(button);
+
+				var color = Color.LightBlue;
+
+				button.Click += (s, e) =>
+				{
+					systemWindow.ShowPopup(
+						new MatePoint()
+						{
+							Widget = button
+						},
+						new MatePoint()
+						{
+							Widget = new GuiWidget(180d, 100d)
+							{
+								BackgroundColor = color,
+								Border = 2,
+								BorderColor = color.Blend(Color.Black, 0.4)
+							}
+						});
+				};
+
+				testRunner.ClickByName("targetA");
+
+				testRunner.Delay();
+
+				return Task.CompletedTask;
+			}, 30);
+		}
+
+		[Test]
+		public async Task TopBottomPopupTest()
+		{
+			var systemWindow = new PopupsTestWindow(800, 600)
+			{
+				Details = new Dictionary<string, string>()
+				{
+					["Task"] = "Top-Bottom Tests",
+					["Expected"] = "Popup bottoms should align with button top"
+				}
+			};
+
+			await AnchorTests(
+				systemWindow,
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Top)
+				},
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Bottom)
+				},
+				new TextButton("Popup", systemWindow.Theme)
+				{
+					Name = "buttonA",
+					VAnchor = VAnchor.Bottom,
+				},
+				(buttonWidget, popupWidget) =>
+				{
+					double buttonPosition = buttonWidget.TransformToScreenSpace(buttonWidget.LocalBounds).Top;
+					double popupPosition = popupWidget.TransformToScreenSpace(popupWidget.LocalBounds).Bottom;
+
+					Assert.AreEqual(buttonPosition, popupPosition);
+				});
+		}
+
+		[Test]
+		public async Task TopTopPopupTest()
+		{
+			var systemWindow = new PopupsTestWindow(800, 600)
+			{
+				Details = new Dictionary<string, string>()
+				{
+					["Task"] = "Top-Bottom Tests",
+					["Expected"] = "Popup tops should align with button top"
+				}
+			};
+
+			await AnchorTests(
+				systemWindow,
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Top)
+				},
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Top)
+				},
+				new TextButton("Popup", systemWindow.Theme)
+				{
+					Name = "buttonA",
+					VAnchor = VAnchor.Bottom,
+				},
+				(buttonWidget, popupWidget) =>
+				{
+					double buttonPosition = buttonWidget.TransformToScreenSpace(buttonWidget.LocalBounds).Top;
+					double popupPosition = popupWidget.TransformToScreenSpace(popupWidget.LocalBounds).Top;
+
+					Assert.AreEqual(buttonPosition, popupPosition);
+				});
+		}
+
+		[Test]
+		public async Task BottomTopPopupTest()
+		{
+			var systemWindow = new PopupsTestWindow(800, 600)
+			{
+				Details = new Dictionary<string, string>()
+				{
+					["Task"] = "Top-Bottom Tests",
+					["Expected"] = "Popup tops should align with button bottom"
+				}
+			};
+
+			await AnchorTests(
+				systemWindow,
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Right, MateEdge.Bottom)
+				},
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Top)
+				},
+				new TextButton("Popup", systemWindow.Theme)
+				{
+					Name = "buttonA",
+					VAnchor = VAnchor.Bottom,
+				},
+				(buttonWidget, popupWidget) =>
+				{
+					double buttonPosition = buttonWidget.TransformToScreenSpace(buttonWidget.LocalBounds).Bottom;
+					double popupPosition = popupWidget.TransformToScreenSpace(popupWidget.LocalBounds).Top;
+
+					Assert.AreEqual(buttonPosition, popupPosition);
+				});
+		}
+
+		[Test]
+		public async Task BottomBottomPopupTest()
+		{
+			var systemWindow = new PopupsTestWindow(800, 600)
+			{
+				Details = new Dictionary<string, string>()
+				{
+					["Task"] = "Bottom-Bottom Tests",
+					["Expected"] = "Popup bottoms should align with button bottom"
+				}
+			};
+
+			await AnchorTests(
+				systemWindow,
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Bottom)
+				},
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Bottom)
+				},
+				new TextButton("Popup", systemWindow.Theme)
+				{
+					Name = "buttonA",
+					VAnchor	= VAnchor.Bottom,
+				},
+				(buttonWidget, popupWidget) =>
+				{
+					double buttonPosition = buttonWidget.TransformToScreenSpace(buttonWidget.LocalBounds).Bottom;
+					double popupPosition = popupWidget.TransformToScreenSpace(popupWidget.LocalBounds).Bottom;
+
+					Assert.AreEqual(buttonPosition, popupPosition);
+				});
+		}
+
+		// Redirect down to up
+		[Test]
+		public async Task BottomTopUpRedirectTest()
+		{
+			var systemWindow = new PopupsTestWindow(800, 600)
+			{
+				Details = new Dictionary<string, string>()
+				{
+					["Task"] = "Top-Bottom Tests",
+					["Expected"] = "Popup tops should align with button bottom"
+				}
+			};
+
+			await AnchorTests(
+				systemWindow,
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Bottom),
+					AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
+				},
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+					AltMate = new MateOptions(MateEdge.Left, MateEdge.Bottom)
+				},
+				new TextButton("Popup", systemWindow.Theme)
+				{
+					Name = "buttonA",
+					VAnchor = VAnchor.Bottom,
+				},
+				(buttonWidget, popupWidget) =>
+				{
+					double buttonPosition = buttonWidget.TransformToScreenSpace(buttonWidget.LocalBounds).Top;
+					double popupPosition = popupWidget.TransformToScreenSpace(popupWidget.LocalBounds).Bottom;
+
+					Assert.AreEqual(buttonPosition, popupPosition);
+				},
+				(row) =>
+				{
+					row.VAnchor = VAnchor.Bottom | VAnchor.Fit;
+				});
+		}
+
+		[Test]
+		public async Task TopTopUpRedirectTest()
+		{
+			var systemWindow = new PopupsTestWindow(800, 600)
+			{
+				Details = new Dictionary<string, string>()
+				{
+					["Task"] = "Top-Bottom Tests",
+					["Expected"] = "Popup tops should align with button top"
+				}
+			};
+
+			await AnchorTests(
+				systemWindow,
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+					AltMate = new MateOptions(MateEdge.Left, MateEdge.Bottom)
+				},
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+					AltMate = new MateOptions(MateEdge.Left, MateEdge.Bottom)
+				},
+				new TextButton("Popup", systemWindow.Theme)
+				{
+					Name = "buttonA",
+					VAnchor = VAnchor.Bottom,
+				},
+				(buttonWidget, popupWidget) =>
+				{
+					double buttonPosition = buttonWidget.TransformToScreenSpace(buttonWidget.LocalBounds).Bottom;
+					double popupPosition = popupWidget.TransformToScreenSpace(popupWidget.LocalBounds).Bottom;
+
+					Assert.AreEqual(buttonPosition, popupPosition);
+				},
+				(row) =>
+				{
+					row.VAnchor = VAnchor.Bottom | VAnchor.Fit;
+				});
+		}
+
+
+		// Redirect up to down
+		[Test]
+		public async Task BottomTopDownRedirectTest()
+		{
+			var systemWindow = new PopupsTestWindow(800, 600)
+			{
+				Details = new Dictionary<string, string>()
+				{
+					["Task"] = "Top-Bottom Tests",
+					["Expected"] = "Popup bottoms should align with button top"
+				}
+			};
+
+			await AnchorTests(
+				systemWindow,
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+					AltMate = new MateOptions(MateEdge.Left, MateEdge.Bottom),
+				},
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Bottom),
+					AltMate = new MateOptions(MateEdge.Left, MateEdge.Top),
+				},
+				new TextButton("Popup", systemWindow.Theme)
+				{
+					Name = "buttonA",
+					VAnchor = VAnchor.Bottom,
+				},
+				(buttonWidget, popupWidget) =>
+				{
+					double buttonPosition = buttonWidget.TransformToScreenSpace(buttonWidget.LocalBounds).Bottom;
+					double popupPosition = popupWidget.TransformToScreenSpace(popupWidget.LocalBounds).Top;
+
+					Assert.AreEqual(buttonPosition, popupPosition);
+				},
+				(row) =>
+				{
+					row.VAnchor = VAnchor.Top | VAnchor.Fit;
+				});
+		}
+
+		[Test]
+		public async Task TopTopDownRedirectTest()
+		{
+			var systemWindow = new PopupsTestWindow(800, 600)
+			{
+				Details = new Dictionary<string, string>()
+				{
+					["Task"] = "Bottom-Bottom Tests",
+					["Expected"] = "Popup bottoms should align with button bottom"
+				}
+			};
+
+			int i = 0;
+
+			await AnchorTests(
+				systemWindow,
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Bottom),
+					AltMate = new MateOptions(MateEdge.Right, MateEdge.Top),
+				},
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Bottom),
+					AltMate = new MateOptions(MateEdge.Left, MateEdge.Top),
+				},
+				new TextButton("Popup", systemWindow.Theme)
+				{
+					Name = "buttonA",
+					VAnchor = VAnchor.Bottom,
+				},
+				(buttonWidget, popupWidget) =>
+				{
+					double buttonPosition = buttonWidget.TransformToScreenSpace(buttonWidget.LocalBounds).Top;
+					double popupPosition = popupWidget.TransformToScreenSpace(popupWidget.LocalBounds).Top;
+
+					Assert.AreEqual(buttonPosition, popupPosition);
+				},
+				(row) =>
+				{
+					row.VAnchor = VAnchor.Top | VAnchor.Fit;
+				});
+		}
+
+		// Redirect left to right
+		[Test]
+		public async Task LeftRightRedirectTest()
+		{
+			var systemWindow = new PopupsTestWindow(800, 600)
+			{
+				Details = new Dictionary<string, string>()
+				{
+					["Task"] = "Top-Bottom Tests",
+					["Expected"] = "Popup tops should align with button bottom"
+				}
+			};
+
+			systemWindow.Padding = systemWindow.Padding.Clone(left: 0);
+
+			int i = 0;
+
+			await AnchorTests(
+				systemWindow,
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Bottom),
+					AltMate = new MateOptions(MateEdge.Left, MateEdge.Top)
+				},
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Top),
+					AltMate = new MateOptions(MateEdge.Left, MateEdge.Bottom)
+				},
+				new TextButton("Popup", systemWindow.Theme)
+				{
+					Name = "buttonA",
+					VAnchor = VAnchor.Bottom,
+				},
+				(buttonWidget, popupWidget) =>
+				{
+					double buttonPosition = buttonWidget.TransformToScreenSpace(buttonWidget.LocalBounds).Left;
+					double popupPosition = popupWidget.TransformToScreenSpace(popupWidget.LocalBounds).Left;
+
+					if (i++ > 2)
+					{
+						// Switch to anchor right aligned for the last case
+						buttonPosition = buttonWidget.TransformToScreenSpace(buttonWidget.LocalBounds).Right;
+					}
+
+					Assert.AreEqual(buttonPosition, popupPosition);
+				},
+				(row) =>
+				{
+					// Clear left margin so menus clip
+					row.Margin = 2;
+				});
+		}
+
+		// Redirect right to left
+		[Test]
+		public async Task RightLeftRedirectTest()
+		{
+			var systemWindow = new PopupsTestWindow(800, 600)
+			{
+				Details = new Dictionary<string, string>()
+				{
+					["Task"] = "Bottom-Bottom Tests",
+					["Expected"] = "Popup bottoms should align with button bottom"
+				}
+			};
+
+			int i = 0;
+
+			await AnchorTests(
+				systemWindow,
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Bottom),
+					AltMate = new MateOptions(MateEdge.Left, MateEdge.Top),
+				},
+				new MatePoint()
+				{
+					Mate = new MateOptions(MateEdge.Left, MateEdge.Bottom),
+					AltMate = new MateOptions(MateEdge.Right, MateEdge.Top),
+				},
+				new TextButton("Popup", systemWindow.Theme)
+				{
+					Name = "buttonA",
+					VAnchor = VAnchor.Bottom,
+				},
+				(buttonWidget, popupWidget) =>
+				{
+					double buttonPosition = buttonWidget.TransformToScreenSpace(buttonWidget.LocalBounds).Left;
+					double popupPosition = popupWidget.TransformToScreenSpace(popupWidget.LocalBounds).Right;
+
+					if (i++ == 2)
+					{
+						// Switch to anchor right aligned for the last case
+						buttonPosition = buttonWidget.TransformToScreenSpace(buttonWidget.LocalBounds).Right;
+					}
+
+					Assert.AreEqual(buttonPosition, popupPosition);
+				},
+				(row) =>
+				{
+					row.Parent.DebugShowBounds = true;
+					row.DebugShowBounds = true;
+					row.HAnchor = HAnchor.Right | HAnchor.Fit;
+					row.VAnchor = VAnchor.Center | VAnchor.Fit;
+				});
+		}
+
+
+		private static async Task AnchorTests(PopupsTestWindow systemWindow, MatePoint anchor, MatePoint popup, TextButton button, Action<GuiWidget, GuiWidget> validator, Action<GuiWidget> rowAdjuster = null)
+		{
+			await systemWindow.RunTest(testRunner =>
+			{
+				var row = new FlowLayoutWidget()
+				{
+					VAnchor = VAnchor.Center | VAnchor.Fit,
+					HAnchor = HAnchor.Left | HAnchor.Fit,
+					Margin = new BorderDouble(left: 120)
+				};
+				systemWindow.AddChild(row);
+
+				row.AddChild(button);
+
+				rowAdjuster?.Invoke(row);
+
+				button.Click += (s, e) =>
+				{
+					popup.Widget = new GuiWidget(180d, 100d)
+					{
+						BackgroundColor = Color.LightBlue,
+						Border = 2,
+						BorderColor = Color.LightBlue.Blend(Color.Black, 0.4)
+					};
+
+					systemWindow.ShowPopup(anchor, popup);
+				};
+
+				anchor.Widget = button;
+
+				for (var i = 0; i < 4; i++)
+				{
+					switch (i)
+					{
+						case 0:
+							anchor.Mate.HorizontalEdge = MateEdge.Left;
+							popup.Mate.HorizontalEdge = MateEdge.Right;
+							break;
+
+						case 1:
+							anchor.Mate.HorizontalEdge = MateEdge.Left;
+							popup.Mate.HorizontalEdge = MateEdge.Left;
+							break;
+
+						case 2:
+							anchor.Mate.HorizontalEdge = MateEdge.Right;
+							popup.Mate.HorizontalEdge = MateEdge.Right;
+							break;
+
+						case 3:
+							anchor.Mate.HorizontalEdge = MateEdge.Right;
+							popup.Mate.HorizontalEdge = MateEdge.Left;
+							break;
+					}
+
+					testRunner.ClickByName("buttonA");
+
+					validator.Invoke(button, popup.Widget);
+
+					popup.Widget.Unfocus();
+				}
+
+				testRunner.Delay();
+
+				return Task.CompletedTask;
+			}, 120);
+		}
+
+		[Test, Ignore("Lame")]
+		public async Task WindowTest3()
+		{
+			string targetWidget = "targetA";
+
+			var systemWindow = new PopupsTestWindow(800, 600)
+			{
+				Details = new Dictionary<string, string>()
+				{
+					["Task"] = "Top-Left Anchor : Bottom-Left Popup",
+					["Expected"] = "Popup should appear above left of anchor click"
+				}
+			};
+
+			systemWindow.Padding = systemWindow.Padding.Clone(bottom: 180);
+
+			await systemWindow.RunTest(testRunner =>
+			{
+				var row = new FlowLayoutWidget()
+				{
+					//Mate = Mate.Center | Mate.Fit,
+					VAnchor = VAnchor.Top | VAnchor.Fit,
+					HAnchor = HAnchor.Left | HAnchor.Fit,
+					Margin = new BorderDouble(left: 120)
+				};
+				systemWindow.AddChild(row);
+
+				var button = new TextButton("Popup", systemWindow.Theme)
+				{
+					Name = "targetA",
+					VAnchor = VAnchor.Bottom,
+				};
+				row.AddChild(button);
+
+				var spacer = new GuiWidget()
+				{
+					Width = 100,
+				};
+				row.AddChild(spacer);
+
+				var button2 = new GuiWidget(140, 140)
+				{
+					BackgroundColor = Color.Blue,
+					Name = "targetB"
+				};
+
+				var hitBounds = new RectangleDouble(65, 45, 65 + 32, 45 + 32);
+
+				button2.AfterDraw += (s, e) =>
+				{
+					e.Graphics2D.Rectangle(hitBounds, Color.White);
+				};
+				row.AddChild(button2);
+
+				var anchor = new MatePoint()
+				{
+					Mate = new MateOptions()
+					{
+						HorizontalEdge = MateEdge.Right,
+						VerticalEdge = MateEdge.Bottom,
+					},
+					Widget = button,
+				};
+
+				var popup = new MatePoint()
+				{
+					Mate = new MateOptions()
+					{
+						HorizontalEdge = MateEdge.Left,
+						VerticalEdge = MateEdge.Top,
+					}
+				};
+
+				button.Click += (s, e) =>
+				{
+					popup.Widget = new GuiWidget(180d, 100d)
+					{
+						BackgroundColor = Color.LightBlue,
+						Border = 2,
+						BorderColor = Color.LightBlue.Blend(Color.Black, 0.4)
+					};
+
+					systemWindow.ShowPopup(anchor, popup);
+				};
+
+				button2.Click += (s, e) =>
+				{
+					popup.Widget = new GuiWidget(180d, 100d)
+					{
+						BackgroundColor = Color.LightBlue,
+						Border = 2,
+						BorderColor = Color.LightBlue.Blend(Color.Black, 0.4)
+					};
+
+					systemWindow.ShowPopup(anchor, popup, hitBounds);
+				};
+
+				bool firstPass = true;
+
+				//testRunner.Delay(90);
+
+				for(var i = 0; i < 16; i++)
+				{
+					switch(i)
+					{
+						// Bottom-Top positions
+						case 0:
+							anchor.Mate.HorizontalEdge = MateEdge.Left;
+							popup.Mate.HorizontalEdge = MateEdge.Right;
+
+							anchor.Mate.VerticalEdge = MateEdge.Top;
+							popup.Mate.VerticalEdge = MateEdge.Bottom;
+
+							anchor.AltMate.VerticalEdge = MateEdge.Bottom;
+							popup.AltMate.VerticalEdge = MateEdge.Top;
+
+							break;
+						case 1:
+							anchor.Mate.HorizontalEdge = MateEdge.Left;
+							popup.Mate.HorizontalEdge = MateEdge.Left;
+
+							anchor.Mate.VerticalEdge = MateEdge.Top;
+							popup.Mate.VerticalEdge = MateEdge.Bottom;
+
+							anchor.AltMate.VerticalEdge = MateEdge.Bottom;
+							popup.AltMate.VerticalEdge = MateEdge.Top;
+							break;
+
+						case 2:
+							anchor.Mate.HorizontalEdge = MateEdge.Right;
+							popup.Mate.HorizontalEdge = MateEdge.Right;
+
+							anchor.Mate.VerticalEdge = MateEdge.Top;
+							popup.Mate.VerticalEdge = MateEdge.Bottom;
+
+							anchor.AltMate.VerticalEdge = MateEdge.Bottom;
+							popup.AltMate.VerticalEdge = MateEdge.Top;
+							break;
+
+						case 3:
+							anchor.Mate.HorizontalEdge = MateEdge.Right;
+							popup.Mate.HorizontalEdge = MateEdge.Left;
+
+							anchor.Mate.VerticalEdge = MateEdge.Top;
+							popup.Mate.VerticalEdge = MateEdge.Bottom;
+
+							anchor.AltMate.VerticalEdge = MateEdge.Bottom;
+							popup.AltMate.VerticalEdge = MateEdge.Top;
+							break;
+
+						// Top-Top positions
+						case 4:
+							anchor.Mate.HorizontalEdge = MateEdge.Left;
+							popup.Mate.HorizontalEdge = MateEdge.Right;
+
+							anchor.Mate.VerticalEdge = MateEdge.Top;
+							popup.Mate.VerticalEdge = MateEdge.Top;
+
+							anchor.AltMate.VerticalEdge = MateEdge.Bottom;
+							popup.AltMate.VerticalEdge = MateEdge.Bottom;
+							break;
+
+						case 5:
+							anchor.Mate.HorizontalEdge = MateEdge.Left;
+							popup.Mate.HorizontalEdge = MateEdge.Left;
+
+							anchor.Mate.VerticalEdge = MateEdge.Top;
+							popup.Mate.VerticalEdge = MateEdge.Top;
+
+							anchor.AltMate.VerticalEdge = MateEdge.Bottom;
+							popup.AltMate.VerticalEdge = MateEdge.Bottom;
+							break;
+
+						case 6:
+							anchor.Mate.HorizontalEdge = MateEdge.Right;
+							popup.Mate.HorizontalEdge = MateEdge.Right;
+
+							anchor.Mate.VerticalEdge = MateEdge.Top;
+							popup.Mate.VerticalEdge = MateEdge.Top;
+
+							anchor.AltMate.VerticalEdge = MateEdge.Bottom;
+							popup.AltMate.VerticalEdge = MateEdge.Bottom;
+							break;
+
+						case 7:
+							anchor.Mate.HorizontalEdge = MateEdge.Right;
+							popup.Mate.HorizontalEdge = MateEdge.Left;
+
+							anchor.Mate.VerticalEdge = MateEdge.Top;
+							popup.Mate.VerticalEdge = MateEdge.Top;
+
+							anchor.AltMate.VerticalEdge = MateEdge.Bottom;
+							popup.AltMate.VerticalEdge = MateEdge.Bottom;
+							break;
+
+						// Bottom-Bottom positions
+						case 8:
+							anchor.Mate.HorizontalEdge = MateEdge.Left;
+							popup.Mate.HorizontalEdge = MateEdge.Right;
+
+							anchor.Mate.VerticalEdge = MateEdge.Bottom;
+							popup.Mate.VerticalEdge = MateEdge.Bottom;
+
+							anchor.AltMate.VerticalEdge = MateEdge.Top;
+							popup.AltMate.VerticalEdge = MateEdge.Bottom;
+							break;
+
+						case 9:
+							anchor.Mate.HorizontalEdge = MateEdge.Left;
+							popup.Mate.HorizontalEdge = MateEdge.Left;
+
+							anchor.Mate.VerticalEdge = MateEdge.Bottom;
+							popup.Mate.VerticalEdge = MateEdge.Bottom;
+
+							anchor.AltMate.VerticalEdge = MateEdge.Top;
+							popup.AltMate.VerticalEdge = MateEdge.Bottom;
+							break;
+
+						case 10:
+							anchor.Mate.HorizontalEdge = MateEdge.Right;
+							popup.Mate.HorizontalEdge = MateEdge.Right;
+
+							anchor.Mate.VerticalEdge = MateEdge.Bottom;
+							popup.Mate.VerticalEdge = MateEdge.Bottom;
+
+							anchor.AltMate.VerticalEdge = MateEdge.Top;
+							popup.AltMate.VerticalEdge = MateEdge.Bottom;
+							break;
+
+						case 11:
+							anchor.Mate.HorizontalEdge = MateEdge.Right;
+							popup.Mate.HorizontalEdge = MateEdge.Left;
+
+							anchor.Mate.VerticalEdge = MateEdge.Bottom;
+							popup.Mate.VerticalEdge = MateEdge.Bottom;
+
+							anchor.AltMate.VerticalEdge = MateEdge.Top;
+							popup.AltMate.VerticalEdge = MateEdge.Bottom;
+							break;
+
+						// Bottom-Top positions
+						case 12:
+							anchor.Mate.HorizontalEdge = MateEdge.Left;
+							popup.Mate.HorizontalEdge = MateEdge.Right;
+
+							anchor.Mate.VerticalEdge = MateEdge.Bottom;
+							popup.Mate.VerticalEdge = MateEdge.Top;
+
+							anchor.AltMate.VerticalEdge = MateEdge.Top;
+							popup.AltMate.VerticalEdge = MateEdge.Bottom;
+							break;
+
+						case 13:
+							anchor.Mate.HorizontalEdge = MateEdge.Left;
+							popup.Mate.HorizontalEdge = MateEdge.Left;
+
+							anchor.Mate.VerticalEdge = MateEdge.Bottom;
+							popup.Mate.VerticalEdge = MateEdge.Top;
+
+							anchor.AltMate.VerticalEdge = MateEdge.Top;
+							popup.AltMate.VerticalEdge = MateEdge.Bottom;
+							break;
+
+						case 14:
+							anchor.Mate.HorizontalEdge = MateEdge.Right;
+							popup.Mate.HorizontalEdge = MateEdge.Right;
+
+							anchor.Mate.VerticalEdge = MateEdge.Bottom;
+							popup.Mate.VerticalEdge = MateEdge.Top;
+
+							anchor.AltMate.VerticalEdge = MateEdge.Top;
+							popup.AltMate.VerticalEdge = MateEdge.Bottom;
+							break;
+
+						case 15:
+							anchor.Mate.HorizontalEdge = MateEdge.Right;
+							popup.Mate.HorizontalEdge = MateEdge.Left;
+
+							anchor.Mate.VerticalEdge = MateEdge.Bottom;
+							popup.Mate.VerticalEdge = MateEdge.Top;
+
+							anchor.AltMate.VerticalEdge = MateEdge.Top;
+							popup.AltMate.VerticalEdge = MateEdge.Bottom;
+							break;
+
+					}
+
+					testRunner.ClickByName(targetWidget);
+					testRunner.Delay(1);
+
+					if (i == 15 && firstPass)
+					{
+						firstPass = false;
+						i = -1;
+						targetWidget = "targetB";
+						anchor.Widget = button2;
+					}
+
+					popup.Widget.Unfocus();
+				}
+
+				testRunner.Delay();
+
+				return Task.CompletedTask;
+			}, 120);
+		}
+
+		public class PopupsTestWindow : SystemWindow
+		{
+			private FlowLayoutWidget column;
+
+			public ThemeConfig Theme { get; }
+
+			public PopupsTestWindow(int width, int height)
+				: base(width, height)
+			{
+				this.BackgroundColor = new Color(56, 56, 56);
+
+				Theme = new ThemeConfig()
+				{
+					Colors = ActiveTheme.Instance
+				};
+
+				this.Padding = new BorderDouble(left: 120, bottom: 10, right: 10, top: 10);
+
+				column = new FlowLayoutWidget(FlowDirection.TopToBottom)
+				{
+					HAnchor = HAnchor.Right | HAnchor.Fit,
+					VAnchor = VAnchor.Stretch,
+				};
+				this.AddChild(column);
+			}
+
+			private Dictionary<string, string> _details;
+
+			public Dictionary<string, string> Details
+			{
+				get => _details;
+				set
+				{
+					_details = value;
+
+					foreach(var kvp in value)
+					{
+						this.ShowDetails(kvp.Key, kvp.Value);
+					}
+				}
+			}
+
+			public void ShowDetails(string heading, string text)
+			{
+				// Store
+				var row = new FlowLayoutWidget
+				{
+					VAnchor  = VAnchor.Fit,
+					HAnchor = HAnchor.Left | HAnchor.Fit
+				};
+				column.AddChild(row);
+
+				row.AddChild(new TextWidget(heading + ":", textColor: Color.White, pointSize: 9)
+				{
+					MinimumSize = new Vector2(80, 0)
+				});
+
+				row.AddChild(new TextWidget(text, textColor: Color.White, pointSize: 9));
+			}
+		}
+	}
+}

--- a/Tests/MatterControl.Tests/MatterControl/PopupAnchorTests.cs
+++ b/Tests/MatterControl.Tests/MatterControl/PopupAnchorTests.cs
@@ -486,8 +486,6 @@ namespace MatterControl.Tests.MatterControl
 				},
 				(row) =>
 				{
-					row.Parent.DebugShowBounds = true;
-					row.DebugShowBounds = true;
 					row.HAnchor = HAnchor.Right | HAnchor.Fit;
 					row.VAnchor = VAnchor.Center | VAnchor.Fit;
 				});


### PR DESCRIPTION
Issues remaining:

- [ ] Popups misplaced on bed on hi-dpi screen at home  
   ![image](https://user-images.githubusercontent.com/175113/43848812-b14ad926-9ae8-11e8-9a14-e5f1fb0e2d59.png)
- [ ] Popup menus fail to close on click due to MatterHackers/MCCentral#3967  
  OnMouseUp fires on Widget but MouseUp event does not
- [ ] Operations that update selection need work, either existing controls need to listen for change and rebuild or we need more work around changing selection to get the right tree/editor updates  
  Example: wrapping operation aren't visible till losefocus/refocus, item renames aren't visible till lose/refocus