### PR TITLE
Guard for null

### DIFF
--- a/SetupWizard/HelpPage.cs
+++ b/SetupWizard/HelpPage.cs
@@ -332,7 +332,8 @@ namespace MatterHackers.MatterControl
 					};
 
 					if (item.Name == guideKey
-						|| (item.ArticleKey == guideKey
+						|| (guideKey != null
+							&& item.ArticleKey == guideKey
 							&& ApplicationController.Instance.HelpArticlesByID.ContainsKey(guideKey)))
 					{
 						initialSelection = newNode;


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#4090
Help fails to open due to null value in dictionary lookup