### PR TITLE
Only center on bed during gcode export when exporting from library

### DIFF
--- a/MatterControl.csproj
+++ b/MatterControl.csproj
@@ -65,6 +65,10 @@
       <Project>{93bebfdf-b81a-4344-ab82-0dbf58b234cd}</Project>
       <Name>MatterControlLib</Name>
     </ProjectReference>
+    <ProjectReference Include="Submodules\MatterSlice\MatterSlice.csproj">
+      <Project>{b0aed568-8796-42b9-baa9-ebc796134e78}</Project>
+      <Name>MatterSlice</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/MatterControlLib/CustomWidgets/ExportPrintItemPage.cs
+++ b/MatterControlLib/CustomWidgets/ExportPrintItemPage.cs
@@ -50,8 +50,11 @@ namespace MatterHackers.MatterControl
 
 		private IEnumerable<ILibraryItem> libraryItems;
 
-		public ExportPrintItemPage(IEnumerable<ILibraryItem> libraryItems)
+		bool centerOnBed;
+
+		public ExportPrintItemPage(IEnumerable<ILibraryItem> libraryItems, bool centerOnBed)
 		{
+			this.centerOnBed = centerOnBed;
 			this.WindowTitle = "Export File".Localize();
 			this.HeaderText = "Export selection to".Localize() + ":";
 
@@ -212,6 +215,10 @@ namespace MatterHackers.MatterControl
 
 										if (activePlugin != null)
 										{
+											if(activePlugin is GCodeExport gCodeExport)
+											{
+												gCodeExport.CenterOnBed = centerOnBed;
+											}
 											succeeded = await activePlugin.Generate(libraryItems, savePath, reporter, cancellationToken);
 										}
 

--- a/MatterControlLib/Library/Export/GCodeExport.cs
+++ b/MatterControlLib/Library/Export/GCodeExport.cs
@@ -121,8 +121,6 @@ namespace MatterHackers.MatterControl.Library.Export
 			{
 				IObject3D loadedItem = null;
 
-				bool centerOnBed = true;
-
 				var assetStream = firstItem as ILibraryAssetStream;
 				if (assetStream?.ContentType == "gcode")
 				{
@@ -140,7 +138,7 @@ namespace MatterHackers.MatterControl.Library.Export
 					// If item is bedplate, save any pending changes before starting the print
 					await ApplicationController.Instance.Tasks.Execute("Saving".Localize(), printer.Bed.SaveChanges);
 					loadedItem = printer.Bed.Scene;
-					centerOnBed = false;
+					CenterOnBed = false;
 				}
 				else if (firstItem is ILibraryObject3D object3DItem)
 				{
@@ -178,7 +176,7 @@ namespace MatterHackers.MatterControl.Library.Export
 						if (ApplicationSettings.ValidFileExtensions.IndexOf(sourceExtension, StringComparison.OrdinalIgnoreCase) >= 0
 							|| string.Equals(sourceExtension, ".mcx", StringComparison.OrdinalIgnoreCase))
 						{
-							if (centerOnBed)
+							if (CenterOnBed)
 							{
 								// Get Bounds
 								var aabb = loadedItem.GetAxisAlignedBoundingBox(Matrix4X4.Identity);
@@ -186,7 +184,6 @@ namespace MatterHackers.MatterControl.Library.Export
 								// Move to bed center
 								var bedCenter = printer.Bed.BedCenter;
 								loadedItem.Matrix *= Matrix4X4.CreateTranslation((double)-aabb.Center.X, (double)-aabb.Center.Y, (double)-aabb.minXYZ.Z) * Matrix4X4.CreateTranslation(bedCenter.X, bedCenter.Y, 0);
-								loadedItem.Color = loadedItem.Color;
 							}
 
 							string originalSpiralVase = printer.Settings.GetValue(SettingsKey.spiral_vase);
@@ -231,6 +228,7 @@ namespace MatterHackers.MatterControl.Library.Export
 		}
 
 		public bool ApplyLeveling { get; set; } = true;
+		public bool CenterOnBed { get; set; }
 
 		private void ApplyStreamPipelineAndExport(GCodeFileStream gCodeFileStream, string outputPath)
 		{

--- a/MatterControlLib/Library/Widgets/PrintLibraryWidget.cs
+++ b/MatterControlLib/Library/Widgets/PrintLibraryWidget.cs
@@ -922,7 +922,7 @@ namespace MatterHackers.MatterControl.PrintLibrary
 		private void exportButton_Click(object sender, EventArgs e)
 		{
 			//Open export options
-			var exportPage = new ExportPrintItemPage(libraryView.SelectedItems.Select(item => item.Model));
+			var exportPage = new ExportPrintItemPage(libraryView.SelectedItems.Select(item => item.Model), true);
 
 			DialogWindow.Show(exportPage);
 		}

--- a/MatterControlLib/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/MatterControlLib/PartPreviewWindow/View3D/View3DWidget.cs
@@ -1232,7 +1232,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 											new ExportPrintItemPage(new[]
 											{
 												new InMemoryLibraryItem(selectedItem)
-											}));
+											}, false));
 									});
 								}
 							}};

--- a/MatterControlLib/PartPreviewWindow/ViewControls3D.cs
+++ b/MatterControlLib/PartPreviewWindow/ViewControls3D.cs
@@ -579,7 +579,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 								new ExportPrintItemPage(new[]
 								{
 									new InMemoryLibraryItem(sceneContext.Scene)
-								}));
+								}, false));
 						});
 					},
 					IsEnabled = () => sceneContext.EditableScene


### PR DESCRIPTION
fixed a bug with MatterSlice dependancy

issue: MatterHackers/MCCentral#4032
Slicing error when slicing for Pulse