### PR TITLE
Set button enabled state on selection change

### DIFF
--- a/MatterControlLib/PartPreviewWindow/SelectedObjectPanel.cs
+++ b/MatterControlLib/PartPreviewWindow/SelectedObjectPanel.cs
@@ -179,13 +179,13 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				var selectedItem = scene.SelectedItem;
 				if (selectedItem != null)
 				{
-					itemColorButton.Color = (scene.SelectedItem.Color == Color.Transparent) ? theme.MinimalHighlight : scene.SelectedItem.Color;
-					itemMaterialButton.Color = MaterialRendering.Color(scene.SelectedItem.MaterialIndex, theme.MinimalHighlight);
+					itemColorButton.Color = (selectedItem.Color == Color.Transparent) ? theme.MinimalHighlight : selectedItem.Color;
+					itemMaterialButton.Color = MaterialRendering.Color(selectedItem.MaterialIndex, theme.MinimalHighlight);
 				}
 
-				applyButton.Enabled = scene.SelectedItem?.CanApply == true;
-				removeButton.Enabled = scene.SelectedItem != null;
-				overflowButton.Enabled = scene.SelectedItem != null;
+				applyButton.Enabled = selectedItem?.CanApply == true;
+				removeButton.Enabled = selectedItem != null;
+				overflowButton.Enabled = selectedItem != null;
 			};
 		}
 

--- a/MatterControlLib/PartPreviewWindow/SelectedObjectPanel.cs
+++ b/MatterControlLib/PartPreviewWindow/SelectedObjectPanel.cs
@@ -183,6 +183,8 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 					itemMaterialButton.Color = MaterialRendering.Color(selectedItem.MaterialIndex, theme.MinimalHighlight);
 				}
 
+				itemColorButton.Enabled = selectedItem != null;
+				itemMaterialButton.Enabled = selectedItem != null;
 				applyButton.Enabled = selectedItem?.CanApply == true;
 				removeButton.Enabled = selectedItem != null;
 				overflowButton.Enabled = selectedItem != null;


### PR DESCRIPTION
This was working the entire time I prototyped the feature - I wasn't sure how, but someone was setting the state on lose focus. Of course, once deployed the behavior is now missing.

Adding explicit setting of Enabled property on scene selection change