### PR TITLE
Change 'alpha' to 'transparency' in feature detector

### DIFF
--- a/MatterControlLib/DesignTools/Attributes/EnumRenameAttribute.cs
+++ b/MatterControlLib/DesignTools/Attributes/EnumRenameAttribute.cs
@@ -1,0 +1,47 @@
+﻿/*
+Copyright (c) 2018, Lars Brubaker, John Lewin
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the FreeBSD Project.
+*/
+
+using System;
+using System.Collections.Generic;
+
+namespace MatterHackers.MatterControl.DesignTools
+{
+	[AttributeUsage(AttributeTargets.Property)]
+	public class EnumRenameAttribute : Attribute
+	{
+		public Dictionary<string, string> NameMaping { get; } = new Dictionary<string, string>();
+		public EnumRenameAttribute(params string[] nameMaping)
+		{
+			for(int i=0; i<nameMaping.Length/2; i++)
+			{
+				NameMaping.Add(nameMaping[i * 2], nameMaping[i * 2 + 1]);
+			}
+		}
+	}
+}

--- a/MatterControlLib/DesignTools/Operations/Image/ImageToPathObject3D.cs
+++ b/MatterControlLib/DesignTools/Operations/Image/ImageToPathObject3D.cs
@@ -65,6 +65,7 @@ namespace MatterHackers.MatterControl.DesignTools
 
 		public enum ThresholdFunctions { Silhouette, Intensity, Alpha, Hue }
 
+		[EnumRename("Alpha", "Transparency")]
 		public ThresholdFunctions FeatureDetector
 		{
 			get { return _featureDetector; }

--- a/MatterControlLib/SlicerConfiguration/UIFields/EnumField.cs
+++ b/MatterControlLib/SlicerConfiguration/UIFields/EnumField.cs
@@ -52,11 +52,21 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			// Enum keyed on name to friendly name
 			var enumItems = Enum.GetNames(property.PropertyType).Select(enumName =>
 			{
+				var renamedName = enumName;
+
+				var renameAttribute = property.PropertyInfo.GetCustomAttributes(true).OfType<EnumRenameAttribute>().FirstOrDefault();
+				if (renameAttribute != null)
+				{
+					if(renameAttribute.NameMaping.TryGetValue(renamedName, out string value))
+					{
+						renamedName = value;
+					}
+				}
 				return new
 				{
 					Key = enumName,
-					Value = enumName.Replace('_', ' ')
-				};
+					Value = renamedName.Replace('_', ' ')
+			};
 			});
 
 			dropDownList = new DropDownList("Name".Localize(), theme.Colors.PrimaryTextColor, Direction.Down, pointSize: theme.DefaultFontSize)


### PR DESCRIPTION
Allow renaming of enum values in public property editor