### PR TITLE
Only require probe calibration if doing leveling

### DIFF
--- a/MatterControlLib/ConfigurationPage/PrintLeveling/ProbeCalibrationWizard.cs
+++ b/MatterControlLib/ConfigurationPage/PrintLeveling/ProbeCalibrationWizard.cs
@@ -45,7 +45,8 @@ namespace MatterHackers.MatterControl.ConfigurationPage.PrintLeveling
 		public static bool UsingZProbe(PrinterConfig printer)
 		{
 			// we have a probe that we are using and we have not done leveling yet
-			return printer.Settings.GetValue<bool>(SettingsKey.has_z_probe)
+			return printer.Settings.GetValue<bool>(SettingsKey.print_leveling_enabled)
+				&& printer.Settings.GetValue<bool>(SettingsKey.has_z_probe)
 				&& printer.Settings.GetValue<bool>(SettingsKey.use_z_probe);
 		}
 

--- a/MatterControlLib/PartPreviewWindow/View3D/PrinterBar/PauseResumeButton.cs
+++ b/MatterControlLib/PartPreviewWindow/View3D/PrinterBar/PauseResumeButton.cs
@@ -110,7 +110,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 		protected void SetButtonStates()
 		{
 			// If we don't have leveling data and we need it
-			bool showSetupButton = PrintLevelingData.NeedsToBeRun(printer);
+			bool showSetupButton = PrintLevelingData.NeedsToBeRun(printer) || ProbeCalibrationWizard.NeedsToBeRun(printer);
 
 			switch (printer.Connection.CommunicationState)
 			{


### PR DESCRIPTION
issue: MatterHackers/MCCentral#4351
Probe calibration is required even when software print leveling is turned off