### PR TITLE
Catch hardware error from Prusa Mk3

### DIFF
--- a/MatterControlLib/PrinterCommunication/PrinterConnection.cs
+++ b/MatterControlLib/PrinterCommunication/PrinterConnection.cs
@@ -293,6 +293,7 @@ namespace MatterHackers.MatterControl.PrinterCommunication
 			ReadLineContainsCallBacks.AddCallbackToKey("Error:Thermal Runaway, system stopped!", PrinterReportsError);
 			ReadLineContainsCallBacks.AddCallbackToKey("Error:Heating failed", PrinterReportsError);
 			ReadLineStartCallBacks.AddCallbackToKey("temp sensor defect", PrinterReportsError);
+			ReadLinestartCallBacks.AddCallbackToKey("Error:Printer halted", PrinterReportsError);
 
 			// repetier temperature failures
 			ReadLineContainsCallBacks.AddCallbackToKey("dry run mode", PrinterReportsError);

--- a/MatterControlLib/PrinterCommunication/PrinterConnection.cs
+++ b/MatterControlLib/PrinterCommunication/PrinterConnection.cs
@@ -293,7 +293,7 @@ namespace MatterHackers.MatterControl.PrinterCommunication
 			ReadLineContainsCallBacks.AddCallbackToKey("Error:Thermal Runaway, system stopped!", PrinterReportsError);
 			ReadLineContainsCallBacks.AddCallbackToKey("Error:Heating failed", PrinterReportsError);
 			ReadLineStartCallBacks.AddCallbackToKey("temp sensor defect", PrinterReportsError);
-			ReadLinestartCallBacks.AddCallbackToKey("Error:Printer halted", PrinterReportsError);
+			ReadLineStartCallBacks.AddCallbackToKey("Error:Printer halted", PrinterReportsError);
 
 			// repetier temperature failures
 			ReadLineContainsCallBacks.AddCallbackToKey("dry run mode", PrinterReportsError);


### PR DESCRIPTION
This is the error the printer throws when bed leveling fails. The printer has to be rebooted after this.