### PR TITLE
added created date to oem settings area

### DIFF
--- a/MatterControlLib/SlicerConfiguration/SlicerMapping/EngineMappingMatterSlice.cs
+++ b/MatterControlLib/SlicerConfiguration/SlicerMapping/EngineMappingMatterSlice.cs
@@ -105,6 +105,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			SettingsKey.show_reset_connection,
 			SettingsKey.validate_layer_height,
 			SettingsKey.make,
+			SettingsKey.created_date,
 			SettingsKey.model,
 			SettingsKey.enable_network_printing,
 			SettingsKey.enable_line_spliting,

--- a/StaticData/SliceSettings/Layouts.txt
+++ b/StaticData/SliceSettings/Layouts.txt
@@ -214,6 +214,7 @@ Printer
         trim_filament_markdown
         insert_filament_markdown
         running_clean_markdown
+        created_date
   G-Code
     G-Code
       G-Code

--- a/StaticData/SliceSettings/Properties.json
+++ b/StaticData/SliceSettings/Properties.json
@@ -1070,6 +1070,13 @@
     "DefaultValue": "Undefined"
   },
   {
+    "SlicerConfigName": "created_date",
+    "PresentationName": "Creation Data",
+    "HelpText": "The date this file was originally created.",
+    "DataEditType": "READONLY_STRING",
+    "DefaultValue": "Undefined"
+  },
+  {
     "SlicerConfigName": "output_only_first_layer",
     "PresentationName": "First Layer Only",
     "HelpText": "Output only the first layer of the print. Especially useful for outputting gcode data for applications like engraving or cutting.",


### PR DESCRIPTION
issue: MatterHackers/MCCentral#4432
Show date of creation of printer profile.

![image](https://user-images.githubusercontent.com/1158332/47813684-013cb500-dd09-11e8-8442-f82ae07dba2c.png)
