### PR TITLE
set selection on design history right click

### DIFF
--- a/MatterControlLib/CustomWidgets/TreeView/TreeNode.cs
+++ b/MatterControlLib/CustomWidgets/TreeView/TreeNode.cs
@@ -171,7 +171,8 @@ namespace MatterHackers.MatterControl.CustomWidgets
 		{
 			if (isDirty)
 			{
-				RebuildContentSection();
+				// doing this durring draw will often result in a enumeration changed
+				UiThread.RunOnIdle(RebuildContentSection);
 			}
 
 			base.OnDraw(graphics2D);

--- a/MatterControlLib/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/MatterControlLib/PartPreviewWindow/View3D/View3DWidget.cs
@@ -183,6 +183,12 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				if (e is MouseEventArgs sourceEvent
 					&& s is GuiWidget clickedWidget)
 				{
+					// Ignore AfterSelect events if they're being driven by a SelectionChanged event
+					if (!assigningTreeNode)
+					{
+						Scene.SelectedItem = (IObject3D)treeView.SelectedNode.Tag;
+					}
+
 					if (sourceEvent.Button == MouseButtons.Right)
 					{
 						UiThread.RunOnIdle(() =>
@@ -203,14 +209,6 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 								},
 								altBounds: new RectangleDouble(sourceEvent.X + 1, sourceEvent.Y + 1, sourceEvent.X + 1, sourceEvent.Y + 1));
 						});
-					}
-					else
-					{
-						// Ignore AfterSelect events if they're being driven by a SelectionChanged event
-						if (!assigningTreeNode)
-						{
-							Scene.SelectedItem = (IObject3D)treeView.SelectedNode.Tag;
-						}
 					}
 				}
 			};


### PR DESCRIPTION
cleans up errors with right clicking on an object different than the one selected in the scene
cleans up errors with multiple selected objects not being shown in tree view
update treenode outside of draw recursion