### PR TITLE
Ensure PrinterConfig is unloaded on PrinterTab close

### DIFF
--- a/MatterControlLib/ApplicationView/ApplicationController.cs
+++ b/MatterControlLib/ApplicationView/ApplicationController.cs
@@ -397,6 +397,13 @@ namespace MatterHackers.MatterControl
 
 			_activePrinters.Remove(printer);
 
+			// Release reference
+			if (this.ActivePrinter == printer)
+			{
+				this.ActivePrinter = PrinterConfig.EmptyPrinter;
+			}
+
+
 			// TODO: Need to revised listeners to be multi-printer aware and process change rather than simply remove and add new printer tab
 			if (allowChangedEvent)
 			{

--- a/MatterControlLib/ApplicationView/PrinterConfig.cs
+++ b/MatterControlLib/ApplicationView/PrinterConfig.cs
@@ -46,7 +46,7 @@ namespace MatterHackers.MatterControl
 
 	public class PrinterConfig : IDisposable
 	{
-		MappedSetting[] replaceWithSettingsStrings = null;
+		private MappedSetting[] replaceWithSettingsStrings = null;
 
 		public event EventHandler Disposed;
 
@@ -60,6 +60,7 @@ namespace MatterHackers.MatterControl
 		{
 			this.Connection = new PrinterConnection(this);
 			var printer = this;
+
 			replaceWithSettingsStrings = new MappedSetting[]
 			{
 				// Have a mapping so that MatterSlice while always use a setting that can be set. (the user cannot set first_layer_bedTemperature in MatterSlice)
@@ -126,6 +127,7 @@ namespace MatterHackers.MatterControl
 					}
 				}
 			}
+
 			this.Connection.PrintFinished += PrintFinished;
 			this.Disposed += (s, e) => this.Connection.PrintFinished -= PrintFinished;
 
@@ -133,6 +135,7 @@ namespace MatterHackers.MatterControl
 			{
 				this.Connection.BaudRate = this.Settings.GetValue<int>(SettingsKey.baud_rate);
 			}
+
 			this.Connection.ConnectGCode = this.Settings.GetValue(SettingsKey.connect_gcode);
 			this.Connection.CancelGCode = this.Settings.GetValue(SettingsKey.cancel_gcode);
 			this.Connection.EnableNetworkPrinting = this.Settings.GetValue<bool>(SettingsKey.enable_network_printing);
@@ -479,6 +482,7 @@ namespace MatterHackers.MatterControl
 
 		public void Dispose()
 		{
+			replaceWithSettingsStrings = null;
 			Connection.Dispose();
 			Disposed?.Invoke(this, null);
 		}

--- a/MatterControlLib/CustomWidgets/DockingTabControl.cs
+++ b/MatterControlLib/CustomWidgets/DockingTabControl.cs
@@ -120,6 +120,19 @@ namespace MatterHackers.MatterControl.CustomWidgets
 			this.Rebuild();
 		}
 
+		public override void OnClosed(EventArgs e)
+		{
+			// Iterate and close all held tab widgets
+			foreach (var item in allTabs)
+			{
+				item.widget.Close();
+			}
+
+			allTabs.Clear();
+
+			base.OnClosed(e);
+		}
+
 		public override void Initialize()
 		{
 			base.Initialize();
@@ -172,7 +185,7 @@ namespace MatterHackers.MatterControl.CustomWidgets
 				nameWidget.widget.ClearRemovedFlag();
 			}
 
-			this.RemoveAllChildren();
+			this.CloseAllChildren();
 
 			SimpleTabs tabControl = null;
 

--- a/MatterControlLib/PartPreviewWindow/PopupMenuButton.cs
+++ b/MatterControlLib/PartPreviewWindow/PopupMenuButton.cs
@@ -27,6 +27,7 @@ of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the FreeBSD Project.
 */
 
+using System;
 using MatterHackers.Agg;
 using MatterHackers.Agg.Image;
 using MatterHackers.Agg.UI;
@@ -153,6 +154,12 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				}
 			}
 			set => base.BackgroundColor = value;
+		}
+
+		public override void OnClosed(EventArgs e)
+		{
+			this.PopupContent?.Close();
+			base.OnClosed(e);
 		}
 
 		protected override void OnBeforePopup()

--- a/MatterControlLib/PartPreviewWindow/SelectedObjectPanel.cs
+++ b/MatterControlLib/PartPreviewWindow/SelectedObjectPanel.cs
@@ -27,6 +27,7 @@ of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the FreeBSD Project.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using JsonPath;
@@ -151,7 +152,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			this.ContentPanel = editorPanel;
 			editorPanel.Padding = new BorderDouble(theme.DefaultContainerPadding, 0);
 
-			scene.SelectionChanged += (s, e) =>
+			void scene_SelectionChanged(object sender, EventArgs e)
 			{
 				if (editorPanel.Children.FirstOrDefault()?.DescendantsAndSelf<SectionWidget>().FirstOrDefault() is SectionWidget firstSectionWidget)
 				{
@@ -164,6 +165,9 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				removeButton.Enabled = selectedItem != null;
 				overflowButton.Enabled = selectedItem != null;
 			};
+
+			scene.SelectionChanged += scene_SelectionChanged;
+			this.Closed += (s, e) => scene.SelectionChanged -= scene_SelectionChanged;
 		}
 
 		public GuiWidget ContentPanel { get; set; }

--- a/MatterControlLib/PartPreviewWindow/Tabs.cs
+++ b/MatterControlLib/PartPreviewWindow/Tabs.cs
@@ -606,6 +606,14 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			base.OnDraw(graphics2D);
 		}
 
+		public override void OnClosed(EventArgs e)
+		{
+			this.parentTabControl = null;
+			this.TabContent = null;
+
+			base.OnClosed(e);
+		}
+
 		public string Title
 		{
 			get => tabPill?.Text;

--- a/MatterControlLib/PartPreviewWindow/Tabs.cs
+++ b/MatterControlLib/PartPreviewWindow/Tabs.cs
@@ -439,8 +439,10 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				}
 				else
 				{
-					this.parentTabControl.RemoveTab(this);
 					this.CloseClicked?.Invoke(this, null);
+
+					// Must be called after CloseClicked otherwise listeners are cleared before event is invoked
+					this.parentTabControl?.RemoveTab(this);
 				}
 			});
 		}

--- a/MatterControlLib/PartPreviewWindow/Tabs.cs
+++ b/MatterControlLib/PartPreviewWindow/Tabs.cs
@@ -403,6 +403,14 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			base.OnMouseDown(mouseEvent);
 		}
 
+		public override void OnClosed(EventArgs e)
+		{
+			base.OnClosed(e);
+
+			// Clear all listeners
+			this.CloseClicked = null;
+		}
+
 		private void ConditionallyCloseTab()
 		{
 			UiThread.RunOnIdle(() =>

--- a/MatterControlLib/PartPreviewWindow/Tabs.cs
+++ b/MatterControlLib/PartPreviewWindow/Tabs.cs
@@ -160,8 +160,9 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 		{
 			_allTabs.Remove(tab);
 
-			TabBar.ActionArea.RemoveChild(tab as GuiWidget);
-			this.TabContainer.RemoveChild(tab.TabContent);
+			// Close Tab and TabContent widgets
+			tab.TabContent.Close();
+			(tab as GuiWidget)?.Close();
 
 			if (tab is ChromeTab chromeTab)
 			{

--- a/MatterControlLib/PartPreviewWindow/View3D/MeshViewerWidget.cs
+++ b/MatterControlLib/PartPreviewWindow/View3D/MeshViewerWidget.cs
@@ -270,11 +270,14 @@ namespace MatterHackers.MeshVisualizer
 
 			gCodeMeshColor = new Color(theme.PrimaryAccentColor, 35);
 
-			scene.SelectionChanged += (sender, e) =>
+			void selection_Changed (object sender, EventArgs e)
 			{
 				Invalidate();
 				lastSelectionChangedMs = UiThread.CurrentTimerMs;
-			};
+			}
+
+			scene.SelectionChanged += selection_Changed;
+			this.Closed += (s, e) => scene.SelectionChanged -= selection_Changed;
 
 			BuildVolumeColor = new ColorF(.2, .8, .3, .2).ToColor();
 

--- a/MatterControlLib/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/MatterControlLib/PartPreviewWindow/View3D/View3DWidget.cs
@@ -147,9 +147,6 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 			this.Scene.Invalidated += Scene_Invalidated;
 
-			// if the scene is invalidated invalidate the widget
-			Scene.Invalidated += (s, e) => Invalidate();
-
 			this.AnchorAll();
 
 			TrackballTumbleWidget.TransformState = TrackBallTransformType.Rotation;
@@ -1823,6 +1820,9 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			{
 				UiThread.RunOnIdle(this.RebuildTree);
 			}
+
+			// Invalidate widget on scene invalidate
+			this.Invalidate();
 		}
 
 		private void Scene_SelectionChanged(object sender, EventArgs e)

--- a/MatterControlLib/PartPreviewWindow/ViewControls3D.cs
+++ b/MatterControlLib/PartPreviewWindow/ViewControls3D.cs
@@ -377,11 +377,14 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 			this.AddChild(new ToolbarSeparator(theme));
 
-			undoBuffer.Changed += (sender, e) =>
+			void undoBuffer_Changed(object sender, EventArgs e)
 			{
 				undoButton.Enabled = undoBuffer.UndoCount > 0;
 				redoButton.Enabled = undoBuffer.RedoCount > 0;
 			};
+
+			undoBuffer.Changed += undoBuffer_Changed;
+			this.Closed += (s, e) => undoBuffer.Changed -= undoBuffer_Changed;
 
 			undoButton.Enabled = undoBuffer.UndoCount > 0;
 			redoButton.Enabled = undoBuffer.RedoCount > 0;

--- a/MatterControlLib/PartPreviewWindow/ViewStyleButton.cs
+++ b/MatterControlLib/PartPreviewWindow/ViewStyleButton.cs
@@ -27,6 +27,7 @@ of the authors and should not be interpreted as representing official policies,
 either expressed or implied, of the FreeBSD Project.
 */
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using MatterHackers.Agg;
@@ -69,6 +70,14 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			});
 
 			UserSettings.Instance.SettingChanged += UserSettings_SettingChanged;
+		}
+
+		public override void OnClosed(EventArgs e)
+		{
+			// Unregister listener
+			UserSettings.Instance.SettingChanged -= UserSettings_SettingChanged;
+
+			base.OnClosed(e);
 		}
 
 		private void UserSettings_SettingChanged(object sender, StringEventArgs e)

--- a/MatterControlLib/PartPreviewWindow/ViewStyleButton.cs
+++ b/MatterControlLib/PartPreviewWindow/ViewStyleButton.cs
@@ -51,7 +51,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			: base(theme)
 		{
 			this.sceneContext = sceneContext;
-			this.PopupContent = () => ShowViewOptions(sceneContext, theme);
+			this.PopupContent = ShowViewOptions;
 			this.HAnchor = HAnchor.Fit;
 			this.VAnchor = VAnchor.Fit;
 
@@ -92,7 +92,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			}
 		}
 
-		private GuiWidget ShowViewOptions(BedConfig sceneContext, ThemeConfig theme)
+		private GuiWidget ShowViewOptions()
 		{
 			var popupMenu = new PopupMenu(ApplicationController.Instance.MenuTheme);
 


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#4585
Memory leak in ImageWidget when source image is static