### PR TITLE
Skip fields during merge that already equal target value

### DIFF
--- a/MatterControlLib/Library/Export/GCodeExport.cs
+++ b/MatterControlLib/Library/Export/GCodeExport.cs
@@ -163,8 +163,8 @@ namespace MatterHackers.MatterControl.Library.Export
 
 				if (loadedItem != null)
 				{
-					// Necessary to ensure scene or non-persisted ILibraryObject3D content is on disk before slicing
-					loadedItem.PersistAssets(null);
+					// Ensure content is on disk before slicing
+					await loadedItem.PersistAssets(null);
 
 					try
 					{

--- a/MatterControlLib/SlicerConfiguration/Settings/PrinterSettings.cs
+++ b/MatterControlLib/SlicerConfiguration/Settings/PrinterSettings.cs
@@ -287,7 +287,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 					string importValue = settingsToImport.GetValue(keyName, sourceFilter).Trim();
 
 					if (!string.IsNullOrEmpty(importValue)
-						&& currentValue != keyName
+						&& currentValue != importValue
 						&& !skipKeys.Contains(keyName))
 					{
 						destinationLayer[keyName] = importValue;

--- a/Tests/MatterControl.Tests/MatterControl/ImportSettingsTests.cs
+++ b/Tests/MatterControl.Tests/MatterControl/ImportSettingsTests.cs
@@ -38,5 +38,41 @@ namespace MatterControl.Tests.MatterControl
 			Assert.AreEqual(printerSettings.GetValue(SettingsKey.cancel_gcode), newValue, "Imported setting applied");
 			Assert.IsEmpty(printerSettings.GetValue(notAnExistingKey), "Invalid settings keys should be skipped");
 		}
+
+		[Test]
+		public void MergeDropsFieldsIfValueAlreadySet()
+		{
+			// Validates that field are dropped during import if they are already set in a base layer
+			//
+			AggContext.StaticData = new FileSystemStaticData(TestContext.CurrentContext.ResolveProjectPath(4, "StaticData"));
+			MatterControlUtilities.OverrideAppDataLocation(TestContext.CurrentContext.ResolveProjectPath(4));
+
+			var printerSettings = new PrinterSettings();
+			printerSettings.SetValue(SettingsKey.cancel_gcode, "cancel gcode");
+			printerSettings.SetValue(SettingsKey.start_gcode, "start gcode");
+
+			// Ensure layer_height of a given value
+			printerSettings.BaseLayer[SettingsKey.layer_height] = "0.25";
+
+			string newValue = "----- cancel gcode ----";
+			string notAnExistingKey = "NotAnExistingKey";
+
+			var toImport = new PrinterSettings();
+			toImport.SetValue(SettingsKey.cancel_gcode, newValue);
+			toImport.SetValue(SettingsKey.layer_height, "0.25");
+			toImport.SetValue(notAnExistingKey, "------------------");
+
+			var sourceFilter = new List<PrinterSettingsLayer>()
+			{
+				toImport.UserLayer
+			};
+
+			printerSettings.Merge(printerSettings.UserLayer, toImport, sourceFilter, false);
+
+			Assert.AreEqual(printerSettings.GetValue(SettingsKey.cancel_gcode), newValue, "Imported setting applied");
+			Assert.IsEmpty(printerSettings.GetValue(notAnExistingKey), "Invalid settings keys should be skipped");
+			Assert.IsFalse(printerSettings.UserLayer.ContainsKey(SettingsKey.layer_height), "User layer should not contain layer_height after merge");
+			Assert.AreEqual(2, printerSettings.UserLayer.Count, "User layer should contain two items after import (start_gcode, cancel_gcode)");
+		}
 	}
 }


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#4627
PrinterSettings merge pushes every imported value into target layer