### PR TITLE
Return that SliceItem failed if we have nothing on the bed

### DIFF
--- a/MatterControlLib/SlicerConfiguration/Slicer.cs
+++ b/MatterControlLib/SlicerConfiguration/Slicer.cs
@@ -203,7 +203,12 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 			var stlFileLocations = GetStlFileLocations(object3D, ref mergeRules, printer, progressReporter, cancellationToken);
 
-			return SliceItem(stlFileLocations, mergeRules, gcodeFilePath, printer, progressReporter, cancellationToken);
+			if (stlFileLocations.Count > 0)
+			{
+				return SliceItem(stlFileLocations, mergeRules, gcodeFilePath, printer, progressReporter, cancellationToken);
+			}
+
+			return Task.FromResult(false);
 		}
 
 		public static Task<bool> SliceItem(List<(Matrix4X4 matrix, string fileName)> stlFileLocations, string mergeRules, string gcodeFilePath, PrinterConfig printer, IProgress<ProgressStatus> reporter, CancellationToken cancellationToken)

--- a/Program.cs
+++ b/Program.cs
@@ -67,8 +67,8 @@ namespace MatterHackers.MatterControl
 			Thread.CurrentThread.CurrentUICulture = CultureInfo.InvariantCulture;
 
 			// Set default Agg providers
-			AggContext.Config.ProviderTypes.SystemWindowProvider = "MatterHackers.Agg.UI.OpenGLWinformsWindowProvider, agg_platform_win32";
-			//AggContext.Config.ProviderTypes.SystemWindowProvider = "MatterHackers.MatterControl.WinformsSingleWindowProvider, MatterControl.Winforms";
+			//AggContext.Config.ProviderTypes.SystemWindowProvider = "MatterHackers.Agg.UI.OpenGLWinformsWindowProvider, agg_platform_win32";
+			AggContext.Config.ProviderTypes.SystemWindowProvider = "MatterHackers.MatterControl.WinformsSingleWindowProvider, MatterControl.Winforms";
 
 			string userProfilePath = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 


### PR DESCRIPTION
issue: MatterHackers/MCCentral#4655
Clicking print in an empty design space results in a locked in print printer space
