### PR TITLE
Make disable leveling per printer rather than static

### DIFF
--- a/MatterControlLib/ConfigurationPage/PrintLeveling/PrintLevelingWizard.cs
+++ b/MatterControlLib/ConfigurationPage/PrintLeveling/PrintLevelingWizard.cs
@@ -50,7 +50,7 @@ namespace MatterHackers.MatterControl.ConfigurationPage.PrintLeveling
 		public static void Start(PrinterConfig printer, ThemeConfig theme)
 		{
 			// turn off print leveling
-			PrintLevelingStream.AllowLeveling = false;
+			printer.Connection.AllowLeveling = false;
 
 			// clear any data that we are going to be acquiring (sampled positions, after z home offset)
 			var levelingData = new PrintLevelingData()
@@ -113,7 +113,7 @@ namespace MatterHackers.MatterControl.ConfigurationPage.PrintLeveling
 			printLevelWizardWindow.Closed += (s, e) =>
 			{
 				// If leveling was on when we started, make sure it is on when we are done.
-				PrintLevelingStream.AllowLeveling = true;
+				printer.Connection.AllowLeveling = true;
 
 				printLevelWizardWindow = null;
 

--- a/MatterControlLib/ConfigurationPage/PrintLeveling/ProbeCalibrationWizard.cs
+++ b/MatterControlLib/ConfigurationPage/PrintLeveling/ProbeCalibrationWizard.cs
@@ -52,7 +52,7 @@ namespace MatterHackers.MatterControl.ConfigurationPage.PrintLeveling
 		public static void Start(PrinterConfig printer, ThemeConfig theme)
 		{
 			// turn off print leveling
-			PrintLevelingStream.AllowLeveling = false;
+			printer.Connection.AllowLeveling = false;
 
 			var levelingContext = new ProbeCalibrationWizard(printer)
 			{
@@ -66,7 +66,7 @@ namespace MatterHackers.MatterControl.ConfigurationPage.PrintLeveling
 			probeCalibrationWizardWindow.Closed += (s, e) =>
 			{
 				// If leveling was on when we started, make sure it is on when we are done.
-				PrintLevelingStream.AllowLeveling = true;
+				printer.Connection.AllowLeveling = true;
 
 				probeCalibrationWizardWindow = null;
 

--- a/MatterControlLib/ConfigurationPage/PrintLeveling/WizardPages/AutoProbeFeedback.cs
+++ b/MatterControlLib/ConfigurationPage/PrintLeveling/WizardPages/AutoProbeFeedback.cs
@@ -119,7 +119,7 @@ namespace MatterHackers.MatterControl.ConfigurationPage.PrintLeveling
 		public override void PageIsBecomingActive()
 		{
 			// always make sure we don't have print leveling turned on
-			PrintLevelingStream.AllowLeveling = false;
+			printer.Connection.AllowLeveling = false;
 
 			base.PageIsBecomingActive();
 

--- a/MatterControlLib/ConfigurationPage/PrintLeveling/WizardPages/FindBedHeight.cs
+++ b/MatterControlLib/ConfigurationPage/PrintLeveling/WizardPages/FindBedHeight.cs
@@ -93,7 +93,7 @@ namespace MatterHackers.MatterControl.ConfigurationPage.PrintLeveling
 		public override void PageIsBecomingActive()
 		{
 			// always make sure we don't have print leveling turned on
-			PrintLevelingStream.AllowLeveling = false;
+			printer.Connection.AllowLeveling = false;
 			NextButton.ToolTipText = string.Format("[{0}]", "Right Arrow".Localize());
 
 			base.PageIsBecomingActive();

--- a/MatterControlLib/ConfigurationPage/PrintLeveling/WizardPages/LastPageInstructions.cs
+++ b/MatterControlLib/ConfigurationPage/PrintLeveling/WizardPages/LastPageInstructions.cs
@@ -86,7 +86,7 @@ namespace MatterHackers.MatterControl.ConfigurationPage.PrintLeveling
 
 			// Invoke setter forcing persistence of leveling data
 			printer.Settings.Helpers.SetPrintLevelingData(levelingData, true);
-			PrintLevelingStream.AllowLeveling = true;
+			printer.Connection.AllowLeveling = true;
 			printer.Settings.Helpers.DoPrintLeveling(true);
 
 			if (printer.Settings.GetValue<bool>(SettingsKey.z_homes_to_max))

--- a/MatterControlLib/PrinterCommunication/Io/PrintLevelingStream.cs
+++ b/MatterControlLib/PrinterCommunication/Io/PrintLevelingStream.cs
@@ -49,7 +49,7 @@ namespace MatterHackers.MatterControl.PrinterCommunication.Io
 			this.activePrinting = activePrinting;
 		}
 
-		public static bool AllowLeveling { get; set; }
+		public bool AllowLeveling { get; set; }
 
 		public PrinterMove LastDestination => lastDestination;
 

--- a/MatterControlLib/PrinterCommunication/Io/PrintRecoveryStream.cs
+++ b/MatterControlLib/PrinterCommunication/Io/PrintRecoveryStream.cs
@@ -117,7 +117,7 @@ namespace MatterHackers.MatterControl.PrinterCommunication.Io
 				// remove it from the part
 				case RecoveryState.Raising:
 					// We don't know where the printer is for sure (it make have been turned off). Disable leveling until we know where it is.
-					PrintLevelingStream.AllowLeveling = false;
+					printer.Connection.AllowLeveling = false;
 					queuedCommands.Add("M114 ; get current position");
 					queuedCommands.Add("G91 ; move relative");
 					queuedCommands.Add("G1 Z10 F{0}".FormatWith(printer.Settings.ZSpeed()));
@@ -144,7 +144,7 @@ namespace MatterHackers.MatterControl.PrinterCommunication.Io
 						queuedCommands.Add("G28 Z0");
 					}
 					// We now know where the printer is re-enable print leveling
-					PrintLevelingStream.AllowLeveling = true;
+					printer.Connection.AllowLeveling = true;
 					RecoveryState = RecoveryState.FindingRecoveryLayer;
 					return "";
 					

--- a/MatterControlLib/PrinterCommunication/PrinterConnection.cs
+++ b/MatterControlLib/PrinterCommunication/PrinterConnection.cs
@@ -2451,6 +2451,11 @@ You will then need to logout and log back in to the computer for the changes to 
 		}
 
 		public bool AppendElapsedTime { get; set; }
+		public bool AllowLeveling
+		{
+			get => printLevelingStream6.AllowLeveling;
+			set => printLevelingStream6.AllowLeveling = value;
+		}
 
 		public void TurnOffBedAndExtruders(TurnOff turnOffTime)
 		{


### PR DESCRIPTION
issue: MatterHackers/MCCentral#4722
Running Pulse Bed leveling while using multiple printers in Single-Windows causes the prints to fail