### PR TITLE
Make export without leveling not do line splitting.

### DIFF
--- a/MatterControlLib/ConfigurationPage/PrintLeveling/LevelingFunctions.cs
+++ b/MatterControlLib/ConfigurationPage/PrintLeveling/LevelingFunctions.cs
@@ -136,22 +136,20 @@ namespace MatterHackers.MatterControl.ConfigurationPage.PrintLeveling
 
 				lastDestinationWithLevelingApplied = outPosition;
 
-				newLine = newLine.Append(String.Format("X{0:0.##} Y{1:0.##} Z{2:0.###}", outPosition.X, outPosition.Y, outPosition.Z));
+				newLine = newLine.Append($"X{outPosition.X:0.##} Y{outPosition.Y:0.##} Z{outPosition.Z:0.##} ");
 			}
 
-			if (extruderDelta != 0)
+			if (lineBeingSent.Contains("E"))
 			{
-				newLine = newLine.Append(String.Format(" E{0:0.###}", extruderDelta));
+				newLine = newLine.Append($"E{extruderDelta:0.###} ");
 			}
 
-			if (feedRate != 0)
+			if (lineBeingSent.Contains("F"))
 			{
-				newLine = newLine.Append(String.Format(" F{0:0.##}", feedRate));
+				newLine = newLine.Append($"F{feedRate:0.##}");
 			}
 
-			lineBeingSent = newLine.ToString();
-
-			return lineBeingSent;
+			return newLine.ToString().Trim();
 		}
 
 		public Vector3 GetPositionWithZOffset(Vector3 currentDestination)

--- a/MatterControlLib/Library/Export/GCodeExport.cs
+++ b/MatterControlLib/Library/Export/GCodeExport.cs
@@ -285,7 +285,10 @@ namespace MatterHackers.MatterControl.Library.Export
 
 			accumulatedStream = new RelativeToAbsoluteStream(printer, accumulatedStream);
 
-			if (printer.Settings.GetValue<bool>(SettingsKey.enable_line_splitting))
+			bool levelingEnabled = printer.Settings.GetValue<bool>(SettingsKey.print_leveling_enabled) && applyLeveling;
+
+			if (levelingEnabled
+				&& printer.Settings.GetValue<bool>(SettingsKey.enable_line_splitting))
 			{
 				accumulatedStream = new BabyStepsStream(printer, accumulatedStream, 1);
 			}
@@ -294,7 +297,7 @@ namespace MatterHackers.MatterControl.Library.Export
 				accumulatedStream = new BabyStepsStream(printer, accumulatedStream, 1000);
 			}
 
-			if (printer.Settings.GetValue<bool>(SettingsKey.print_leveling_enabled) && applyLeveling)
+			if (levelingEnabled)
 			{
 				accumulatedStream = new PrintLevelingStream(printer, accumulatedStream, false);
 			}

--- a/MatterControlLib/PrinterCommunication/Io/PrintLevelingStream.cs
+++ b/MatterControlLib/PrinterCommunication/Io/PrintLevelingStream.cs
@@ -34,7 +34,7 @@ namespace MatterHackers.MatterControl.PrinterCommunication.Io
 {
 	public class PrintLevelingStream : GCodeStreamProxy
 	{
-		private PrinterMove lastDestination = new PrinterMove();
+		private PrinterMove _lastDestination = PrinterMove.Unknown;
 		private bool activePrinting;
 		private LevelingFunctions currentLevelingFunctions = null;
 		private double currentProbeOffset;
@@ -51,7 +51,7 @@ namespace MatterHackers.MatterControl.PrinterCommunication.Io
 
 		public bool AllowLeveling { get; set; }
 
-		public PrinterMove LastDestination => lastDestination;
+		public PrinterMove LastDestination => _lastDestination;
 
 		bool LevelingActive
 		{
@@ -90,9 +90,9 @@ namespace MatterHackers.MatterControl.PrinterCommunication.Io
 			{
 				if (LineIsMovement(lineToSend))
 				{
-					PrinterMove currentDestination = GetPosition(lineToSend, lastDestination);
+					PrinterMove currentDestination = GetPosition(lineToSend, LastDestination);
 					var leveledLine = GetLeveledPosition(lineToSend, currentDestination);
-					lastDestination = currentDestination;
+					_lastDestination = currentDestination;
 
 					return leveledLine;
 				}
@@ -119,11 +119,11 @@ namespace MatterHackers.MatterControl.PrinterCommunication.Io
 
 				PrinterMove withoutLevelingOffset = position - deltaToLeveledPosition;
 
-				lastDestination = withoutLevelingOffset;
-				lastDestination.extrusion = position.extrusion;
-				lastDestination.feedRate = position.feedRate;
+				_lastDestination = withoutLevelingOffset;
+				_lastDestination.extrusion = position.extrusion;
+				_lastDestination.feedRate = position.feedRate;
 
-				internalStream.SetPrinterPosition(lastDestination);
+				internalStream.SetPrinterPosition(_lastDestination);
 			}
 			else
 			{

--- a/Tests/MatterControl.Tests/MatterControl/GCodeStreamTests.cs
+++ b/Tests/MatterControl.Tests/MatterControl/GCodeStreamTests.cs
@@ -217,6 +217,108 @@ namespace MatterControl.Tests.MatterControl
 			}
 		}
 
+		[Test]
+		public void LineCuttingOffWhenNoLevelingTest()
+		{
+			string[] inputLines = new string[]
+			{
+				"G1 X0Y0Z0E0 F1000",
+				"G1 X10 Y0 Z0 F1000",
+				null,
+			};
+
+			// We should go back to the above code when possible. It requires making pause part and move while paused part of the stream.
+			// All communication should go through stream to minimize the difference between printing and controlling while not printing (all printing in essence).
+			string[] expected = new string[]
+			{
+				"G1 X0 Y0 Z0 E0 F1000",
+				"G1 X10",
+				 null,
+			};
+
+			AggContext.StaticData = new FileSystemStaticData(TestContext.CurrentContext.ResolveProjectPath(4, "StaticData"));
+			MatterControlUtilities.OverrideAppDataLocation(TestContext.CurrentContext.ResolveProjectPath(4));
+
+			var printer = new PrinterConfig(new PrinterSettings());
+
+			printer.Settings.SetValue(SettingsKey.has_hardware_leveling, "1");
+
+			var testStream = GCodeExport.GetExportStream(printer, new TestGCodeStream(printer, inputLines), true);
+
+			int expectedIndex = 0;
+			string actualLine = testStream.ReadLine();
+			string expectedLine = expected[expectedIndex++];
+
+			Assert.AreEqual(expectedLine, actualLine, "Unexpected response from testStream");
+			Debug.WriteLine(actualLine);
+
+			while (actualLine != null)
+			{
+				actualLine = testStream.ReadLine();
+				expectedLine = expected[expectedIndex++];
+
+				Debug.WriteLine(actualLine);
+				Assert.AreEqual(expectedLine, actualLine, "Unexpected response from testStream");
+			}
+		}
+
+		[Test]
+		public void LineCuttingOnWhenLevelingOnTest()
+		{
+			string[] inputLines = new string[]
+			{
+				"G1 X0Y0Z0E0F1000",
+				"G1 X0Y0Z0E1F1000",
+				"G1 X10 Y0 Z0 F1000",
+				null,
+			};
+
+			// We should go back to the above code when possible. It requires making pause part and move while paused part of the stream.
+			// All communication should go through stream to minimize the difference between printing and controlling while not printing (all printing in essence).
+			string[] expected = new string[]
+			{
+				"; Software Leveling Applied",
+				"G1 X0 Y0 Z-0.1 E0 F1000",
+				"G1 E1",
+				"G1 X1 Y0 Z-0.1",
+				"G1 X2 Y0 Z-0.1",
+				"G1 X3 Y0 Z-0.1",
+				"G1 X4 Y0 Z-0.1",
+				"G1 X5 Y0 Z-0.1",
+				"G1 X6 Y0 Z-0.1",
+				"G1 X7 Y0 Z-0.1",
+				"G1 X8 Y0 Z-0.1",
+				"G1 X9 Y0 Z-0.1",
+				"G1 X10 Y0 Z-0.1",
+				 null,
+			};
+
+			AggContext.StaticData = new FileSystemStaticData(TestContext.CurrentContext.ResolveProjectPath(4, "StaticData"));
+			MatterControlUtilities.OverrideAppDataLocation(TestContext.CurrentContext.ResolveProjectPath(4));
+
+			var printer = new PrinterConfig(new PrinterSettings());
+
+			printer.Settings.SetValue(SettingsKey.print_leveling_enabled, "1");
+
+			var testStream = GCodeExport.GetExportStream(printer, new TestGCodeStream(printer, inputLines), true);
+
+			int expectedIndex = 0;
+			string actualLine = testStream.ReadLine();
+			string expectedLine = expected[expectedIndex++];
+
+			Assert.AreEqual(expectedLine, actualLine, "Unexpected response from testStream");
+			Debug.WriteLine(actualLine);
+
+			while (actualLine != null)
+			{
+				actualLine = testStream.ReadLine();
+				expectedLine = expected[expectedIndex++];
+
+				Debug.WriteLine(actualLine);
+				Assert.AreEqual(expectedLine, actualLine, "Unexpected response from testStream");
+			}
+		}
+
 		public static GCodeStream CreateTestGCodeStream(PrinterConfig printer, string[] inputLines, out List<GCodeStream> streamList)
 		{
 			streamList = new List<GCodeStream>();
@@ -262,33 +364,33 @@ namespace MatterControl.Tests.MatterControl
 			// All communication should go through stream to minimize the difference between printing and controlling while not printing (all printing in essence).
 			string[] expected = new string[]
 			{
-			"G1 E11 F300",
-			"G92 E0",
-			"",
-			"G1 E-1 F302",
-			"G1 E-2",
-			"G1 E-3",
-			"G1 E-4",
-			"G1 E-5",
-			"G90",
-			"",
-			"G1 E-4 F150",
-			"G1 E-3",
-			"G1 E-2",
-			"G1 E-1",
-			"G1 E0",
-			"G1 E1",
-			"G1 E2",
-			"G1 E3",
-			"G90",
-			"G4 P0",
-			"G92 E0",
-			"G4 P0",
-			"",
-			"G1 E-1 F301",
-			"G1 E-2",
-			"G90",
-			 null,
+				"G1 E11 F300",
+				"G92 E0",
+				"",
+				"G1 E-1 F302",
+				"G1 E-2",
+				"G1 E-3",
+				"G1 E-4",
+				"G1 E-5",
+				"G90",
+				"",
+				"G1 E-4 F150",
+				"G1 E-3",
+				"G1 E-2",
+				"G1 E-1",
+				"G1 E0",
+				"G1 E1",
+				"G1 E2",
+				"G1 E3",
+				"G90",
+				"G4 P0",
+				"G92 E0",
+				"G4 P0",
+				"",
+				"G1 E-1 F301",
+				"G1 E-2",
+				"G90",
+				 null,
 			};
 
 			AggContext.StaticData = new FileSystemStaticData(TestContext.CurrentContext.ResolveProjectPath(4, "StaticData"));


### PR DESCRIPTION
Adding tests for export with and without leveling

issue: MatterHackers/MCCentral#4840
Move chopping significantly increases size of exported .gcode files