### PR TITLE
Revise tests to account for new "Finish Setup Button" location

### DIFF
--- a/MatterControlLib/ApplicationView/SettingsValidation.cs
+++ b/MatterControlLib/ApplicationView/SettingsValidation.cs
@@ -67,6 +67,7 @@ namespace MatterHackers.MatterControl
 					Details = "Printer Setup must be run before printing".Localize(),
 					FixAction = new NamedAction()
 					{
+						ID = "SetupPrinter",
 						Title = "Setup".Localize() + "...",
 						Action = () =>
 						{

--- a/MatterControlLib/PartPreviewWindow/View3D/PrinterBar/ValidationErrorsPanel.cs
+++ b/MatterControlLib/PartPreviewWindow/View3D/PrinterBar/ValidationErrorsPanel.cs
@@ -83,6 +83,12 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 					{
 						ToolTipText = action.Title
 					};
+
+					if (!string.IsNullOrEmpty(action.ID))
+					{
+						button.Name = action.ID;
+					}
+
 					button.Click += (s, e) =>
 					{
 						action.Action.Invoke();

--- a/Tests/MatterControl.AutomationTests/HardwareLevelingUITests.cs
+++ b/Tests/MatterControl.AutomationTests/HardwareLevelingUITests.cs
@@ -48,13 +48,13 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					testRunner.OpenPrintPopupMenu(false, false);
 
 					// HACK: automatically resuming setup wizard. Long term we want a better plan
-					testRunner.ClickByName("Finish Setup Button");
+					testRunner.ClickByName("SetupPrinter");
 
 					testRunner.Complete9StepLeveling();
 
 					// make sure the button has changed to start print
 					Assert.IsTrue(testRunner.WaitForName("PrintPopupMenu"), "Start Print should be visible after leveling the printer");
-					Assert.IsFalse(testRunner.WaitForName("Finish Setup Button", .5), "Finish Setup should not be visible after leveling the printer");
+					Assert.IsFalse(testRunner.WaitForName("SetupPrinter", .5), "Finish Setup should not be visible after leveling the printer");
 
 					// reset to defaults and make sure print leveling is cleared
 					testRunner.SwitchToSliceSettings();
@@ -66,7 +66,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					testRunner.OpenPrintPopupMenu(false, false);
 
 					// make sure it is showing the correct button
-					Assert.IsTrue(testRunner.WaitForName("Finish Setup Button"), "Finish Setup should be visible after reset to Defaults");
+					Assert.IsTrue(testRunner.WaitForName("SetupPrinter"), "Finish Setup should be visible after reset to Defaults");
 				}
 
 				return Task.CompletedTask;

--- a/Tests/MatterControl.AutomationTests/PrintingTests.cs
+++ b/Tests/MatterControl.AutomationTests/PrintingTests.cs
@@ -94,7 +94,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 					testRunner.OpenPrintPopupMenu(false, false);
 
-					testRunner.ClickByName("Finish Setup Button");
+					testRunner.ClickByName("SetupPrinter");
 
 					testRunner.Complete9StepLeveling();
 

--- a/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
+++ b/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
@@ -236,7 +236,6 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			// Create the printer
 			testRunner.AddAndSelectPrinter(make, model);
 
-
 			// edit the com port
 			testRunner.SwitchToPrinterSettings();
 
@@ -562,7 +561,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 		{
 			// Complete new material selection requirement
 			testRunner.ClickByName("PrintPopupMenu");
-			testRunner.ClickByName("Finish Setup Button");
+			testRunner.ClickByName("SetupPrinter");
 
 			// Configure ABS as selected material
 			//testRunner.ClickByName("Material DropDown List");
@@ -892,9 +891,9 @@ namespace MatterHackers.MatterControl.Tests.Automation
 
 			// make sure we are in a state that can print
 			if (doFinishSetup
-				&& testRunner.NameExists("Finish Setup Button"))
+				&& testRunner.NameExists("SetupPrinter"))
 			{
-				testRunner.ClickByName("Finish Setup Button");
+				testRunner.ClickByName("SetupPrinter");
 				testRunner.ClickByName("Already Loaded Button");
 				// open it again
 				testRunner.ClickByName("PrintPopupMenu");


### PR DESCRIPTION
- Add infrastructure to find and set new button identifier
- Issue MatterHackers/MCCentral#4902
Investigate failing PulseRequiresLevelingAndLevelingWorks test