### PR TITLE
Add case for suppressed GCode warnings

### DIFF
--- a/MatterControlLib/ConfigurationPage/PrintLeveling/WizardPages/CalibrateProbeLastPagelInstructions.cs
+++ b/MatterControlLib/ConfigurationPage/PrintLeveling/WizardPages/CalibrateProbeLastPagelInstructions.cs
@@ -56,7 +56,7 @@ namespace MatterHackers.MatterControl.ConfigurationPage.PrintLeveling
 				+ "    • " + "Remove the paper".Localize() + "\n"
 				+ "\n"
 				+ "If you wish to re-calibrate your probe in the future:".Localize() + "\n"
-				+ "    1. Select the 'Controls' tab on the right" + "\n"
+				+ "    1. Select the 'Controls' tab on the right".Localize() + "\n"
 				+ "    2. Look for the calibration section (pictured below)".Localize() + "\n";
 			contentRow.AddChild(this.CreateTextField(calibrated));
 

--- a/MatterControlLib/PartPreviewWindow/View3D/PrinterBar/PrintPopupMenu.cs
+++ b/MatterControlLib/PartPreviewWindow/View3D/PrinterBar/PrintPopupMenu.cs
@@ -117,7 +117,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				anySettingOverridden |= printer.Settings.GetValue<bool>(SettingsKey.spiral_vase);
 				anySettingOverridden |= !string.IsNullOrWhiteSpace(printer.Settings.GetValue(SettingsKey.layer_to_pause));
 
-				var sectionWidget = new SectionWidget("Advanced", subPanel, menuTheme, expanded: anySettingOverridden)
+				var sectionWidget = new SectionWidget("Advanced".Localize(), subPanel, menuTheme, expanded: anySettingOverridden)
 				{
 					Name = "Advanced Section",
 					HAnchor = HAnchor.Stretch,

--- a/MatterControlLib/PartPreviewWindow/ViewControls3D.cs
+++ b/MatterControlLib/PartPreviewWindow/ViewControls3D.cs
@@ -325,7 +325,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			undoButton = new IconButton(AggContext.StaticData.LoadIcon("Undo_grey_16x.png", 16, 16, theme.InvertIcons), theme)
 			{
 				Name = "3D View Undo",
-				ToolTipText = "Undo",
+				ToolTipText = "Undo".Localize(),
 				Enabled = false,
 				Margin = theme.ButtonSpacing,
 				VAnchor = VAnchor.Center
@@ -341,7 +341,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			{
 				Name = "3D View Redo",
 				Margin = theme.ButtonSpacing,
-				ToolTipText = "Redo",
+				ToolTipText = "Redo".Localize(),
 				Enabled = false,
 				VAnchor = VAnchor.Center
 			};

--- a/MatterControlLib/SlicerConfiguration/UIFields/ExtruderOffsetField.cs
+++ b/MatterControlLib/SlicerConfiguration/UIFields/ExtruderOffsetField.cs
@@ -31,6 +31,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MatterHackers.Agg;
 using MatterHackers.Agg.UI;
+using MatterHackers.Localizations;
 using MatterHackers.MatterControl.CustomWidgets;
 using MatterHackers.VectorMath;
 
@@ -86,7 +87,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				};
 				column.AddChild(row);
 
-				var labelWidget = SettingsRow.CreateSettingsLabel($"Nozzle {i + 1}", "", textColor);
+				var labelWidget = SettingsRow.CreateSettingsLabel(string.Format("{0} {1}", "Nozzle".Localize(), i + 1), "", textColor);
 				labelWidget.Name = $"Nozzle {i}";
 				labelWidget.Margin = new BorderDouble(right: 60);
 				row.AddChild(labelWidget);


### PR DESCRIPTION
- Issue MatterHackers/MatterControl#4202
GCode export not working and warning message can't be turned back on