### PR TITLE
Set sceneContext.ModelView when changing view modes

### DIFF
--- a/MatterControlLib/PartPreviewWindow/PrinterTabPage.cs
+++ b/MatterControlLib/PartPreviewWindow/PrinterTabPage.cs
@@ -368,7 +368,9 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			gcode2DWidget.Visible = viewMode == PartViewMode.Layers2D;
 
 			view3DWidget.InteractionLayer.DrawOpenGLContent = printer?.ViewState.ViewMode != PartViewMode.Layers2D;
-			
+
+			sceneContext.ViewState.ModelView = viewMode == PartViewMode.Model;
+
 			gcodeContainer.Visible = viewMode != PartViewMode.Model;
 
 			tumbleCubeControl.Visible = !gcode2DWidget.Visible;


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#5015
MeshViewer draws models in GCode3D view, lacks layer scrollbars