### PR TITLE
Improve loading up to previously active GCode file

### DIFF
--- a/MatterControlLib/ApplicationView/BedConfig.cs
+++ b/MatterControlLib/ApplicationView/BedConfig.cs
@@ -140,9 +140,6 @@ namespace MatterHackers.MatterControl
 					await LoadGCodeContent(task.Stream);
 				}
 
-				this.Scene.Children.Modify(children => children.Clear());
-
-				editContext.FreezeGCode = true;
 			}
 			else
 			{
@@ -168,6 +165,10 @@ namespace MatterHackers.MatterControl
 					progressStatus.Progress0To1 = progress0To1;
 					reporter.Report(progressStatus);
 				});
+
+				this.Scene.Children.Modify(children => children.Clear());
+
+				this.EditContext.FreezeGCode = true;
 
 				return Task.CompletedTask;
 			});

--- a/MatterControlLib/ApplicationView/BedConfig.cs
+++ b/MatterControlLib/ApplicationView/BedConfig.cs
@@ -140,6 +140,8 @@ namespace MatterHackers.MatterControl
 					await LoadGCodeContent(task.Stream);
 				}
 
+				// No content store for GCode
+				editContext.ContentStore = null;
 			}
 			else
 			{
@@ -248,7 +250,7 @@ namespace MatterHackers.MatterControl
 						new EditContext()
 						{
 							SourceItem = new FileSystemFileItem(firstFilePath),
-							ContentStore = null // No content store for GCode, otherwise PlatingHistory
+							ContentStore = null // No content store for GCode
 						});
 
 					return;

--- a/MatterControlLib/ApplicationView/ISceneContext.cs
+++ b/MatterControlLib/ApplicationView/ISceneContext.cs
@@ -47,7 +47,7 @@ namespace MatterHackers.MatterControl
 	public interface ISceneContext
 	{
 		Vector2 BedCenter { get; }
-		
+
 		string ContentType { get; }
 
 		bool EditableScene { get; }
@@ -75,7 +75,7 @@ namespace MatterHackers.MatterControl
 		Task LoadContent(EditContext editContext);
 
 		void LoadEmptyContent(EditContext editContext);
-		
+
 		Task LoadGCodeContent(Stream stream);
 
 		Task LoadIntoCurrent(EditContext editContext);

--- a/MatterControlLib/PartPreviewWindow/PrinterTabPage.cs
+++ b/MatterControlLib/PartPreviewWindow/PrinterTabPage.cs
@@ -213,6 +213,18 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 			this.LayerScrollbar.Margin = LayerScrollbar.Margin.Clone(top: tumbleCubeControl.Height + tumbleCubeControl.Margin.Height + 4);
 
+			// On load, switch to gcode view if previously editing gcode file. Listeners would normally do this but workspace loads before this UI widget
+			if (this?.printerActionsBar?.modelViewButton is GuiWidget button)
+			{
+				button.Enabled = sceneContext.EditableScene;
+
+				if (sceneContext.ContentType == "gcode"
+					&& this?.printerActionsBar?.layers3DButton is GuiWidget gcodeButton)
+				{
+					gcodeButton.InvokeClick();
+				}
+			}
+
 			// Register listeners
 			printer.ViewState.VisibilityChanged += ProcessOptionalTabs;
 			printer.ViewState.ViewModeChanged += ViewState_ViewModeChanged;


### PR DESCRIPTION
- Issue MatterHackers/MCCentral#5065
Occasionally Exported Gcode is of a previous slice not the current slice.