### PR TITLE
Show a max of 3 decimals

### DIFF
--- a/MatterControl.Printing/Settings/SettingsHelpers.cs
+++ b/MatterControl.Printing/Settings/SettingsHelpers.cs
@@ -245,7 +245,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 				{
 					newValue += ",";
 				}
-				newValue += $"{offset.X}x{offset.Y}x{offset.Z}";
+				newValue += $"{offset.X:0.###}x{offset.Y:0.###}x{offset.Z:0.###}";
 				first = false;
 			}
 

--- a/MatterControlLib/SlicerConfiguration/UIFields/Vector2Field.cs
+++ b/MatterControlLib/SlicerConfiguration/UIFields/Vector2Field.cs
@@ -84,7 +84,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			xEditWidget.ActuallNumberEdit.EditComplete += (sender, e) =>
 			{
 				this.SetValue(
-					string.Format("{0},{1}", xEditWidget.ActuallNumberEdit.Value.ToString(), yEditWidget.ActuallNumberEdit.Value.ToString()),
+					string.Format("{0},{1}", xEditWidget.ActuallNumberEdit.Value.ToString("0.###"), yEditWidget.ActuallNumberEdit.Value.ToString("0.###")),
 					userInitiated: true);
 			};
 
@@ -101,7 +101,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			yEditWidget.ActuallNumberEdit.EditComplete += (sender, e) =>
 			{
 				this.SetValue(
-					string.Format("{0},{1}", xEditWidget.ActuallNumberEdit.Value.ToString(), yEditWidget.ActuallNumberEdit.Value.ToString()),
+					string.Format("{0},{1}", xEditWidget.ActuallNumberEdit.Value.ToString("0.###"), yEditWidget.ActuallNumberEdit.Value.ToString("0.###")),
 					userInitiated: true);
 			};
 

--- a/MatterControlLib/SlicerConfiguration/UIFields/Vector3Field.cs
+++ b/MatterControlLib/SlicerConfiguration/UIFields/Vector3Field.cs
@@ -86,9 +86,9 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			{
 				this.SetValue(
 					string.Format("{0},{1},{2}",
-						xEditWidget.ActuallNumberEdit.Value.ToString(),
-						yEditWidget.ActuallNumberEdit.Value.ToString(),
-						zEditWidget.ActuallNumberEdit.Value.ToString()),
+						xEditWidget.ActuallNumberEdit.Value.ToString("0.###"),
+						yEditWidget.ActuallNumberEdit.Value.ToString("0.###"),
+						zEditWidget.ActuallNumberEdit.Value.ToString("0.###")),
 					userInitiated: true);
 			};
 
@@ -107,9 +107,9 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			{
 				this.SetValue(
 					string.Format("{0},{1},{2}",
-					xEditWidget.ActuallNumberEdit.Value.ToString(),
-					yEditWidget.ActuallNumberEdit.Value.ToString(),
-					zEditWidget.ActuallNumberEdit.Value.ToString()),
+					xEditWidget.ActuallNumberEdit.Value.ToString("0.###"),
+					yEditWidget.ActuallNumberEdit.Value.ToString("0.###"),
+					zEditWidget.ActuallNumberEdit.Value.ToString("0.###")),
 					userInitiated: true);
 			};
 
@@ -128,9 +128,9 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			{
 				this.SetValue(
 					string.Format("{0},{1},{2}",
-					xEditWidget.ActuallNumberEdit.Value.ToString(),
-					yEditWidget.ActuallNumberEdit.Value.ToString(),
-					zEditWidget.ActuallNumberEdit.Value.ToString()),
+					xEditWidget.ActuallNumberEdit.Value.ToString("0.###"),
+					yEditWidget.ActuallNumberEdit.Value.ToString("0.###"),
+					zEditWidget.ActuallNumberEdit.Value.ToString("0.###")),
 					userInitiated: true);
 			};
 


### PR DESCRIPTION
issue: MatterHackers/MCCentral#5301
XY calibration wizard should truncate to two or three decimals