### PR TITLE
Don't fit objects that have no size

### DIFF
--- a/MatterControlLib/DesignTools/Operations/FitToBoundsObject3D_2.cs
+++ b/MatterControlLib/DesignTools/Operations/FitToBoundsObject3D_2.cs
@@ -256,7 +256,10 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 						break;
 				}
 
-				ItemWithTransform.Matrix = Object3DExtensions.ApplyAtPosition(ItemWithTransform.Matrix, aabb.Center, Matrix4X4.CreateScale(scale));
+				if (aabb.XSize > 0 && aabb.YSize > 0 && aabb.ZSize > 0)
+				{
+					ItemWithTransform.Matrix = Object3DExtensions.ApplyAtPosition(ItemWithTransform.Matrix, aabb.Center, Matrix4X4.CreateScale(scale));
+				}
 			}
 		}
 


### PR DESCRIPTION
issue: MatterHackers/MCCentral#5431
Changing Text to just a space " " crashes MatterControl