### PR TITLE
make sure we can flatten a just flattened subtract and replace child

### DIFF
--- a/MatterControlLib/DesignTools/Operations/OperationSourceObject3D.cs
+++ b/MatterControlLib/DesignTools/Operations/OperationSourceObject3D.cs
@@ -110,11 +110,17 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 					newChildren.Add(group);
 				}
 
+				if (newChildren.Count == 0)
+				{
+					newChildren = this.Children.Select(i => i.Clone()).ToList();
+				}
+
 				// add flatten to the name to show what happened
 				newChildren[0].Name = this.Name + " - " + "Flattened".Localize();
 
 				// and replace us with the children
 				var replaceCommand = new ReplaceCommand(new[] { this }, newChildren);
+
 				if (undoBuffer != null)
 				{
 					undoBuffer.AddAndDo(replaceCommand);
@@ -245,6 +251,7 @@ namespace MatterHackers.MatterControl.DesignTools.Operations
 
 	public class OperationSourceObject3D : Object3D
 	{
+		public override bool CanFlatten => true;
 		public OperationSourceObject3D()
 		{
 			Name = "Source".Localize();


### PR DESCRIPTION
also make sure we can flatten the inner content of a subtract and replace

issue: MatterHackers/MCCentral#5436
Shark hex tile crashes on ungroup