### PR TITLE
making bend do a merge vertices after to fix non-manifold edges

### DIFF
--- a/MatterControlLib/DesignTools/Operations/CurveObject3D_2.cs
+++ b/MatterControlLib/DesignTools/Operations/CurveObject3D_2.cs
@@ -181,8 +181,9 @@ namespace MatterHackers.MatterControl.DesignTools
 						// transform back into item local space
 						transformedMesh.Transform(Matrix4X4.CreateTranslation(-rotationCenter) * itemMatrix.Inverted);
 
-						transformedMesh.MarkAsChanged();
+						transformedMesh.MergeVertices(.1);
 						transformedMesh.CalculateNormals();
+						transformedMesh.MarkAsChanged();
 
 						var curvedChild = new Object3D()
 						{


### PR DESCRIPTION
issue: MatterHackers/MCCentral#5430
Subtracting a Bend-modified object doesn't do anything.