### PR TITLE
Revise icon loading

### DIFF
--- a/MatterControlLib/ApplicationView/Themes/ThemeConfig.cs
+++ b/MatterControlLib/ApplicationView/Themes/ThemeConfig.cs
@@ -238,6 +238,9 @@ namespace MatterHackers.MatterControl
 			// {
 			// 	this.BedColor = this.ResolveColor(this.BackgroundColor, Color.Gray.WithAlpha(60));
 			// }
+
+			// EnsureDefaults is called after deserialization and at a point when state should be fully loaded. Invoking RebuildTheme here ensures icons are inverted correctly
+			this.RebuildTheme();
 		}
 
 		public Color RowBorder { get; set; }

--- a/MatterControlLib/ApplicationView/WorkspacesChangedEventArgs.cs
+++ b/MatterControlLib/ApplicationView/WorkspacesChangedEventArgs.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (c) 2018, Lars Brubaker, John Lewin
+Copyright (c) 2020, Lars Brubaker, John Lewin
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -28,55 +28,7 @@ either expressed or implied, of the FreeBSD Project.
 */
 
 using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Diagnostics;
-using System.IO;
-using System.IO.Compression;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Text;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
-using global::MatterControl.Printing;
-using Markdig.Agg;
-using Markdig.Renderers.Agg;
-using MatterHackers.Agg;
-using MatterHackers.Agg.Font;
-using MatterHackers.Agg.Image;
-using MatterHackers.Agg.Platform;
-using MatterHackers.Agg.UI;
-using MatterHackers.Agg.VertexSource;
-using MatterHackers.DataConverters3D;
-using MatterHackers.DataConverters3D.UndoCommands;
-using MatterHackers.Localizations;
-using MatterHackers.MatterControl.CustomWidgets;
-using MatterHackers.MatterControl.DataStorage;
-using MatterHackers.MatterControl.DesignTools;
-using MatterHackers.MatterControl.DesignTools.Operations;
-using MatterHackers.MatterControl.Extensibility;
-using MatterHackers.MatterControl.Library;
-using MatterHackers.MatterControl.PartPreviewWindow;
-using MatterHackers.MatterControl.PartPreviewWindow.View3D;
-using MatterHackers.MatterControl.Plugins;
-using MatterHackers.MatterControl.PrinterCommunication;
-using MatterHackers.MatterControl.PrinterControls.PrinterConnections;
-using MatterHackers.MatterControl.PrintQueue;
-using MatterHackers.MatterControl.SettingsManagement;
-using MatterHackers.MatterControl.SlicerConfiguration;
-using MatterHackers.MatterControl.Tour;
-using MatterHackers.PolygonMesh;
-using MatterHackers.PolygonMesh.Processors;
-using MatterHackers.VectorMath;
-using MatterHackers.VectorMath.TrackBall;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Linq;
 
 [assembly: InternalsVisibleTo("MatterControl.Tests")]
 [assembly: InternalsVisibleTo("MatterControl.AutomationTests")]
@@ -85,7 +37,7 @@ using Newtonsoft.Json.Linq;
 namespace MatterHackers.MatterControl
 {
 
-	public class WorkspacesChangedEventArgs : EventArgs
+    public class WorkspacesChangedEventArgs : EventArgs
 	{
 		public WorkspacesChangedEventArgs(PartWorkspace workspace, OperationType operation)
 		{

--- a/MatterControlLib/Library/ContentProviders/MeshContentProvider.cs
+++ b/MatterControlLib/Library/ContentProviders/MeshContentProvider.cs
@@ -1,5 +1,5 @@
 ﻿/*
-Copyright (c) 2018, John Lewin
+Copyright (c) 2020, John Lewin
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -37,7 +37,8 @@ namespace MatterHackers.MatterControl
 	using MatterHackers.Agg.Image;
 	using MatterHackers.Agg.Platform;
 	using MatterHackers.DataConverters3D;
-	using MatterHackers.MatterControl.DesignTools.Operations;
+    using MatterHackers.ImageProcessing;
+    using MatterHackers.MatterControl.DesignTools.Operations;
 	using MatterHackers.MatterControl.Library;
 	using MatterHackers.RayTracer;
 
@@ -52,6 +53,10 @@ namespace MatterHackers.MatterControl
 		private long MaxFileSizeForTracing => Is32Bit ? 8 * 1000 * 1000 : 16 * 1000 * 1000;
 
 		private long MaxFileSizeForThumbnail => Is32Bit ? 16 * 1000 * 1000 : 32 * 1000 * 1000;
+
+		private ThemeConfig theme = null;
+
+		private ImageBuffer defaultIcon = new ImageBuffer();
 
 		public Task<IObject3D> CreateItem(ILibraryItem item, Action<double, string> progressReporter)
 		{
@@ -174,6 +179,20 @@ namespace MatterHackers.MatterControl
 				allowMultiThreading: !ApplicationController.Instance.AnyPrintTaskRunning);
 		}
 
-		public ImageBuffer DefaultImage { get; } = AggContext.StaticData.LoadIcon("mesh.png");
+		public ImageBuffer DefaultImage
+		{
+			get 
+			{
+				// Ensure icon is reloaded after theme change
+				if (theme != AppContext.Theme)
+				{
+					theme = AppContext.Theme;
+
+					defaultIcon = AggContext.StaticData.LoadIcon("mesh.png", theme.InvertIcons); //.AnyAlphaToColor(theme.PrimaryAccentColor);
+				}
+
+				return defaultIcon;
+			}
+		}
 	}
 }

--- a/MatterControlLib/Library/Providers/FileSystem/FileSystemContainer.cs
+++ b/MatterControlLib/Library/Providers/FileSystem/FileSystemContainer.cs
@@ -66,7 +66,7 @@ namespace MatterHackers.MatterControl.Library
 				&& Directory.Exists(fullPath))
 			{
 				directoryWatcher = new FileSystemWatcher(fullPath);
-				directoryWatcher.NotifyFilter = NotifyFilters.LastAccess | NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName;
+				directoryWatcher.NotifyFilter = NotifyFilters.LastWrite | NotifyFilters.FileName | NotifyFilters.DirectoryName;
 				directoryWatcher.Changed += DirectoryContentsChanged;
 				directoryWatcher.Created += DirectoryContentsChanged;
 				directoryWatcher.Deleted += DirectoryContentsChanged;

--- a/MatterControlLib/Library/Widgets/ListView/ListViewItemBase.cs
+++ b/MatterControlLib/Library/Widgets/ListView/ListViewItemBase.cs
@@ -193,8 +193,6 @@ namespace MatterHackers.MatterControl.CustomWidgets
 			}
 		}
 
-		public event EventHandler ImageSet;
-
 		protected void SetUnsizedThumbnail(ImageBuffer thumbnail)
 		{
 			this.SetSizedThumbnail(
@@ -212,7 +210,6 @@ namespace MatterHackers.MatterControl.CustomWidgets
 				|| !thumbnail.Equals(this.imageWidget.Image, 5)))
 			{
 				this.imageWidget.Image = thumbnail;
-				this.ImageSet?.Invoke(this, null);
 				this.Invalidate();
 			}
 		}


### PR DESCRIPTION
- Ensure icon is loaded after .InvertIcons property is deserialized 
- Ensure MeshProvider default icon is theme aware
- Prevent loss of state and flicker during icon generation
- Code cleanup, remove unused event
