### PR TITLE
Created test and addressed printer name bug

### DIFF
--- a/MatterControlLib/CustomWidgets/ConfigurePrinterWidget.cs
+++ b/MatterControlLib/CustomWidgets/ConfigurePrinterWidget.cs
@@ -57,11 +57,11 @@ namespace MatterHackers.MatterControl
 				}
 			}
 
-			PrinterSettings.AnyPrinterSettingChanged += Printer_SettingChanged;
+			printer.Settings.SettingChanged += Printer_SettingChanged;
 
 			inlineNameEdit.Closed += (s, e) =>
 			{
-				PrinterSettings.AnyPrinterSettingChanged -= Printer_SettingChanged;
+				printer.Settings.SettingChanged -= Printer_SettingChanged;
 			};
 
 			this.AddChild(

--- a/MatterControlLib/PartPreviewWindow/MainViewWidget.cs
+++ b/MatterControlLib/PartPreviewWindow/MainViewWidget.cs
@@ -672,6 +672,8 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 
 		public ChromeTabs TabControl => tabControl;
 
+		private static int debugPrinterTabIndex = 0;
+
 		private ChromeTab CreatePrinterTab(PartWorkspace workspace, ThemeConfig theme)
 		{
 			var printer = workspace.Printer;
@@ -698,7 +700,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 					theme,
 					tabImageUrl: ApplicationController.Instance.GetFavIconUrl(oemName: printer.Settings.GetValue(SettingsKey.make)))
 				{
-					Name = "3D View Tab",
+					Name = $"3D View Tab {debugPrinterTabIndex++}",
 				};
 
 				// add a right click menu

--- a/MatterControlLib/SlicerConfiguration/Settings/ProfileManager.cs
+++ b/MatterControlLib/SlicerConfiguration/Settings/ProfileManager.cs
@@ -126,7 +126,10 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			var key = printer.Settings.ID;
 			Task.Run(async () =>
 			{
-				ProfileManager.oemSettingsNeedingUpdateCache[key] = await GetChangedOemSettings(printer);
+				if (ProfileManager.oemSettingsNeedingUpdateCache.ContainsKey(key))
+				{
+					ProfileManager.oemSettingsNeedingUpdateCache[key] = await GetChangedOemSettings(printer);
+				}
 			});
 
 			if (oemSettingsNeedingUpdateCache.TryGetValue(key, out List<(string key, string currentValue, string newValue)> cache))

--- a/MatterControlLib/SlicerConfiguration/Settings/ProfileManager.cs
+++ b/MatterControlLib/SlicerConfiguration/Settings/ProfileManager.cs
@@ -126,10 +126,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 			var key = printer.Settings.ID;
 			Task.Run(async () =>
 			{
-				if (ProfileManager.oemSettingsNeedingUpdateCache.ContainsKey(key))
-				{
-					ProfileManager.oemSettingsNeedingUpdateCache[key] = await GetChangedOemSettings(printer);
-				}
+				ProfileManager.oemSettingsNeedingUpdateCache[key] = await GetChangedOemSettings(printer);
 			});
 
 			if (oemSettingsNeedingUpdateCache.TryGetValue(key, out List<(string key, string currentValue, string newValue)> cache))

--- a/Tests/MatterControl.AutomationTests/PrinterDropDownTests.cs
+++ b/Tests/MatterControl.AutomationTests/PrinterDropDownTests.cs
@@ -8,10 +8,51 @@ using NUnit.Framework;
 namespace MatterHackers.MatterControl.Tests.Automation
 {
 	[TestFixture, Category("MatterControl.UI.Automation"), RunInApplicationDomain, Apartment(ApartmentState.STA)]
-	public class PrinterNameChangePersists
+	public class PrinterNameChangeTests
 	{
 		[Test]
-		public async Task PrinterNameChangeTest()
+		public async Task NameChangeOnlyEffectsOnePrinter()
+		{
+			await MatterControlUtilities.RunTest((testRunner) =>
+			{
+				testRunner.WaitForFirstDraw();
+
+				// Add Guest printers
+				testRunner.AddAndSelectPrinter("Airwolf 3D", "HD");
+
+				var printer1 = testRunner.FirstPrinter();
+
+				testRunner.AddAndSelectPrinter("BCN3D", "Sigma");
+
+				var printer2 = ApplicationController.Instance.ActivePrinters.Last();
+
+				string newName0 = "Updated name 0";
+				string newName1 = "Updated name 1";
+				var printerTab0 = testRunner.GetWidgetByName("3D View Tab 0", out _) as ChromeTab;
+				var printerTab1 = testRunner.GetWidgetByName("3D View Tab 1", out _) as ChromeTab;
+
+				// switch back to airwolf tab
+				testRunner.ClickByName("3D View Tab 0")
+					.SwitchToPrinterSettings()
+					.InlineTitleEdit("Printer Name", newName0);
+
+				Assert.AreEqual(newName0, printerTab0.Title);
+				Assert.AreEqual("BCN3D Sigma", printerTab1.Title);
+
+				// switch back to BCN tab
+				testRunner.ClickByName("3D View Tab 1")
+					.SwitchToPrinterSettings()
+					.InlineTitleEdit("Printer Name", newName1);
+
+				Assert.AreEqual(newName1, printerTab1.Title);
+				Assert.AreEqual(newName0, printerTab0.Title, "Name did not change");
+
+				return Task.CompletedTask;
+			}, maxTimeToRun: 120);
+		}
+
+		[Test]
+		public async Task NameChangePersists()
 		{
 			// Ensures that printer model changes are applied correctly and observed by the view
 			await MatterControlUtilities.RunTest((testRunner) =>
@@ -42,12 +83,11 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				Assert.IsTrue(testRunner.WaitForName(newName + " Node"), "Widget with updated printer name exists");
 
 				// Validate that the tab reflects the new name
-				var printerTab = testRunner.GetWidgetByName("3D View Tab", out _) as ChromeTab;
+				var printerTab = testRunner.GetWidgetByName("3D View Tab 0", out _) as ChromeTab;
 				Assert.AreEqual(newName, printerTab.Title);
 
 				// Validate that the settings layer reflects the new name
 				Assert.AreEqual(newName, printer.Settings.GetValue(SettingsKey.printer_name));
-
 
 				return Task.CompletedTask;
 			});

--- a/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
+++ b/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
@@ -1090,17 +1090,17 @@ namespace MatterHackers.MatterControl.Tests.Automation
 		/// Switch to printer settings
 		/// </summary>
 		/// <param name="testRunner">The AutomationRunner in use</param>
-		public static void SwitchToPrinterSettings(this AutomationRunner testRunner)
+		public static AutomationRunner SwitchToPrinterSettings(this AutomationRunner testRunner)
 		{
 			EnsurePrinterSidebarOpen(testRunner);
 
 			if (!testRunner.NameExists("Printer Tab", 0.1))
 			{
-				testRunner.ClickByName("Printer Overflow Menu");
-				testRunner.ClickByName("Configure Printer Menu Item");
+				testRunner.ClickByName("Printer Overflow Menu")
+					.ClickByName("Configure Printer Menu Item");
 			}
 
-			testRunner.ClickByName("Printer Tab");
+			return testRunner.ClickByName("Printer Tab");
 		}
 
 		public static void InlineTitleEdit(this AutomationRunner testRunner, string controlName, string replaceString)
@@ -1208,7 +1208,10 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			if (testRunner.WaitForName("Slice Settings Sidebar", 0.2))
 			{
 				testRunner.ClickByName("Slice Settings Sidebar");
-				testRunner.ClickByName("Pin Settings Button");
+				if (UserSettings.Instance.get(UserSettingsKey.SliceSettingsTabPinned) != "true")
+				{
+					testRunner.ClickByName("Pin Settings Button");
+				}
 			}
 		}
 


### PR DESCRIPTION
issue: MatterHackers/MCCentral#6102
Renaming printer when 2 are open, renames both