### PR TITLE
Changes for orthographic view mode

### DIFF
--- a/MatterControlLib/PartPreviewWindow/View3D/CameraFittingUtil.cs
+++ b/MatterControlLib/PartPreviewWindow/View3D/CameraFittingUtil.cs
@@ -153,13 +153,13 @@ namespace MatterHackers
 			Vector2 viewportSize = world.ViewportSize + new Vector2(centerOffsetX, 0);
 			double margin = MarginScale * Math.Min(viewportSize.X, viewportSize.Y);
 			WorldView reducedWorld = new WorldView(viewportSize.X - margin * 2, viewportSize.Y - margin * 2);
-			double reducedVFOVRadians = Math.Atan(reducedWorld.Height / world.Height * (world.NearPlaneHeightInViewspace / 2) / world.NearZ) * 2;
+			double reducedVFOVDegrees = WorldView.CalcPerspectiveVFOVDegreesFromDistanceAndHeight(world.NearZ, world.NearPlaneHeightInViewspace * (reducedWorld.Height / world.Height));
 			
 			reducedWorld.CalculatePerspectiveMatrixOffCenter(
 				reducedWorld.Width, reducedWorld.Height,
 				0,
 				1, 2, // Arbitrary
-				MathHelper.RadiansToDegrees(reducedVFOVRadians)
+				reducedVFOVDegrees
 				);
 
 			Plane[] viewspacePlanes = Frustum.FrustumFromProjectionMatrix(reducedWorld.ProjectionMatrix).Planes.Take(4).ToArray();

--- a/MatterControlLib/PartPreviewWindow/View3D/TrackballTumbleWidgetExtended.cs
+++ b/MatterControlLib/PartPreviewWindow/View3D/TrackballTumbleWidgetExtended.cs
@@ -718,11 +718,11 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				}
 			}
 
-			double refFOV = MathHelper.DegreesToRadians(
+			double refFOVDegrees = 
 				toOrthographic
 				? this.world.VFovDegrees // start FOV
 				: WorldView.DefaultPerspectiveVFOVDegrees  // end FOV
-				);
+				;
 
 			const int numUpdates = 10;
 
@@ -735,16 +735,16 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 				else
 				{
 					double t = i / (double)numUpdates;
-					double fov = toOrthographic ? refFOV * (1 - t) : refFOV * t;
+					double fov = toOrthographic ? refFOVDegrees * (1 - t) : refFOVDegrees * t;
 
-					double dist = refPlaneHeightInViewspace / 2 / Math.Tan(fov / 2);
+					double dist = WorldView.CalcPerspectiveDistance(refPlaneHeightInViewspace, fov);
 					double eyeZ = refViewspaceZ + dist;
 
 					Vector3 viewspaceEyePosition = new Vector3(0, 0, eyeZ);
 
 					//System.Diagnostics.Trace.WriteLine("{0} {1} {2}".FormatWith(fovDegrees, dist, eyeZ));
 
-					world.CalculatePerspectiveMatrixOffCenter(world.Width, world.Height, CenterOffsetX, WorldView.DefaultNearZ, WorldView.DefaultFarZ, MathHelper.RadiansToDegrees(fov));
+					world.CalculatePerspectiveMatrixOffCenter(world.Width, world.Height, CenterOffsetX, WorldView.DefaultNearZ, WorldView.DefaultFarZ, fov);
 					world.EyePosition = viewspaceEyePosition.TransformPosition(originalViewToWorld);
 				}
 			});

--- a/MatterControlLib/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/MatterControlLib/PartPreviewWindow/View3D/View3DWidget.cs
@@ -69,7 +69,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
     public class View3DWidget : GuiWidget, IDrawable
 	{
 		// Padded by this amount on each side, in case of unaccounted for scene geometry.
-		// For orthogrpahic, this is an offset on either side scaled by far - near.
+		// For orthographic, this is an offset on either side scaled by far - near.
 		// For perspective, this + 1 is used to scale the near and far planes.
 		private const double DynamicNearFarBoundsPaddingFactor = 0.1;
 


### PR DESCRIPTION
Better orthographic zoom limits, replace raw trig calls with WorldView util functions, and handle the case where viewspace Z is too close to zero during a switch to orthographic.