### PR TITLE
Use Math.Round for snap rounding.

### DIFF
--- a/MatterControlLib/PartPreviewWindow/View3D/View3DWidget.cs
+++ b/MatterControlLib/PartPreviewWindow/View3D/View3DWidget.cs
@@ -1785,7 +1785,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 					}
 					double xToSnap = xSnapOffset + delta.X;
 
-					double snappedX = ((int)((xToSnap / snapGridDistance) + .5)) * snapGridDistance;
+					double snappedX = Math.Round(xToSnap / snapGridDistance) * snapGridDistance;
 					delta.X = snappedX - xSnapOffset;
 
 					double ySnapOffset = selectedBounds.MinXYZ.Y;
@@ -1798,7 +1798,7 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 					}
 					double yToSnap = ySnapOffset + delta.Y;
 
-					double snappedY = ((int)((yToSnap / snapGridDistance) + .5)) * snapGridDistance;
+					double snappedY = Math.Round(yToSnap / snapGridDistance) * snapGridDistance;
 					delta.Y = snappedY - ySnapOffset;
 				}
 


### PR DESCRIPTION
Avoid going through integers. And make translation snapping consistent when crossing over the zero point on an axis, rather than rounding towards zero.