### PR TITLE
Fix the position of the blue dot on the upgrade tab.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,4 +120,3 @@ MatterControl.userprefs
 
 # JetBrains Rider user configuration directory
 /.idea/
-/MainOutputDirectory.cs

--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,4 @@ MatterControl.userprefs
 
 # JetBrains Rider user configuration directory
 /.idea/
+/MainOutputDirectory.cs

--- a/MatterControlLib/PartPreviewWindow/MainViewWidget.cs
+++ b/MatterControlLib/PartPreviewWindow/MainViewWidget.cs
@@ -261,20 +261,26 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			// Upgrade tab
 			if (!ApplicationController.Instance.IsMatterControlPro())
 			{
-				tabControl.AddTab(
-					tab = new ChromeTab("Upgrade", "Upgrade".Localize(), tabControl, new UpgradeToProTabPage(theme), theme, hasClose: false)
-					{
-						MinimumSize = new Vector2(0, theme.TabButtonHeight),
-						Name = "Upgrade",
-						Padding = new BorderDouble(15, 0),
-					});
+				tab = new ChromeTab("Upgrade", "Upgrade".Localize(), tabControl, new UpgradeToProTabPage(theme), theme, hasClose: false)
+				{
+					MinimumSize = new Vector2(0, theme.TabButtonHeight),
+					Name = "Upgrade",
+					Padding = new BorderDouble(15, 0),
+				};
+				tabControl.AddTab(tab);
+
+				ChromeTab upgradeTab = tab;
 
 				tab.AfterDraw += (s, e) =>
 				{
-					var textWidget = tab.Descendants<TextWidget>().FirstOrDefault();
-					e.Graphics2D.Circle(Math.Max(textWidget.Width, tab.LocalBounds.Right - 25 * DeviceScale),
-						tab.LocalBounds.Bottom + tab.Height / 2 - 1 * DeviceScale,
-						5 * DeviceScale,
+					var textWidget = upgradeTab.Descendants<TextWidget>().FirstOrDefault();
+
+					var localLabelEndPosition = textWidget.TransformToScreenSpace(textWidget.Printer.GetSize()) - upgradeTab.TransformToScreenSpace(Vector2.Zero);
+
+					double radius = 5 * DeviceScale;
+					e.Graphics2D.Circle(localLabelEndPosition.X + radius + 3 * DeviceScale,
+						upgradeTab.LocalBounds.Bottom + upgradeTab.Height / 2 - 1 * DeviceScale,
+						radius,
 						theme.PrimaryAccentColor);
 				};
 			}

--- a/MatterControlLib/SlicerConfiguration/SliceSettingsWidget.cs
+++ b/MatterControlLib/SlicerConfiguration/SliceSettingsWidget.cs
@@ -335,7 +335,7 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 									hasClose: false,
 									pointSize: theme.DefaultFontSize)
 								{
-									Name = category.Name + " Tab",
+									Name = category.Name + " SliceSettingsTab",
 									InactiveTabColor = Color.Transparent,
 									ActiveTabColor = theme.BackgroundColor
 								});

--- a/Tests/MatterControl.AutomationTests/HardwareLevelingUITests.cs
+++ b/Tests/MatterControl.AutomationTests/HardwareLevelingUITests.cs
@@ -18,7 +18,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				testRunner.AddAndSelectPrinter("Airwolf 3D", "HD");
 
 				testRunner.SwitchToPrinterSettings();
-				testRunner.ClickByName("Features Tab");
+				testRunner.ClickByName("Features SliceSettingsTab");
 				testRunner.ClickByName("Slice Settings Overflow Menu");
 				testRunner.ClickByName("Advanced Menu Item");
 				Assert.IsFalse(testRunner.WaitForName("print_leveling_solution Row", .5), "Print leveling should not exist for an Airwolf HD");
@@ -27,7 +27,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 				testRunner.AddAndSelectPrinter("3D Factory", "MendelMax 1.5");
 
 				testRunner.SwitchToPrinterSettings();
-				testRunner.ClickByName("Features Tab");
+				testRunner.ClickByName("Features SliceSettingsTab");
 				testRunner.ClickByName("Slice Settings Overflow Menu");
 				testRunner.ClickByName("Advanced Menu Item");
 				Assert.IsTrue(testRunner.WaitForName("print_leveling_solution Row"), "Print leveling should exist for a 3D Factory MendelMax");

--- a/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
+++ b/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
@@ -243,7 +243,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					.AddAndSelectPrinter("Airwolf 3D", "HD")
 					// Navigate to Local Library
 					.SwitchToPrinterSettings()
-					.ClickByName("Features Tab");
+					.ClickByName("Features SliceSettingsTab");
 
 				var printer = testRunner.FirstPrinter();
 
@@ -262,7 +262,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			{
 				using (var emulator = testRunner.LaunchAndConnectToPrinterEmulator())
 				{
-					testRunner.ClickByName("Features Tab");
+					testRunner.ClickByName("Features SliceSettingsTab");
 
 					// only 1 hotend and 1 extruder
 					Assert.IsTrue(testRunner.NameExists("Hotend 0"));
@@ -399,7 +399,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 					Assert.AreEqual(0, (int)emulator.CurrentExtruder.TargetTemperature);
 
 					// Switch back to the general tab
-					testRunner.ClickByName("General Tab")
+					testRunner.ClickByName("General SliceSettingsTab")
 						.SelectSliceSettingsField(SettingsKey.extruder_count)
 						.Type("2")
 						.Type("{Enter}");

--- a/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
+++ b/Tests/MatterControl.Tests/MatterControl/MatterControlUtilities.cs
@@ -1326,7 +1326,7 @@ namespace MatterHackers.MatterControl.Tests.Automation
 			var category = group.Category;
 
 			// Click tab
-			testRunner.ClickByName(category.Name + " Tab");
+			testRunner.ClickByName(category.Name + " SliceSettingsTab");
 
 			// Open the subGroup if required
 			var foundWidget = testRunner.GetWidgetByName(group.Name + " Panel", out _, .1);


### PR DESCRIPTION
The draw handler in the old code used the `tab` local variable, which got changed to a different tab.

*The "Fix slice settings tests." commit is part of the coming .NET 6 upgrade PR. But it seems the checks have passed anyway.