### PR TITLE
Add the name of the slice setting to the 'Save to' menu

### DIFF
--- a/MatterControlLib/SlicerConfiguration/SliceSettingsRow.cs
+++ b/MatterControlLib/SlicerConfiguration/SliceSettingsRow.cs
@@ -325,7 +325,10 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 					// add menu item to set quality
 					{
-						var setAsQualityMenuItem = subMenu.CreateMenuItem("Quality Setting".Localize());
+						var qualitySettingName = printer.Settings.QualityLayer?.Name;
+						var setAsQualityMenuItem = subMenu.CreateMenuItem(!string.IsNullOrEmpty(qualitySettingName) ?
+							"Quality Setting '{0}'".Localize().FormatWith(qualitySettingName) :
+							"Quality Setting".Localize());
 						setAsQualityMenuItem.Enabled = canSaveQuality;
 						setAsQualityMenuItem.Click += (s, e) =>
 						{
@@ -338,7 +341,10 @@ namespace MatterHackers.MatterControl.SlicerConfiguration
 
 					// add menu item to set material
 					{
-						var setAsMaterialMenuItem = subMenu.CreateMenuItem("Material Setting".Localize());
+						var materialSettingName = printer.Settings.MaterialLayer?.Name;
+						var setAsMaterialMenuItem = subMenu.CreateMenuItem(!string.IsNullOrEmpty(materialSettingName) ?
+							"Material Setting '{0}'".Localize().FormatWith(materialSettingName) :
+							"Material Setting".Localize());
 						setAsMaterialMenuItem.Enabled = canSaveMaterial;
 						setAsMaterialMenuItem.Click += (s, e) =>
 						{

--- a/StaticData/Translations/Master.txt
+++ b/StaticData/Translations/Master.txt
@@ -2782,6 +2782,9 @@ Translated:Material density. Only used for estimating mass in the Layer View.
 English:Material Setting
 Translated:Material Setting
 
+English:Material Setting '{0}'
+Translated:Material Setting '{0}'
+
 English:Material Settings
 Translated:Material Settings
 
@@ -3897,6 +3900,9 @@ Translated:Quality
 
 English:Quality Setting
 Translated:Quality Setting
+
+English:Quality Setting '{0}'
+Translated:Quality Setting '{0}'
 
 English:Queue
 Translated:Queue

--- a/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
+++ b/Tests/MatterControl.AutomationTests/SliceSettingsTests.cs
@@ -521,6 +521,63 @@ namespace MatterHackers.MatterControl.Tests.Automation
 		}
 
 		[Test, ChildProcessTest]
+		public async Task ValidateSaveMenuItemLabels()
+		{
+			await MatterControlUtilities.RunTest((testRunner) =>
+			{
+				testRunner.AddAndSelectPrinter("Airwolf 3D", "HD");
+
+				// Navigate to Slice Settings Tab and make sure Layer Thickness row is visible
+				testRunner.SwitchToSliceSettings()
+					.NavigateToSliceSettingsField(SettingsKey.layer_height);
+
+				// Set Quality to "Coarse" and Material to "ABS"
+				testRunner.ClickByName("Quality")
+					.ClickByName("Coarse Menu")
+					.ClickByName("Material")
+					.ClickByName("ABS Menu")
+					.RightClickByName("Layer Thickness OverrideIndicator", offset: new Point2D(30, 0))
+					.ClickByName("Save to Menu Item")
+					.Delay(.5);
+				Assert.IsTrue(testRunner.NameExists("Quality Setting 'Coarse' Menu Item"));
+				Assert.IsTrue(testRunner.NameExists("Material Setting 'ABS' Menu Item"));
+
+				// Set Quality to "Fine" and Material to "BENDLAY"
+				testRunner.ClickByName("Quality")
+					.ClickByName("Fine Menu")
+					.ClickByName("Material")
+					.ClickByName("BENDLAY Menu")
+					.RightClickByName("Layer Thickness OverrideIndicator", offset: new Point2D(30, 0))
+					.ClickByName("Save to Menu Item")
+					.Delay(.5);
+				Assert.IsTrue(testRunner.NameExists("Quality Setting 'Fine' Menu Item"));
+				Assert.IsTrue(testRunner.NameExists("Material Setting 'BENDLAY' Menu Item"));
+
+				// Set Quality to none
+				testRunner.ClickByName("Quality")
+					.ClickByName("- none - Menu Item")
+					.RightClickByName("Layer Thickness OverrideIndicator", offset: new Point2D(30, 0))
+					.ClickByName("Save to Menu Item")
+					.Delay(.5);
+				Assert.IsTrue(testRunner.NameExists("Quality Setting Menu Item"));
+				Assert.IsTrue(testRunner.NameExists("Material Setting 'BENDLAY' Menu Item"));
+
+				// Set Quality to "Standard" and Material to none
+				testRunner.ClickByName("Quality")
+					.ClickByName("Standard Menu")
+					.ClickByName("Material")
+					.ClickByName("- none - Menu Item")
+					.RightClickByName("Layer Thickness OverrideIndicator", offset: new Point2D(30, 0))
+					.ClickByName("Save to Menu Item")
+					.Delay(.5);
+				Assert.IsTrue(testRunner.NameExists("Quality Setting 'Standard' Menu Item"));
+				Assert.IsTrue(testRunner.NameExists("Material Setting Menu Item"));
+
+				return Task.CompletedTask;
+			}, maxTimeToRun: 1000);
+		}
+
+		[Test, ChildProcessTest]
 		public async Task DeleteProfileWorksForGuest()
 		{
 			await MatterControlUtilities.RunTest((testRunner) =>


### PR DESCRIPTION
This is my proposal to resolve #5190.
The name of the setting to be saved is now included in the label of the 'Save to' menu items.

![screenshot](https://user-images.githubusercontent.com/516991/182408589-823b58cb-61ad-4295-ae2f-56a8a7ab2795.png)

The title of the issue also mentions a 'Remove From' menu, but I couldn't find it. Is that part still relevant?