### PR TITLE
Fixed NullReferenceException being thrown when exporting AMF file

### DIFF
--- a/MatterControlLib/Library/Export/AmfExport.cs
+++ b/MatterControlLib/Library/Export/AmfExport.cs
@@ -57,7 +57,7 @@ namespace MatterHackers.MatterControl.Library.Export
             var firstItem = libraryItems.OfType<ILibraryAsset>().FirstOrDefault();
             if (firstItem is ILibraryAsset libraryItem)
             {
-                bool exportSuccessful = await MeshExport.ExportMesh(libraryItem, outputPath, null);
+                bool exportSuccessful = await MeshExport.ExportMesh(libraryItem, outputPath, progress);
                 if (exportSuccessful)
                 {
                     return null;


### PR DESCRIPTION
Exporting an AMF file throws a NullReferenceException.

It seems the `progress` parameter of `MeshExport.ExportMesh` must not be `null` and should be forwarded from `AmfExport.Generate` in this case.