### PR TITLE
Markdig table renderer prototype

### DIFF
--- a/MatterControlLib/PartPreviewWindow/ViewToolBarControls.cs
+++ b/MatterControlLib/PartPreviewWindow/ViewToolBarControls.cs
@@ -99,8 +99,8 @@ namespace MatterHackers.MatterControl.PartPreviewWindow
 			this.workspace = workspace;
 
 			this.RowPadding = 0;
-			this.RowBoarder = new BorderDouble(0, 0, 0, 1);
-			this.RowBoarderColor = theme.GetBorderColor(50);
+			this.RowBorder = new BorderDouble(0, 0, 0, 1);
+			this.RowBorderColor = theme.GetBorderColor(50);
 
 			var openLibraryButton = CreateOpenLibraryButton(sceneContext, theme);
 

--- a/MatterControlLib/Utilities/MarkdigAgg/AggRenderer.cs
+++ b/MatterControlLib/Utilities/MarkdigAgg/AggRenderer.cs
@@ -90,7 +90,7 @@ namespace Markdig.Renderers
 			ObjectRenderers.Add(new AggMatchingTextRenderer(theme));
 
 			// Extension renderers
-			//ObjectRenderers.Add(new AggTableRenderer());
+			ObjectRenderers.Add(new AggTableRenderer());
 			//ObjectRenderers.Add(new AggTaskListRenderer());
 		}
 

--- a/MatterControlLib/Utilities/MarkdigAgg/AggTableRenderer.cs
+++ b/MatterControlLib/Utilities/MarkdigAgg/AggTableRenderer.cs
@@ -1,0 +1,117 @@
+﻿// Copyright (c) Nicolas Musset. All rights reserved.
+// Copyright (c) 2022, John Lewin
+// This file is licensed under the MIT license.
+// See the LICENSE.md file in the project root for more information.
+
+using System;
+using Markdig.Extensions.Tables;
+using MatterHackers.Agg;
+using MatterHackers.Agg.Platform;
+using MatterHackers.Agg.UI;
+using MatterHackers.MatterControl;
+
+namespace Markdig.Renderers.Agg
+{
+    public class AggTableRenderer : AggObjectRenderer<Table>
+    {
+        protected override void Write(AggRenderer renderer, Table table)
+        {
+            if (renderer == null) throw new ArgumentNullException(nameof(renderer));
+            if (table == null) throw new ArgumentNullException(nameof(table));
+
+            var aggTable = new FlowLayoutWidget(FlowDirection.TopToBottom)
+            {
+                HAnchor = HAnchor.Fit,
+                VAnchor = VAnchor.Fit,
+                Margin = new BorderDouble(top: 12),
+            };
+
+            // TODO: Use Markdig parser data to drive column/cell widths
+            //foreach (var tableColumnDefinition in table.ColumnDefinitions)
+            //  Width = (tableColumnDefinition?.Width ?? 0) != 0 ? tableColumnDefinition.Width : <or auto>
+
+            renderer.Push(aggTable);
+
+            foreach (var rowObj in table)
+            {
+                var row = (TableRow)rowObj;
+
+                GuiWidget aggRow = row.IsHeader ? new TableHeadingRow() : new FlowLayoutWidget()
+                {
+                    HAnchor = HAnchor.Fit,
+                    VAnchor = VAnchor.Absolute,
+                    Height = 25,
+                };
+
+                renderer.Push(aggRow);
+
+                if (row.IsHeader)
+                {
+                    // Update to desired header row styling
+                    aggRow.BackgroundColor = MatterHackers.MatterControl.AppContext.Theme.TabBarBackground;
+                }
+
+                for (var i = 0; i < row.Count; i++)
+                {
+                    var cellObj = row[i];
+                    var cell = (TableCell)cellObj;
+
+                    // Fixed width cells just to get something initially on screen
+                    var aggCellBox = new GuiWidget()
+                    {
+                        Width = 200,
+                        Height = 25,
+                    };
+
+                    // Cell box above enforces boundaries, use flow for layout
+                    var aggCellFlow = new FlowLayoutWidget()
+                    {
+                        HAnchor = HAnchor.Stretch,
+                    };
+
+                    if (table.ColumnDefinitions.Count > 0)
+                    {
+                        // TODO: Ideally we'd be driving column width from metadata rather than hard-coded
+                        // See example below from WPF implementation
+                        //
+                        // Grab the column definition, or fall back to a default
+                        var columnIndex = cell.ColumnIndex < 0 || cell.ColumnIndex >= table.ColumnDefinitions.Count
+                            ? i
+                            : cell.ColumnIndex;
+                        columnIndex = columnIndex >= table.ColumnDefinitions.Count ? table.ColumnDefinitions.Count - 1 : columnIndex;
+
+                        // TODO: implement alignment into Agg types that won't throw when set
+                        var alignment = table.ColumnDefinitions[columnIndex].Alignment;
+                        if (alignment.HasValue)
+                        {
+                            switch (alignment)
+                            {
+                                //case TableColumnAlign.Center:
+                                //    aggCell.HAnchor |= HAnchor.Center;
+                                //    break;
+                                //case TableColumnAlign.Right:
+                                //    aggCell.HAnchor |= HAnchor.Right;
+                                //    break;
+                                //case TableColumnAlign.Left:
+                                //    aggCell.HAnchor |= HAnchor.Left;
+                                //    break;
+                            }
+                        }
+                    }
+
+                    renderer.Push(aggCellBox);
+                    renderer.Push(aggCellFlow);
+                    renderer.Write(cell);
+                    renderer.Pop();
+                    renderer.Pop();
+                }
+
+                // Pop row
+                renderer.Pop();
+            }
+
+            // Pop table
+            renderer.Pop();
+        }
+    }
+}

--- a/MatterControlLib/Utilities/MarkdigAgg/AggTableRenderer.cs
+++ b/MatterControlLib/Utilities/MarkdigAgg/AggTableRenderer.cs
@@ -36,18 +36,16 @@ namespace Markdig.Renderers.Agg
             {
                 var row = (TableRow)rowObj;
 
-                GuiWidget aggRow = row.IsHeader ? new TableHeadingRow() : new FlowLayoutWidget()
+                var aggRow = new AggTableRow()
                 {
-                    HAnchor = HAnchor.Fit,
-                    VAnchor = VAnchor.Absolute,
-                    Height = 25,
+                    IsHeadingRow = row.IsHeader,
                 };
 
                 renderer.Push(aggRow);
 
                 if (row.IsHeader)
                 {
-                    // Update to desired header row styling
+                    // Update to desired header row styling and/or moving into AggTableRow for consistency
                     aggRow.BackgroundColor = MatterHackers.MatterControl.AppContext.Theme.TabBarBackground;
                 }
 
@@ -62,6 +60,16 @@ namespace Markdig.Renderers.Agg
                         Width = 200,
                         Height = 25,
                     };
+
+                    // TODO: Cell Width - implement next, might be easy to track and perform in AggTableRow
+                    /*  (Spec)
+                     *  If any line of the markdown source is longer than the column width (see --columns), then the
+                     *  table will take up the full text width and the cell contents will wrap, with the relative cell
+                     *  widths determined by the number of dashes in the line separating the table header from the table
+                     *  body. (For example ---|- would make the first column 3/4 and the second column 1/4 of the full
+                     *  text width.) On the other hand, if no lines are wider than column width, then cell contents will
+                     *  not be wrapped, and the cells will be sized to their contents.
+                    */
 
                     // Cell box above enforces boundaries, use flow for layout
                     var aggCellFlow = new FlowLayoutWidget()
@@ -80,21 +88,22 @@ namespace Markdig.Renderers.Agg
                             : cell.ColumnIndex;
                         columnIndex = columnIndex >= table.ColumnDefinitions.Count ? table.ColumnDefinitions.Count - 1 : columnIndex;
 
-                        // TODO: implement alignment into Agg types that won't throw when set
-                        var alignment = table.ColumnDefinitions[columnIndex].Alignment;
+                        // TODO: revise alignment via Agg types that produce aligned text
+                        var columnDefinition = table.ColumnDefinitions[columnIndex];
+                        var alignment = columnDefinition.Alignment;
                         if (alignment.HasValue)
                         {
                             switch (alignment)
                             {
-                                //case TableColumnAlign.Center:
-                                //    aggCell.HAnchor |= HAnchor.Center;
-                                //    break;
-                                //case TableColumnAlign.Right:
-                                //    aggCell.HAnchor |= HAnchor.Right;
-                                //    break;
-                                //case TableColumnAlign.Left:
-                                //    aggCell.HAnchor |= HAnchor.Left;
-                                //    break;
+                                case TableColumnAlign.Center:
+                                    aggCellFlow.HAnchor |= HAnchor.Center;
+                                    break;
+                                case TableColumnAlign.Right:
+                                    aggCellFlow.HAnchor |= HAnchor.Right;
+                                    break;
+                                case TableColumnAlign.Left:
+                                    aggCellFlow.HAnchor |= HAnchor.Left;
+                                    break;
                             }
                         }
                     }

--- a/MatterControlLib/Utilities/MarkdigAgg/AggTableRow.cs
+++ b/MatterControlLib/Utilities/MarkdigAgg/AggTableRow.cs
@@ -10,29 +10,39 @@ using MatterHackers.Agg.UI;
 
 namespace Markdig.Renderers.Agg
 {
-	public class TableHeadingRow: FlowLayoutWidget
+	public class AggTableRow: FlowLayoutWidget
 	{
-		public TableHeadingRow()
+		public AggTableRow()
 		{
 			this.VAnchor = VAnchor.Fit;
-			this.HAnchor = HAnchor.Stretch;
 			this.Margin = new BorderDouble(3, 4, 0, 12);
-			// Likely needs to be implemented here as well
-			//this.RowPadding = new BorderDouble(0, 3);
+
+			// Hack to force content on-screen (seemingly not working when set late/after constructor)
+			VAnchor = VAnchor.Absolute;
+			Height = 25;
 		}
 
+        public bool IsHeadingRow { get; set; }
+
+		// Override AddChild to push styles to child elements when table rows are resolved to the tree
 		public override GuiWidget AddChild(GuiWidget childToAdd, int indexInChildrenList = -1)
 		{
 			if (childToAdd is TextWidget textWidget)
 			{
 				// textWidget.TextColor = new Color("#036ac3");
-				textWidget.Bold = true;
+				if (this.IsHeadingRow)
+				{
+					textWidget.Bold = true;
+				}
 			}
 			else if (childToAdd is TextLinkX textLink)
 			{
 				foreach (var childTextWidget in childToAdd.Children.OfType<TextWidget>())
 				{
-                    childTextWidget.Bold = true;
+					if (this.IsHeadingRow)
+					{
+						childTextWidget.Bold = true;
+					}
 				}
 			}
 

--- a/MatterControlLib/Utilities/MarkdigAgg/TableHeadingRow.cs
+++ b/MatterControlLib/Utilities/MarkdigAgg/TableHeadingRow.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) 2016-2017 Nicolas Musset. All rights reserved.
+// Copyright (c) 2022, John Lewin
+// This file is licensed under the MIT license.
+// See the LICENSE.md file in the project root for more information.
+
+using System.Linq;
+using Markdig.Renderers.Agg.Inlines;
+using MatterHackers.Agg;
+using MatterHackers.Agg.UI;
+
+namespace Markdig.Renderers.Agg
+{
+	public class TableHeadingRow: FlowLayoutWidget
+	{
+		public TableHeadingRow()
+		{
+			this.VAnchor = VAnchor.Fit;
+			this.HAnchor = HAnchor.Stretch;
+			this.Margin = new BorderDouble(3, 4, 0, 12);
+			// Likely needs to be implemented here as well
+			//this.RowPadding = new BorderDouble(0, 3);
+		}
+
+		public override GuiWidget AddChild(GuiWidget childToAdd, int indexInChildrenList = -1)
+		{
+			if (childToAdd is TextWidget textWidget)
+			{
+				// textWidget.TextColor = new Color("#036ac3");
+				textWidget.Bold = true;
+			}
+			else if (childToAdd is TextLinkX textLink)
+			{
+				foreach (var childTextWidget in childToAdd.Children.OfType<TextWidget>())
+				{
+                    childTextWidget.Bold = true;
+				}
+			}
+
+			return base.AddChild(childToAdd, indexInChildrenList);
+		}
+	}
+}


### PR DESCRIPTION
I came across an open ticket (#5191) and thought it would be interesting to revisit how the Markdig renderers worked and how to map to anything in Agg that might be a start for a table implementation. I'm certain you can quickly revise the layout issues 
I ran into, and pick more appropriate types for table row/cells. If nothing else, hopefully, this might demystify the Markdig steps needed to plug in something for table support in Agg. 

I'm not sure if you'd want to merge as is, but you might consider it and simply disable the `ObjectRenderers.Add(new AggTableRenderer());` in release builds.

Next steps would be to eliminate the fixed width values I put in place to demo a quick prototype, and wire up to configuration-based widths from the Markdig parser, and track and use cell content widths rather than the arbitrary fixed constants. Plus, row/column spans and all the other more detailed and challenging next steps.

# Prototype

![image](https://user-images.githubusercontent.com/175113/187152165-1efd923a-7d1a-40c5-b714-6a53941f8e8c.png)

