### PR TITLE
Add initial support for terminal text selection 

### DIFF
--- a/MatterControl.sln
+++ b/MatterControl.sln
@@ -106,13 +106,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "geometry3Sharp", "Submodule
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestInvoker", "Submodules\agg-sharp\Tests\TestInvoker\TestInvoker.csproj", "{A1F2F1DA-2B86-461E-9602-EAB2BD899A8F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MarkdigAgg", "Submodules\agg-sharp\MarkdigAgg\MarkdigAgg.csproj", "{C0E747D6-53CA-4747-B581-D175DCDD085F}"
+EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		Submodules\agg-sharp\Typography\Typography.OpenFont\Typography.OpenFont.projitems*{235a071b-8d06-40ae-a5c5-b1ce59715ee9}*SharedItemsImports = 13
-		Submodules\agg-sharp\Typography\Typography.GlyphLayout\Typography.GlyphLayout.projitems*{b112455b-e42e-4718-821f-862884b9c07c}*SharedItemsImports = 5
-		Submodules\agg-sharp\Typography\Typography.OpenFont\Typography.OpenFont.projitems*{b112455b-e42e-4718-821f-862884b9c07c}*SharedItemsImports = 5
-		Submodules\agg-sharp\Typography\Typography.GlyphLayout\Typography.GlyphLayout.projitems*{d8861cf8-c506-472b-8a57-632bd6ca6496}*SharedItemsImports = 13
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
@@ -286,6 +282,10 @@ Global
 		{A1F2F1DA-2B86-461E-9602-EAB2BD899A8F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1F2F1DA-2B86-461E-9602-EAB2BD899A8F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1F2F1DA-2B86-461E-9602-EAB2BD899A8F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C0E747D6-53CA-4747-B581-D175DCDD085F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C0E747D6-53CA-4747-B581-D175DCDD085F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C0E747D6-53CA-4747-B581-D175DCDD085F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C0E747D6-53CA-4747-B581-D175DCDD085F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -334,9 +334,16 @@ Global
 		{34383A75-1831-4816-A38A-AB06B969D7C7} = {FED00F38-E911-45E1-A788-26980E84C3D6}
 		{3A25C796-F676-4422-8F30-01D4FDB240F1} = {2AB9B589-5C98-4C05-BBEA-F97DAE168EAB}
 		{A1F2F1DA-2B86-461E-9602-EAB2BD899A8F} = {FBE6DF29-85A9-4A8B-B739-35BE4CA0A9B7}
+		{C0E747D6-53CA-4747-B581-D175DCDD085F} = {2AB9B589-5C98-4C05-BBEA-F97DAE168EAB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {42D74E06-00EA-43D2-A05B-9BEAD4A2C8A0}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		Submodules\agg-sharp\Typography\Typography.OpenFont\Typography.OpenFont.projitems*{235a071b-8d06-40ae-a5c5-b1ce59715ee9}*SharedItemsImports = 13
+		Submodules\agg-sharp\Typography\Typography.GlyphLayout\Typography.GlyphLayout.projitems*{b112455b-e42e-4718-821f-862884b9c07c}*SharedItemsImports = 5
+		Submodules\agg-sharp\Typography\Typography.OpenFont\Typography.OpenFont.projitems*{b112455b-e42e-4718-821f-862884b9c07c}*SharedItemsImports = 5
+		Submodules\agg-sharp\Typography\Typography.GlyphLayout\Typography.GlyphLayout.projitems*{d8861cf8-c506-472b-8a57-632bd6ca6496}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(MonoDevelopProperties) = preSolution
 		StartupItem = MatterControl.csproj


### PR DESCRIPTION
A first pass at functional text selection in the terminal.  #4880 

- Currently limited to ctrl-c copy to clipboard. UI support can follow if this gets merged.
- Continues to work on long drags, as text scrolls up and out of view.
- Filters out in/out communication markers.
- Seemingly works well to copy/paste a selection from the terminal into an external app.

Quirks

- Used text color rather than background for selection as its available and easy.
- Use of floor/ceiling to get line index can at times appear to select above/below mouse position.
- Use of line index rather than float 0-1 may not be preferred, seemed easier to keep track of expectations while prototyping
- Long drag with pauses in movement fail to redraw to current mouse position. Seems like a pulse from the ondraw into the mouse handler could sync things up, but figured I'd leave it to you to consider

Feel free to merge, pass, or radically change... just seemed fun to try and tackle the problem.

