### PR TITLE
fix: show default thumbnail immediately for MeshContentProvider

### DIFF
--- a/MatterControlLib/Library/Providers/LibraryConfig.cs
+++ b/MatterControlLib/Library/Providers/LibraryConfig.cs
@@ -265,6 +265,8 @@ namespace MatterHackers.MatterControl.Library
 
 					if (contentProvider is MeshContentProvider meshContentProvider)
 					{
+						// Show default image immediately while thumbnail is being generated
+						setItemThumbnail(thumbnail);
 						buildThumbnail?.Invoke(meshContentProvider);
 					}
 					else


### PR DESCRIPTION
## Summary

Fixes the issue where Open Recent menu items appear empty on first load.

## Root Cause

When loading item thumbnails via LoadItemThumbnail, the code was setting thumbnail = contentProvider.DefaultImage for MeshContentProvider but then never calling setItemThumbnail() to display it. The code only called buildThumbnail?.Invoke() to queue async generation, but never showed any initial image.

For other content providers, the code properly calls setItemThumbnail(theme.GeneratingThumbnailIcon) to show a default image while processing.

## Fix

Added setItemThumbnail(thumbnail) before buildThumbnail?.Invoke(meshContentProvider) to show the default image immediately while the actual thumbnail is being generated in the background.

This ensures Open Recent menu items display existing icons from cache or default icons on first open, then update when the generated thumbnail is ready.
